### PR TITLE
feat: publish Homebrew formula for macOS only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,13 +8,25 @@ before:
     - go mod tidy
 
 builds:
-  - # Définit la compilation principale
+  # macOS build, kept as its own id so the Homebrew formula can reference a
+  # darwin-only archive (Homebrew is published for macOS only).
+  - id: macos
+    main: ./main.go
+    binary: "{{ .ProjectName }}"
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+  # Linux + Windows build, used for GitHub Release archives and Docker images.
+  - id: others
     main: ./main.go
     binary: "{{ .ProjectName }}"
     goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm64
@@ -22,8 +34,20 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - # Archives pour les différentes plateformes
-    # Windows utilise automatiquement .zip, les autres .tar.gz
+  # darwin-only archive consumed by the Homebrew formula (brews.ids below).
+  - id: macos
+    ids:
+      - macos
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+      - config.yaml
+  # linux + windows archives for the GitHub Release.
+  # Windows utilise automatiquement .zip, les autres .tar.gz
+  - id: others
+    ids:
+      - others
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
@@ -57,6 +81,8 @@ signs:
 dockers:
   - image_templates:
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-amd64"
+    ids:
+      - others
     use: buildx
     dockerfile: Dockerfile.goreleaser
     build_flag_templates:
@@ -70,6 +96,8 @@ dockers:
       - config.yaml
   - image_templates:
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-arm64"
+    ids:
+      - others
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
@@ -92,6 +120,22 @@ docker_manifests:
     image_templates:
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-amd64"
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-arm64"
+
+brews:
+  - # Homebrew formula is published for macOS only: it references the darwin-only
+    # archive, so no on_linux block is generated.
+    ids:
+      - macos
+    repository:
+      owner: fjacquet
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/fjacquet/nbu_exporter"
+    description: "Prometheus exporter for Veritas NetBackup"
+    license: "MIT"
+    test: |
+      system "#{bin}/nbu_exporter", "--version"
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (No unreleased changes yet)
 
+## [2.7.0] - 2026-06-05
+
+### Added
+
+- Re-introduced the Homebrew tap, **scoped to macOS only**. The GoReleaser
+  build is split into a darwin-only `macos` build/archive and a `others`
+  (linux + windows) build/archive; the formula references the macOS archive,
+  so it generates a `depends_on :macos` formula with no `on_linux` block.
+  Linux users should use a GitHub Release binary, Docker, or build from source.
+
 ## [2.6.0] - 2026-06-05
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -22,15 +22,26 @@ A Prometheus exporter that collects backup job statistics and storage metrics fr
 
 ## Quick Start
 
-```bash
-# Build from source
-make cli
+On macOS, install via Homebrew:
 
+```bash
+brew install fjacquet/tap/nbu_exporter
+```
+
+Or build from source (macOS/Linux):
+
+```bash
+make cli
+```
+
+Then configure and run:
+
+```bash
 # Configure
 cp config.yaml.example config.yaml  # edit with your NBU server details
 
 # Run
-./bin/nbu_exporter --config config.yaml
+nbu_exporter --config config.yaml   # or ./bin/nbu_exporter when built from source
 ```
 
 Metrics are exposed at `http://localhost:2112/metrics`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,6 +7,29 @@
 - Access to NetBackup REST API
 - NetBackup API key (generated from NBU UI)
 
+## Homebrew (macOS)
+
+On macOS, install via the tap:
+
+```bash
+brew install fjacquet/tap/nbu_exporter
+```
+
+Or tap the repository first, then install:
+
+```bash
+brew tap fjacquet/tap
+brew install nbu_exporter
+```
+
+Upgrade to the latest release:
+
+```bash
+brew upgrade nbu_exporter
+```
+
+> **Linux users:** Homebrew is not published for Linux. Use a [GitHub Release](#github-releases) binary, [Docker](#docker), or build [from source](#from-source).
+
 ## From Source
 
 ```bash


### PR DESCRIPTION
## Summary

Re-introduces the Homebrew tap, but **scoped to macOS only** (v2.6.0 had dropped it entirely). Linux is intentionally excluded from Homebrew — Linux users use GitHub Release binaries, Docker, or build from source.

## How it works

A Homebrew formula is a single artifact whose OS coverage is derived from the archives it references — there's no per-OS flag on `brews`, and two archives can't both emit the same darwin file (name collision). So the GoReleaser build is split:

- **`macos` build/archive** — darwin amd64 + arm64
- **`others` build/archive** — linux + windows (feeds GitHub Release + Docker)
- **`brews.ids: [macos]`** — formula references only the darwin archive
- **`dockers.ids: [others]`** — images pinned to the linux build

## Verification

Local `goreleaser release --snapshot` generates a macOS-only formula:

```ruby
class NbuExporter < Formula
  depends_on :macos
  if Hardware::CPU.intel?  # darwin_amd64 url ...
  if Hardware::CPU.arm?    # darwin_arm64 url ...
  # no on_linux block
```

`semgrep p/github-actions` on the workflow change: 0 findings.

## Notes

- GoReleaser now marks `brews` deprecated (steering toward `homebrew_casks`). It still functions at release time in v2.16 — our CI runs `release --clean`, not `check`, so this is a non-blocking warning. A future migration to `homebrew_casks` is a separate follow-up.
- Restores the `TAP_GITHUB_TOKEN` env in `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)