### PR TITLE
chore: migrate Homebrew formula to cask (homebrew_casks)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,21 +121,28 @@ docker_manifests:
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-amd64"
       - "ghcr.io/fjacquet/nbu_exporter:{{ .Version }}-arm64"
 
-brews:
-  - # Homebrew formula is published for macOS only: it references the darwin-only
-    # archive, so no on_linux block is generated.
+homebrew_casks:
+  - # Casks are macOS-only by definition; references the darwin-only archive.
     ids:
       - macos
     repository:
       owner: fjacquet
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
+    binaries:
+      - nbu_exporter
     homepage: "https://github.com/fjacquet/nbu_exporter"
     description: "Prometheus exporter for Veritas NetBackup"
     license: "MIT"
-    test: |
-      system "#{bin}/nbu_exporter", "--version"
+    # The binary is not notarized/signed; strip the Gatekeeper quarantine bit on
+    # install so it runs without a "developer cannot be verified" prompt.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/nbu_exporter"]
+          end
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (No unreleased changes yet)
 
+## [2.8.0] - 2026-06-05
+
+### Changed
+
+- Migrated the Homebrew distribution from a **formula** (`brews`) to a
+  **cask** (`homebrew_casks`), following GoReleaser's deprecation of `brews`.
+  The cask references the darwin-only archive (`binary "nbu_exporter"`) and
+  includes a `postflight` hook that strips the Gatekeeper quarantine bit, since
+  the binary is not notarized. `brew install fjacquet/tap/nbu_exporter` is
+  unchanged for users. The tap's old `Formula/nbu_exporter.rb` is removed and a
+  `tap_migrations.json` entry migrates existing formula installs to the cask.
+
 ## [2.7.0] - 2026-06-05
 
 ### Added


### PR DESCRIPTION
## Summary

Migrates the Homebrew distribution from a **formula** (`brews`) to a **cask** (`homebrew_casks`). GoReleaser deprecated `brews` in v2.10+ in favor of `homebrew_casks`; this removes the deprecation warning and adopts the supported path. Still macOS-only.

## Changes

- `.goreleaser.yml`: `brews:` → `homebrew_casks:`
  - `ids: [macos]` — references the darwin-only archive (casks are macOS-only anyway)
  - `binaries: [nbu_exporter]` — CLI binary stanza
  - `postflight` hook strips the Gatekeeper quarantine bit (`xattr -dr com.apple.quarantine`) because the binary isn't notarized — without it `brew install` fails with "developer cannot be verified"
  - dropped the formula-only `test:` block (casks have no test stanza)

## Verification

`goreleaser check` passes — the `brews` deprecation error is gone (only the unrelated `dockers`→`dockers_v2` notice remains). Local `goreleaser release --snapshot` generates:

```ruby
cask "nbu_exporter" do
  on_macos do
    on_intel do ... darwin_amd64 ... end
    on_arm do   ... darwin_arm64 ... end
  end
  binary "nbu_exporter"
  postflight do
    if OS.mac?
      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/nbu_exporter"]
    end
  end
end
```

No Linux stanza. `semgrep p/secrets` on the config: 0 findings.

## Follow-up (tap repo, after release)

The tap `fjacquet/homebrew-tap` will receive `Casks/nbu_exporter.rb` on release. To avoid a formula/cask name clash, a post-release cleanup removes the old `Formula/nbu_exporter.rb` and adds `tap_migrations.json` so existing formula installs migrate to the cask. `brew install fjacquet/tap/nbu_exporter` stays the same for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)