### PR TITLE
fix(docker): copy CA bundle from builder instead of apk add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,16 @@ RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o nbu_exporter .
 # Stage 2: Runtime
 FROM alpine:latest
 
-# ca-certificates for HTTPS, plus a non-root user and writable log dir
-RUN apk --no-cache add ca-certificates && \
-    adduser -D -u 10001 nbu && \
+# Create the runtime user and log dir. These are busybox builtins (no network).
+RUN adduser -D -u 10001 nbu && \
     mkdir -p /var/log/nbu_exporter && \
     chown nbu:nbu /var/log/nbu_exporter
+
+# Copy the CA bundle from the builder stage instead of `apk add ca-certificates`.
+# The latter fetches from the Alpine CDN over TLS, which fails behind a corporate
+# MITM proxy: the bare alpine image has no CA bundle yet to validate the proxy
+# cert (chicken-and-egg). The Debian-based golang builder already ships the bundle.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy the binary and default config
 COPY --from=builder /app/nbu_exporter /usr/bin/nbu_exporter


### PR DESCRIPTION
## Problem
Behind a corporate MITM proxy, `docker build` fails at the alpine runtime stage: `apk add ca-certificates` fetches the Alpine package index over HTTPS, but the bare `alpine` image has no CA bundle yet to validate the proxy cert (chicken-and-egg).

## Fix
Copy the CA bundle the Debian-based `golang` builder already ships:

```dockerfile
COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
```

`adduser`/`mkdir`/`chown` are busybox builtins (no network). Keeps Alpine + uid 10001. Verified: builds clean, CA bundle + uid 10001 present.

Family fix; see fjacquet/pstore_exporter#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)