### PR TITLE
docs: ADR-0001 + CHANGELOG for v2.5.0 tooling-baseline sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+(No unreleased changes yet)
+
+## [2.5.0] - 2026-06-05
+
+Tooling/CI/security baseline sync with the sibling `pflex_exporter` (see
+[ADR-0001](docs/adr/0001-tooling-baseline-sync-with-pflex.md), [#19](https://github.com/fjacquet/nbu_exporter/pull/19)).
+
 ### Added
 
-(No unreleased changes yet)
+- **CycloneDX SBOMs and signed releases**: each release archive now ships a
+  CycloneDX SBOM (syft), and the checksums file is signed with cosign keyless
+  (bundle format).
+- **Consolidated CI** (`ci.yml`): golangci-lint v2.12.2, `go vet`, race-enabled
+  tests, `govulncheck`, Semgrep, and a CycloneDX module SBOM — alongside the
+  existing CodeQL analysis. The 70% coverage gate (`.testcoverage.yml`) is retained.
+- **Makefile quality/security targets**: `tools`, `fmt-check`, `vet`, `lint`,
+  `test-race`, `vuln`, `sbom`, and an aggregate `ci` target.
+- **Architecture Decision Records** under `docs/adr/`.
+
+### Changed
+
+- **Go 1.26** (from 1.25); the `go` directive is pinned to `1.26.4` so CI installs
+  a toolchain that includes stdlib security fixes.
+- **Docker image runs as non-root** (uid 10001); the builder is pinned to
+  `golang:1.26` and the binary is built statically (`Dockerfile` and
+  `Dockerfile.goreleaser`).
+- All GitHub Actions are **SHA-pinned** to their latest releases and the Semgrep
+  container image is **digest-pinned** for reproducible, supply-chain-hardened CI.
+
+### Security
+
+- `govulncheck` runs in CI; pinning Go to 1.26.4 resolves 16 Go standard-library
+  vulnerabilities present in 1.26.0.
+- Removed the committed `.vscode/` editor configuration and added it to
+  `.gitignore`.
 
 ## [2.2.1] - 2026-02-18
 

--- a/docs/adr/0001-tooling-baseline-sync-with-pflex.md
+++ b/docs/adr/0001-tooling-baseline-sync-with-pflex.md
@@ -1,0 +1,81 @@
+# ADR-0001: Sync the tooling/CI/security baseline with pflex_exporter
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Deciders:** Frederic Jacquet
+- **Related:** `docs/superpowers/specs/2026-06-04-sync-nbu-tooling-baseline-design.md`, `docs/superpowers/plans/2026-06-04-sync-nbu-tooling-baseline.md`, PR #19, release v2.5.0
+
+## Context
+
+`nbu_exporter` and `pflex_exporter` are sibling Prometheus exporters maintained in
+parallel. Their application architecture and core dependency versions were already
+in sync, but the **engineering-hygiene layer had drifted**: `pflex_exporter` was
+ahead on Go version, Makefile quality targets, CI security scanning, SBOM
+generation, and Docker hardening.
+
+This drift also violated a standing project rule that every repository must run
+Semgrep scanning in CI — `pflex` honored it, `nbu` did not.
+
+We treat **`pflex_exporter` as the reference baseline** for the tooling layer and
+bring `nbu_exporter` up to it, one-directionally, without copying pflex's
+domain-specific features.
+
+## Decision
+
+Adopt the following baseline in `nbu_exporter`:
+
+1. **Go 1.26** — bumped from 1.25; the `go` directive is pinned to a patch release
+   (`go 1.26.4`) so CI (`go-version-file: go.mod`) installs a toolchain that
+   includes stdlib security fixes.
+2. **Makefile quality/security targets** — `tools` (pinned `golangci-lint v2.12.2`,
+   `cyclonedx-gomod`, `govulncheck`), `fmt-check`, `vet`, `lint`, `test-race`,
+   `vuln`, `sbom`, and an aggregate `ci` target. `fmt-check` excludes `vendor/`.
+3. **Consolidated CI** — a single `ci.yml` with `quality` + `sbom` + `semgrep`
+   jobs. `coverage.yml` was renamed to `codeql.yml` (it always ran CodeQL); the
+   old `build.yml` was retired. **Both CodeQL and Semgrep** run, plus govulncheck.
+   The 70 % coverage gate (`.testcoverage.yml`) is carried into `ci.yml`.
+4. **Supply-chain hardening** — all GitHub Actions are **SHA-pinned** to their
+   latest releases (with version comments), and the Semgrep container image is
+   **digest-pinned**.
+5. **Release SBOM + signing** — GoReleaser emits per-archive CycloneDX SBOMs
+   (syft) and **cosign keyless** signatures (bundle format) for the checksums file.
+6. **Docker hardening** — builder pinned to `golang:1.26`, static build, and the
+   runtime image runs as a **non-root user (uid 10001)** in both `Dockerfile` and
+   `Dockerfile.goreleaser`.
+
+We **keep GoReleaser + the Homebrew tap** (more capable than pflex's hand-rolled
+Makefile release) rather than converging on pflex's release mechanism.
+
+## Alternatives considered
+
+- **Replace GoReleaser with pflex's Makefile-based release** — rejected; GoReleaser
+  + Homebrew tap is strictly more capable and already working.
+- **Match pflex exactly (Semgrep only, drop CodeQL)** — rejected; running both
+  scanners catches complementary issue classes at acceptable CI cost.
+- **Make Semgrep non-blocking to avoid pre-existing findings** — rejected; it
+  contradicts the project's Semgrep mandate. Pre-existing findings were instead
+  triaged (false positives annotated, real hardening applied).
+- **Container-image SBOM/provenance attestation (as pflex does via
+  `docker/build-push-action`)** — deferred; `nbu` builds images through
+  GoReleaser, which does not natively attest image SBOMs. Out of scope.
+
+## Consequences
+
+### Positive
+- Semgrep + CodeQL + govulncheck now gate every PR; releases are signed and ship SBOMs.
+- Reproducible CI via SHA-pinned actions; hardened, non-root container image.
+- Stricter gates immediately surfaced and fixed real pre-existing debt: an
+  un-gofmt'd test file, 16 stdlib CVEs (from pinning `go 1.26.0`), and a committed
+  `.vscode/` editor config.
+
+### Negative / trade-offs
+- SHA-pinned actions require periodic maintenance (e.g. Dependabot) to stay current.
+- `nbu` is now **ahead of `pflex`** on SHA-pinning and SBOM-in-GoReleaser, so a
+  reverse-sync pass on `pflex` is warranted.
+- `cosign-installer v4` defaults to the new bundle format; the signing config had
+  to migrate from `--output-signature/--output-certificate` to `--bundle`.
+
+### Follow-ups
+- Migrate `.goreleaser.yml` off the deprecated `dockers`/`docker_manifests`
+  (→ `dockers_v2`) and `brews` properties.
+- Reverse-sync the SHA-pinning + release SBOM/signing improvements into `pflex_exporter`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+This directory records significant architectural and engineering decisions for
+`nbu_exporter`, using lightweight [ADRs](https://adr.github.io/).
+
+Each ADR captures the **context**, the **decision**, the **alternatives
+considered**, and the **consequences**. ADRs are immutable once accepted; a
+superseding decision gets a new ADR that references the old one.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](0001-tooling-baseline-sync-with-pflex.md) | Sync the tooling/CI/security baseline with pflex_exporter | Accepted | 2026-06-05 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,4 +58,7 @@ nav:
       - Quick Reference: deployment-quick-reference.md
       - Docker: docker.md
   - Configuration Examples: config-examples/README.md
+  - Architecture Decisions:
+      - Overview: adr/README.md
+      - ADR-0001 Tooling Baseline Sync: adr/0001-tooling-baseline-sync-with-pflex.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

Documentation follow-up to the v2.5.0 tooling/CI/security baseline sync (#19).

- **ADR-0001** (`docs/adr/0001-tooling-baseline-sync-with-pflex.md`) — records the decision to sync nbu's tooling baseline to `pflex_exporter`: context, decision, alternatives considered, consequences, and follow-ups. Adds an ADR index (`docs/adr/README.md`).
- **CHANGELOG.md** — adds the `[2.5.0] - 2026-06-05` entry (Added / Changed / Security).
- **mkdocs.yml** — new "Architecture Decisions" nav section.

## Notes
- `CHANGELOG.md` was behind: it had no entries for 2.3.0–2.4.0. This PR adds 2.5.0 only; backfilling the gap needs those releases' details and is out of scope here.
- `mkdocs build` (non-strict, as `static.yml` runs it) passes. `--strict` flags pre-existing `../README.md`/`docs/...` link warnings in other docs, not introduced here.

## Test Plan
- [x] `mkdocs build` succeeds (exit 0)
- [x] ADR renders in nav; CHANGELOG transcludes into the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)