### PR TITLE
chore: drop Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,18 +93,6 @@ docker_manifests:
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-amd64"
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-arm64"
 
-brews:
-  - repository:
-      owner: fjacquet
-      name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    homepage: "https://github.com/fjacquet/nbu_exporter"
-    description: "Prometheus exporter for Veritas NetBackup"
-    license: "MIT"
-    test: |
-      system "#{bin}/nbu_exporter", "--version"
-
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -23,20 +23,13 @@ A Prometheus exporter that collects backup job statistics and storage metrics fr
 ## Quick Start
 
 ```bash
-# Install (macOS/Linux)
-brew install fjacquet/tap/nbu_exporter
+# Build from source
+make cli
 
 # Configure
 cp config.yaml.example config.yaml  # edit with your NBU server details
 
 # Run
-nbu_exporter --config config.yaml
-```
-
-Or build from source:
-
-```bash
-make cli
 ./bin/nbu_exporter --config config.yaml
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,33 +7,6 @@
 - Access to NetBackup REST API
 - NetBackup API key (generated from NBU UI)
 
-## Homebrew
-
-The quickest way to install on macOS or Linux:
-
-```bash
-brew install fjacquet/tap/nbu_exporter
-```
-
-Or tap the repository first, then install:
-
-```bash
-brew tap fjacquet/tap
-brew install nbu_exporter
-```
-
-Upgrade to the latest release:
-
-```bash
-brew upgrade nbu_exporter
-```
-
-Verify the installation:
-
-```bash
-nbu_exporter --version
-```
-
 ## From Source
 
 ```bash


### PR DESCRIPTION
## Summary

Removes Homebrew tap distribution. The tap was deemed not in the proper location and is being dropped in favor of the remaining install paths: build-from-source, Docker, and GitHub Releases.

## Changes

- **`.goreleaser.yml`** — removed the `brews:` block that published a formula to `fjacquet/homebrew-tap`
- **`.github/workflows/release.yml`** — removed the now-orphaned `TAP_GITHUB_TOKEN` env (the `TAP_GITHUB_TOKEN` repo secret can also be deleted)
- **`README.md`** — Quick Start now leads with build-from-source
- **`docs/getting-started/installation.md`** — removed the Homebrew section

## Notes

- `goreleaser check` validates clean.
- `docs/adr/0001-...md` still records the original "keep the tap" decision; left untouched pending a decision on whether to add a supersede note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)