### PR TITLE
feat: NetBackup 11.2 validation + expanded metrics

### DIFF
--- a/config-auto-detect.yaml
+++ b/config-auto-detect.yaml
@@ -28,3 +28,10 @@ nbuserver:
 #     endpoint: "localhost:4317"
 #     insecure: true
 #     samplingRate: 0.1
+
+# Optional: opt-in NetBackup 11.2 metric collectors (all default to disabled)
+collectors:
+  alerts:  { enabled: false }
+  malware: { enabled: false }
+  catalog: { enabled: false }
+  slo:     { enabled: false }

--- a/config.yaml
+++ b/config.yaml
@@ -87,3 +87,10 @@ opentelemetry:
 #     endpoint: "otel-collector.example.com:4317"
 #     insecure: false
 #     samplingRate: 0.01
+
+# Optional: opt-in NetBackup 11.2 metric collectors (all default to disabled)
+collectors:
+  alerts:  { enabled: false }
+  malware: { enabled: false }
+  catalog: { enabled: false }
+  slo:     { enabled: false }

--- a/docs/adr/0002-opt-in-sub-collector-framework.md
+++ b/docs/adr/0002-opt-in-sub-collector-framework.md
@@ -1,0 +1,76 @@
+# ADR-0002: Pluggable opt-in sub-collector framework
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** Frederic Jacquet
+- **Related:** `docs/superpowers/specs/2026-06-14-nbu-11.2-validation-design.md`, `docs/superpowers/plans/2026-06-14-nbu-11.2-validation.md`
+
+## Context
+
+Until now the exporter collected exactly two metric areas — storage and jobs —
+hardcoded directly in `NbuCollector.Collect` and fetched concurrently via an
+`errgroup`. Validating the implementation against the NetBackup 11.2 API
+(`version=14.0`) surfaced several additional, valuable signals the exporter did
+not expose: alerts (`/manage/alerts`), malware scan results
+(`/malware/latest-scan-results`), catalog posture (`/catalog/images`), and SLOs
+(`/servicecatalog/slos`).
+
+Adding these inline would have:
+
+- grown `prometheus.go` past the point where it can be reasoned about as one unit;
+- made each new area untestable in isolation;
+- forced every deployment (and every NetBackup version) to call endpoints it may
+  not need or support, increasing API load and failure surface.
+
+These endpoints are also not universally available or relevant — malware and SLO
+features depend on appliance configuration, and `/catalog/images` is heavier than
+the core collectors.
+
+## Decision
+
+Introduce a small `subCollector` interface (`Name() string`,
+`Collect(ctx, ch) error`) in `internal/exporter/subcollector.go`. Each optional
+metric area is its own focused file (`collector_alerts.go`, `collector_malware.go`,
+`collector_catalog.go`, `collector_slo.go`) implementing that interface, taking
+the `NetBackupClient` interface for testability.
+
+`NbuCollector` holds an `[]subCollector` built once at construction from config
+(`buildSubCollectors`) and runs them via `runSubCollectors` alongside the existing
+storage/jobs collection. Three properties are intentional:
+
+1. **Opt-in, default off.** A new `collectors` config section
+   (`alerts`/`malware`/`catalog`/`slo`, each `{enabled: bool}`) gates each
+   collector; the zero value is disabled. Existing deployments and older NetBackup
+   versions are unaffected unless an operator explicitly enables a collector.
+2. **Per-collector graceful degradation.** `runSubCollectors` runs each collector
+   concurrently and logs-and-skips on error; a failing endpoint never propagates
+   or suppresses the others. This extends the existing graceful-degradation
+   principle already used for storage/jobs.
+3. **`nbu_up` stays tied to storage/jobs only.** The optional collectors never
+   flip the core reachability signal, so enabling an unsupported endpoint cannot
+   make the exporter look "down".
+
+The core storage and jobs collection paths are left unchanged — they are not
+retrofitted onto the interface in this change.
+
+## Consequences
+
+**Positive**
+
+- New metric areas are added as small, independently testable files that follow a
+  single established pattern.
+- Operators pay only for the endpoints they enable; older appliances are safe by
+  default.
+- `prometheus.go` stays focused on the core collector and orchestration.
+
+**Negative / trade-offs**
+
+- Two parallel mechanisms now exist: the original storage/jobs code in
+  `prometheus.go` and the `subCollector` framework. Storage/jobs were not migrated
+  to keep this change focused; a future ADR could unify them if the duplication
+  becomes a burden.
+- Sub-collector metric descriptors are created per-collector and emitted as const
+  metrics rather than registered through `NbuCollector.Describe` (the exporter
+  already uses the unchecked-collector pattern).
+- Curated label subsets (e.g. catalog malware/anomaly status) are required to keep
+  cardinality bounded; this is a manual guard, not an automatic one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ superseding decision gets a new ADR that references the old one.
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [0001](0001-tooling-baseline-sync-with-pflex.md) | Sync the tooling/CI/security baseline with pflex_exporter | Accepted | 2026-06-05 |
+| [0002](0002-opt-in-sub-collector-framework.md) | Pluggable opt-in sub-collector framework | Accepted | 2026-06-14 |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,6 +33,58 @@ The `nbu_job_duration_seconds` histogram covers completed jobs only (those with 
 !!! note
     Tape storage units are excluded from metrics collection.
 
+## NetBackup 11.2 opt-in collectors
+
+These metrics require NetBackup 11.2 (API `version=14.0`) endpoints and are exposed
+by four optional sub-collectors. **All default to disabled** — enable only the ones
+your appliance and account permissions support. They are graceful: a failing
+endpoint is logged and skipped without affecting core storage/jobs metrics or
+flipping `nbu_up` to `0`.
+
+| Metric | Type | Labels | Source endpoint | Source API attribute |
+|--------|------|--------|-----------------|----------------------|
+| `nbu_alerts_count` | Gauge | `severity`, `category` | `GET /manage/alerts` | Alerts grouped by `severity` + `category` |
+| `nbu_malware_files_scanned` | Gauge | — | `GET /malware/latest-scan-results` | Sum of `numberOfFilesScanned` |
+| `nbu_malware_files_infected` | Gauge | — | `GET /malware/latest-scan-results` | Sum of `numberOfFilesImpacted` |
+| `nbu_malware_scan_count` | Gauge | `status` | `GET /malware/latest-scan-results` | Results grouped by `scanState` |
+| `nbu_catalog_images_count` | Gauge | `malware_status`, `anomaly_status` | `GET /catalog/images` | `meta.pagination.count` per filter combination |
+| `nbu_slo_count` | Gauge | — | `GET /servicecatalog/slos` | Total number of `data[]` entries |
+
+Notes on the implemented attributes (these differ from early guesses):
+
+- **Malware infected count** reads `numberOfFilesImpacted`, not
+  `numberOfFilesInfected`. The 11.2 `latest-scan-results` response uses
+  `numberOfFilesImpacted`.
+- **Malware scan status** is grouped by `scanState` (enum values such as
+  `SCAN_COMPLETED` / `SCAN_FAILED`), exposed via the `status` label.
+- **Catalog posture** is collected with count-only queries (`page[limit]=1`,
+  reading `meta.pagination.count`) issued once per curated combination of
+  `malwareStatus` × `anomalyStatus`, keeping label cardinality bounded.
+- **SLO count** is a single unlabeled gauge. The 11.2 SLO response has no
+  per-SLO enforcement-type attribute, so the originally planned
+  `enforcement_type` label was dropped.
+
+### Enabling the collectors
+
+Add a `collectors` block to your `config.yaml` (each collector is a
+`{ enabled: false }` toggle; all default to disabled):
+
+```yaml
+collectors:
+  alerts:  { enabled: false }
+  malware: { enabled: false }
+  catalog: { enabled: false }
+  slo:     { enabled: false }
+```
+
+!!! note "Job metrics and the missing 11.2 `admin.yaml`"
+    Job metrics (`GET /admin/jobs`) are validated against the NetBackup 11.0
+    (`version=13.0`) spec because `admin.yaml` is absent from the local
+    `docs/veritas-11.2/` bundle. The endpoint is backward-compatible under
+    `version=14.0`, so the existing job metrics remain correct. Obtaining the
+    11.2 `admin.yaml` is a follow-up item to confirm no new job attributes were
+    added.
+
 ## System Metrics
 
 | Metric | Labels | Description |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -90,7 +90,7 @@ collectors:
 | Metric | Labels | Description |
 |--------|--------|-------------|
 | `nbu_up` | — | `1` if any collection succeeded, `0` if all collections failed |
-| `nbu_api_version` | `version` | Currently active NetBackup API version (13.0, 12.0, or 3.0) |
+| `nbu_api_version` | `version` | Currently active NetBackup API version (14.0, 13.0, 12.0, or 3.0) |
 | `nbu_response_time_ms` | — | NetBackup API response time in milliseconds |
 | `nbu_last_scrape_timestamp_seconds` | `source` | Unix timestamp of the last successful collection (`source`: `storage` or `jobs`) |
 

--- a/docs/superpowers/plans/2026-06-14-nbu-11.2-validation.md
+++ b/docs/superpowers/plans/2026-06-14-nbu-11.2-validation.md
@@ -1,0 +1,1111 @@
+# NetBackup 11.2 Validation Fixes + Expanded Metrics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the exporter NetBackup 11.2-native (API `version=14.0`), add four opt-in collectors (alerts, malware, catalog posture, SLO), and fix the Grafana dashboards.
+
+**Architecture:** Add `14.0` to the version-negotiation list. Introduce a small `subCollector` interface; implement each new metric area as its own focused, opt-in file that the `NbuCollector` runs under errgroup alongside the existing storage/jobs collection, with per-collector graceful degradation. New collectors fetch via the existing `client.FetchData(ctx, url, &target)` + `cfg.BuildURL(path, params)` helpers and reuse the versioned `Accept` header.
+
+**Tech Stack:** Go 1.26, `prometheus/client_golang`, `go-resty/resty/v2`, `logrus`, `testify`, `golang.org/x/sync/errgroup`, OpenTelemetry.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-nbu-11.2-validation-design.md`
+
+**Conventions for every task:**
+- Run `make sure` (fmt, vet, test, build, lint) before each commit; the snippet shows the focused test command.
+- Follow existing patterns: metric descriptors are `prometheus.NewDesc` fields on the collector struct, registered in `Describe`, emitted via `prometheus.MustNewConstMetric`.
+- Keep the 70% coverage gate (`.testcoverage.yml`) green.
+- Commit messages use Conventional Commits.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `internal/models/Config.go` | Version constants, `SupportedAPIVersions`, `SetDefaults`, `collectors` config + validation | Modify |
+| `internal/models/Config_test.go` | Version + collectors config tests | Modify |
+| `internal/exporter/version_detector.go` | Doc comments referencing probe order | Modify |
+| `testdata/api-versions/{jobs,storage}-response-v14.json` | v14 fixtures | Create |
+| `internal/exporter/subcollector.go` | `subCollector` interface + registration helper | Create |
+| `internal/exporter/collector_alerts.go` (+ `_test.go`) | `/manage/alerts` → `nbu_alerts_count` | Create |
+| `internal/exporter/collector_malware.go` (+ `_test.go`) | `/malware/latest-scan-results` → malware metrics | Create |
+| `internal/exporter/collector_catalog.go` (+ `_test.go`) | `/catalog/images` count-only → posture metrics | Create |
+| `internal/exporter/collector_slo.go` (+ `_test.go`) | `/servicecatalog/slos` → `nbu_slo_count` | Create |
+| `internal/exporter/prometheus.go` | Build + run enabled sub-collectors in `collectAllMetrics` | Modify |
+| `internal/models/{Alerts,MalwareScans,CatalogImages,Slos}.go` | Response structs | Create |
+| `testdata/api-versions/{alerts,malware,catalog,slo}-response.json` | Collector fixtures | Create |
+| `grafana/nbu-overview.json` | New panels for new metrics | Modify |
+| `grafana/NBU Statistics-1629904585394.json` | Templatize hardcoded storage units | Modify |
+| `docs/metrics.md` | Document new metrics + `collectors` config | Modify |
+
+---
+
+## Phase 1 — API version 14.0 (correctness fix)
+
+### Task 1: Add API version 14.0 to the supported set
+
+**Files:**
+- Modify: `internal/models/Config.go:14-27` (constants + `SupportedAPIVersions`), `internal/models/Config.go:69-73` (`SetDefaults`)
+- Test: `internal/models/Config_test.go`
+
+- [ ] **Step 1: Update the failing test first**
+
+In `internal/models/Config_test.go`, find `TestSupportedAPIVersions` (~line 369). Change the expected slice to include `14.0` as the first element:
+
+```go
+func TestSupportedAPIVersions(t *testing.T) {
+	expectedVersions := []string{"14.0", "13.0", "12.0", "3.0"}
+	if len(SupportedAPIVersions) != len(expectedVersions) {
+		t.Errorf("SupportedAPIVersions length = %d, want %d", len(SupportedAPIVersions), len(expectedVersions))
+	}
+	for i, expected := range expectedVersions {
+		if SupportedAPIVersions[i] != expected {
+			t.Errorf("SupportedAPIVersions[%d] = %s, want %s", i, SupportedAPIVersions[i], expected)
+		}
+	}
+}
+```
+
+Also update the default-version assertion near line 123 (`config.NbuServer.APIVersion != "13.0"` → `"14.0"`) and **remove or invert** the `"unsupported version 14.0"` case near line 966 (14.0 is now supported — change it to expect no error, and pick a genuinely unsupported version like `"99.0"` for the negative case).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/models -run 'TestSupportedAPIVersions|TestConfigSetDefaults|TestConfigValidate' -v`
+Expected: FAIL (length 3 ≠ 4; default 13.0 ≠ 14.0).
+
+- [ ] **Step 3: Implement**
+
+In `internal/models/Config.go`, add the constant and prepend it to the list:
+
+```go
+const (
+	// APIVersion30 represents NetBackup 10.0-10.4 API version
+	APIVersion30 = "3.0"
+	// APIVersion120 represents NetBackup 10.5 API version
+	APIVersion120 = "12.0"
+	// APIVersion130 represents NetBackup 11.0 API version
+	APIVersion130 = "13.0"
+	// APIVersion140 represents NetBackup 11.2 API version
+	APIVersion140 = "14.0"
+)
+
+// SupportedAPIVersions contains all supported NetBackup API versions in descending order.
+var SupportedAPIVersions = []string{APIVersion140, APIVersion130, APIVersion120, APIVersion30}
+```
+
+In `SetDefaults` (~line 71), change the default to the newest version:
+
+```go
+	if c.NbuServer.APIVersion == "" {
+		c.NbuServer.APIVersion = APIVersion140
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/models -run 'TestSupportedAPIVersions|TestConfigSetDefaults|TestConfigValidate' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Check for other 13.0 default assumptions**
+
+Run: `grep -rn '"13.0"' internal/ | grep -v _test.go`
+For each non-test hit (e.g. `internal/models/immutable_test.go` is a test — fine), confirm it is not an implicit default. Update `internal/models/immutable_test.go` only if a test asserts the default version; explicit `cfg.NbuServer.APIVersion = "13.0"` setters in tests stay as-is (they set explicitly, not default).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/models/Config.go internal/models/Config_test.go
+git commit -m "feat(version): support NetBackup 11.2 API version 14.0"
+```
+
+### Task 2: Update version-detector doc comments + add v14 fixtures
+
+**Files:**
+- Modify: `internal/exporter/version_detector.go` (comments only — it iterates `models.SupportedAPIVersions`, so behavior already updated)
+- Create: `testdata/api-versions/jobs-response-v14.json`, `testdata/api-versions/storage-response-v14.json`
+
+- [ ] **Step 1: Create v14 fixtures by copying the v13 shape**
+
+Run:
+```bash
+cp testdata/api-versions/jobs-response-v13.json testdata/api-versions/jobs-response-v14.json
+cp testdata/api-versions/storage-response-v13.json testdata/api-versions/storage-response-v14.json
+```
+(The v14 jobs/storage payload shape is unchanged from v13; these fixtures exercise the v14 negotiation path.)
+
+- [ ] **Step 2: Update doc comments**
+
+In `internal/exporter/version_detector.go`, update the comment lines (41-42, 84, 88-90) that say `13.0 → 12.0 → 3.0` to `14.0 → 13.0 → 12.0 → 3.0`, and add `// 1. Try API version 14.0 (NetBackup 11.2)` to the ordered comment list.
+
+- [ ] **Step 3: Add a detector test asserting 14.0 is attempted first**
+
+If `internal/exporter/version_detector_test.go` has a table of expected attempted versions, add `14.0` as the first expected entry. Run:
+`go test ./internal/exporter -run TestVersionDetection -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/exporter/version_detector.go testdata/api-versions/ internal/exporter/version_detector_test.go
+git commit -m "docs(version): document 14.0-first probe order and add v14 fixtures"
+```
+
+---
+
+## Phase 2 — Config for opt-in collectors
+
+### Task 3: Add `collectors` config section + validation
+
+**Files:**
+- Modify: `internal/models/Config.go` (add `Collectors` field to `Config` struct, after the `OpenTelemetry` block ~line 59)
+- Test: `internal/models/Config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/models/Config_test.go`:
+
+```go
+func TestCollectorsConfigDefaults(t *testing.T) {
+	var c Config
+	c.SetDefaults()
+	if c.Collectors.Alerts.Enabled || c.Collectors.Malware.Enabled ||
+		c.Collectors.Catalog.Enabled || c.Collectors.SLO.Enabled {
+		t.Errorf("new collectors must default to disabled, got %+v", c.Collectors)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/models -run TestCollectorsConfigDefaults -v`
+Expected: FAIL (`c.Collectors` undefined).
+
+- [ ] **Step 3: Implement the struct**
+
+In `internal/models/Config.go`, add a field to the `Config` struct (after the `OpenTelemetry` block):
+
+```go
+	Collectors struct {
+		Alerts  CollectorToggle `yaml:"alerts"`
+		Malware CollectorToggle `yaml:"malware"`
+		Catalog CollectorToggle `yaml:"catalog"`
+		SLO     CollectorToggle `yaml:"slo"`
+	} `yaml:"collectors"`
+```
+
+And add the toggle type (near the other type definitions):
+
+```go
+// CollectorToggle enables an optional metric collector. New collectors default
+// to disabled so existing deployments and older NetBackup versions are unaffected.
+type CollectorToggle struct {
+	Enabled bool `yaml:"enabled"`
+}
+```
+
+The zero value is `false`, so `SetDefaults` needs no change for these.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/models -run TestCollectorsConfigDefaults -v`
+Expected: PASS.
+
+- [ ] **Step 5: Document in config samples**
+
+Append to `config.yaml` and `config-auto-detect.yaml`:
+
+```yaml
+collectors:
+  alerts:  { enabled: false }
+  malware: { enabled: false }
+  catalog: { enabled: false }
+  slo:     { enabled: false }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/models/Config.go internal/models/Config_test.go config.yaml config-auto-detect.yaml
+git commit -m "feat(config): add opt-in collectors section (default disabled)"
+```
+
+---
+
+## Phase 3 — Sub-collector framework
+
+### Task 4: Define the `subCollector` interface and wire it into Collect
+
+**Files:**
+- Create: `internal/exporter/subcollector.go`
+- Modify: `internal/exporter/prometheus.go` (`NbuCollector` struct: add `subCollectors []subCollector`; `collectAllMetrics`: run them under the existing errgroup)
+- Test: `internal/exporter/subcollector_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/exporter/subcollector_test.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type fakeSub struct {
+	name string
+	err  error
+	ran  bool
+}
+
+func (f *fakeSub) Name() string { return f.name }
+func (f *fakeSub) Collect(_ context.Context, _ chan<- prometheus.Metric) error {
+	f.ran = true
+	return f.err
+}
+
+func TestRunSubCollectorsGracefulDegradation(t *testing.T) {
+	ok := &fakeSub{name: "ok"}
+	bad := &fakeSub{name: "bad", err: errors.New("boom")}
+	ch := make(chan prometheus.Metric, 8)
+	runSubCollectors(context.Background(), []subCollector{ok, bad}, ch, noopTracer())
+	if !ok.ran || !bad.ran {
+		t.Fatalf("all sub-collectors must run despite one failing: ok=%v bad=%v", ok.ran, bad.ran)
+	}
+}
+```
+
+If a `noopTracer()` helper does not already exist in the test package, replace `noopTracer()` with the collector's existing `TracerWrapper` construction used by other tests (grep `NewTracerWrapper` in `internal/exporter/*_test.go` and mirror it). Keep the signature of `runSubCollectors` consistent with what you implement in Step 3.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/exporter -run TestRunSubCollectorsGracefulDegradation -v`
+Expected: FAIL (`subCollector`, `runSubCollectors` undefined).
+
+- [ ] **Step 3: Implement the interface + runner**
+
+Create `internal/exporter/subcollector.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+// subCollector is an optional, opt-in metric source (alerts, malware, catalog, SLO).
+// Each runs independently; a failure is logged and skipped so other collectors and
+// the core storage/jobs metrics are unaffected (graceful degradation).
+type subCollector interface {
+	Name() string
+	Collect(ctx context.Context, ch chan<- prometheus.Metric) error
+}
+
+// runSubCollectors runs every sub-collector concurrently. Errors are logged, never
+// propagated, so one failing endpoint cannot suppress the others.
+func runSubCollectors(ctx context.Context, collectors []subCollector, ch chan<- prometheus.Metric, tracing *TracerWrapper) {
+	if len(collectors) == 0 {
+		return
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, sc := range collectors {
+		sc := sc
+		g.Go(func() error {
+			spanCtx, span := tracing.StartSpan(gCtx, "subcollector."+sc.Name(), 0)
+			defer span.End()
+			if err := sc.Collect(spanCtx, ch); err != nil {
+				log.WithField("collector", sc.Name()).WithError(err).Warn("sub-collector failed; skipping")
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+```
+
+If `StartSpan`'s third argument is a `trace.SpanKind` in this codebase, import `go.opentelemetry.io/otel/trace` and pass `trace.SpanKindClient` instead of `0`.
+
+- [ ] **Step 4: Wire into the collector**
+
+In `internal/exporter/prometheus.go`:
+1. Add field to `NbuCollector` struct: `subCollectors []subCollector`.
+2. In `NewNbuCollector` (after descriptors are built), populate it from config (the constructor functions are added in Phase 4 — until then this slice stays empty):
+
+```go
+	c.subCollectors = buildSubCollectors(c)
+```
+
+3. Add a temporary stub at the bottom of `prometheus.go` (replaced incrementally in Phase 4):
+
+```go
+// buildSubCollectors returns the enabled optional collectors based on config.
+func buildSubCollectors(c *NbuCollector) []subCollector {
+	var subs []subCollector
+	return subs
+}
+```
+
+4. In `Collect`, after `c.exposeMetrics(...)`, run them:
+
+```go
+	runSubCollectors(ctx, c.subCollectors, ch, c.tracing)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/exporter -run TestRunSubCollectorsGracefulDegradation -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/exporter/subcollector.go internal/exporter/subcollector_test.go internal/exporter/prometheus.go
+git commit -m "feat(exporter): add opt-in sub-collector framework"
+```
+
+---
+
+## Phase 4 — The four collectors
+
+Each collector follows the same shape: response model → constructor (builds Descs) → `Collect` (fetch via `c.client.FetchData`, parse, emit) → registration in `buildSubCollectors` → unit test with a fixture and an `httptest`-free mock via the existing `NetBackupClient` interface. Grep an existing test (e.g. `internal/exporter/netbackup_test.go`) to see how `FetchData` is mocked, and mirror that mock.
+
+### Task 5: Alerts collector (`/manage/alerts`)
+
+**Files:**
+- Create: `internal/models/Alerts.go`, `internal/exporter/collector_alerts.go`, `internal/exporter/collector_alerts_test.go`, `testdata/api-versions/alerts-response.json`
+- Modify: `internal/exporter/prometheus.go` (`buildSubCollectors`)
+
+- [ ] **Step 1: Create the response model**
+
+`internal/models/Alerts.go`:
+
+```go
+package models
+
+// Alerts is the response from GET /manage/alerts (JSON:API).
+type Alerts struct {
+	Data []struct {
+		Attributes struct {
+			Severity    string `json:"severity"`    // INFO, WARNING, ERROR
+			Category    string `json:"category"`    // e.g. JOB
+			SubCategory string `json:"subCategory"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+```
+
+- [ ] **Step 2: Create the fixture**
+
+`testdata/api-versions/alerts-response.json`:
+
+```json
+{
+  "data": [
+    { "attributes": { "severity": "ERROR",   "category": "JOB", "subCategory": "STANDARD" } },
+    { "attributes": { "severity": "ERROR",   "category": "JOB", "subCategory": "ORACLE" } },
+    { "attributes": { "severity": "WARNING", "category": "JOB", "subCategory": "ANY" } }
+  ]
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+`internal/exporter/collector_alerts_test.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertsCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "testdata/api-versions/alerts-response.json")
+	c := newAlertsCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	counts := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		key := labelValue(&d, "severity") + "/" + labelValue(&d, "category")
+		counts[key] = d.GetGauge().GetValue()
+	}
+	require.Equal(t, float64(2), counts["ERROR/JOB"])
+	require.Equal(t, float64(1), counts["WARNING/JOB"])
+}
+```
+
+Add two helpers in this file if they don't already exist in the test package (grep first; reuse if present):
+
+```go
+func labelValue(d *dto.Metric, name string) string {
+	for _, l := range d.GetLabel() {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}
+```
+
+`newMockClientFromFixture` and `testConfig` should mirror existing test helpers; if absent, implement `newMockClientFromFixture` to return an `NetBackupClient` mock whose `FetchData` reads the fixture file and `json.Unmarshal`s it into `target` (use `os.ReadFile` + `json.Unmarshal`), and `testConfig` to return a minimal valid `models.Config` with a base URL set.
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `go test ./internal/exporter -run TestAlertsCollector -v`
+Expected: FAIL (`newAlertsCollector` undefined).
+
+- [ ] **Step 5: Implement the collector**
+
+`internal/exporter/collector_alerts.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const alertsPath = "/manage/alerts"
+
+type alertsCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newAlertsCollector(client NetBackupClient, cfg models.Config) *alertsCollector {
+	return &alertsCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_alerts_count",
+			"Number of NetBackup alerts by severity and category",
+			[]string{"severity", "category"}, nil,
+		),
+	}
+}
+
+func (a *alertsCollector) Name() string { return "alerts" }
+
+func (a *alertsCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := a.cfg.BuildURL(alertsPath, map[string]string{
+		QueryParamLimit: pageLimit,
+	})
+	var resp models.Alerts
+	if err := a.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	type key struct{ severity, category string }
+	counts := map[key]float64{}
+	for _, d := range resp.Data {
+		counts[key{d.Attributes.Severity, d.Attributes.Category}]++
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(a.desc, prometheus.GaugeValue, v, k.severity, k.category)
+	}
+	return nil
+}
+```
+
+Note: the `NbuCollector` field `client` is `*NbuClient`; `*NbuClient` already satisfies `NetBackupClient` (it implements `FetchData`). Sub-collectors take the interface for testability.
+
+- [ ] **Step 6: Register it**
+
+In `prometheus.go` `buildSubCollectors`:
+
+```go
+	if c.cfg.Collectors.Alerts.Enabled {
+		subs = append(subs, newAlertsCollector(c.client, c.cfg))
+	}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `go test ./internal/exporter -run 'TestAlertsCollector|TestRunSubCollectors' -v && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/models/Alerts.go internal/exporter/collector_alerts.go internal/exporter/collector_alerts_test.go testdata/api-versions/alerts-response.json internal/exporter/prometheus.go
+git commit -m "feat(metrics): add opt-in alerts collector (nbu_alerts_count)"
+```
+
+### Task 6: Malware collector (`/malware/latest-scan-results`)
+
+**Files:**
+- Create: `internal/models/MalwareScans.go`, `internal/exporter/collector_malware.go`, `internal/exporter/collector_malware_test.go`, `testdata/api-versions/malware-response.json`
+- Modify: `internal/exporter/prometheus.go` (`buildSubCollectors`)
+
+- [ ] **Step 1: Model**
+
+`internal/models/MalwareScans.go`:
+
+```go
+package models
+
+// MalwareScanResults is the response from GET /malware/latest-scan-results.
+type MalwareScanResults struct {
+	Data []struct {
+		Attributes struct {
+			ScanStatus            string `json:"scanStatus"`
+			NumberOfFilesScanned  int64  `json:"numberOfFilesScanned"`
+			NumberOfFilesInfected int64  `json:"numberOfFilesInfected"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+```
+
+(Confirm the exact attribute names against `docs/veritas-11.2/malware.yaml` `latest-scan-results` schema during implementation; `numberOfFilesScanned`/`numberOfFilesInfected` are confirmed present. If `scanStatus` differs, use the actual field name and keep the metric label name `status`.)
+
+- [ ] **Step 2: Fixture** — `testdata/api-versions/malware-response.json`:
+
+```json
+{
+  "data": [
+    { "attributes": { "scanStatus": "Completed", "numberOfFilesScanned": 1000, "numberOfFilesInfected": 2 } },
+    { "attributes": { "scanStatus": "Completed", "numberOfFilesScanned": 500,  "numberOfFilesInfected": 0 } },
+    { "attributes": { "scanStatus": "Failed",    "numberOfFilesScanned": 0,    "numberOfFilesInfected": 0 } }
+  ]
+}
+```
+
+- [ ] **Step 3: Failing test** — `internal/exporter/collector_malware_test.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMalwareCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "testdata/api-versions/malware-response.json")
+	c := newMalwareCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	var scanned, infected float64
+	statusCounts := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		switch m.Desc().String() {
+		default:
+			// use fqName via a label-free check below
+		}
+		_ = d
+		_ = statusCounts
+		_ = scanned
+		_ = infected
+	}
+	// Replace the loop above with assertions keyed on the metric name string match.
+}
+```
+
+Because all three metrics are gauges, distinguish them by `m.Desc().String()` containing the fqName (e.g. `strings.Contains(m.Desc().String(), "nbu_malware_files_infected")`). Assert: `nbu_malware_files_scanned` total = 1500, `nbu_malware_files_infected` total = 2, and `nbu_malware_scan_count{status="Completed"}` = 2, `{status="Failed"}` = 1.
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `go test ./internal/exporter -run TestMalwareCollector -v`
+Expected: FAIL (`newMalwareCollector` undefined).
+
+- [ ] **Step 5: Implement** — `internal/exporter/collector_malware.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const malwarePath = "/malware/latest-scan-results"
+
+type malwareCollector struct {
+	client       NetBackupClient
+	cfg          models.Config
+	scannedDesc  *prometheus.Desc
+	infectedDesc *prometheus.Desc
+	scanDesc     *prometheus.Desc
+}
+
+func newMalwareCollector(client NetBackupClient, cfg models.Config) *malwareCollector {
+	return &malwareCollector{
+		client: client,
+		cfg:    cfg,
+		scannedDesc:  prometheus.NewDesc("nbu_malware_files_scanned", "Total files scanned by malware scans", nil, nil),
+		infectedDesc: prometheus.NewDesc("nbu_malware_files_infected", "Total infected files found by malware scans", nil, nil),
+		scanDesc:     prometheus.NewDesc("nbu_malware_scan_count", "Number of malware scan results by status", []string{"status"}, nil),
+	}
+}
+
+func (m *malwareCollector) Name() string { return "malware" }
+
+func (m *malwareCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := m.cfg.BuildURL(malwarePath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.MalwareScanResults
+	if err := m.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	var scanned, infected float64
+	statusCounts := map[string]float64{}
+	for _, d := range resp.Data {
+		scanned += float64(d.Attributes.NumberOfFilesScanned)
+		infected += float64(d.Attributes.NumberOfFilesInfected)
+		statusCounts[d.Attributes.ScanStatus]++
+	}
+	ch <- prometheus.MustNewConstMetric(m.scannedDesc, prometheus.GaugeValue, scanned)
+	ch <- prometheus.MustNewConstMetric(m.infectedDesc, prometheus.GaugeValue, infected)
+	for status, v := range statusCounts {
+		ch <- prometheus.MustNewConstMetric(m.scanDesc, prometheus.GaugeValue, v, status)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Register** in `buildSubCollectors`:
+
+```go
+	if c.cfg.Collectors.Malware.Enabled {
+		subs = append(subs, newMalwareCollector(c.client, c.cfg))
+	}
+```
+
+- [ ] **Step 7: Run tests** — `go test ./internal/exporter -run TestMalwareCollector -v && go build ./...` → PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/models/MalwareScans.go internal/exporter/collector_malware.go internal/exporter/collector_malware_test.go testdata/api-versions/malware-response.json internal/exporter/prometheus.go
+git commit -m "feat(metrics): add opt-in malware scan collector"
+```
+
+### Task 7: Catalog posture collector (`/catalog/images`, count-only)
+
+**Files:**
+- Create: `internal/models/CatalogImages.go`, `internal/exporter/collector_catalog.go`, `internal/exporter/collector_catalog_test.go`, `testdata/api-versions/catalog-count-response.json`
+- Modify: `internal/exporter/prometheus.go` (`buildSubCollectors`)
+
+- [ ] **Step 1: Model** — only the pagination count is needed.
+
+`internal/models/CatalogImages.go`:
+
+```go
+package models
+
+// CatalogImagesCount captures only the pagination count from GET /catalog/images
+// (queried with page[limit]=1 per filter combination to read the total cheaply).
+type CatalogImagesCount struct {
+	Meta struct {
+		Pagination struct {
+			Count int64 `json:"count"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}
+```
+
+(Confirm the JSON path `meta.pagination.count` against `docs/veritas-11.2/catalog.yaml`; the storage/jobs responses use `Meta.Pagination` with a `count` field — mirror the exact casing used there.)
+
+- [ ] **Step 2: Fixture** — `testdata/api-versions/catalog-count-response.json`:
+
+```json
+{ "meta": { "pagination": { "count": 42 } } }
+```
+
+- [ ] **Step 3: Failing test** — `internal/exporter/collector_catalog_test.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "testdata/api-versions/catalog-count-response.json")
+	c := newCatalogCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	emitted := 0
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.True(t, strings.Contains(m.Desc().String(), "nbu_catalog_images_count"))
+		require.Equal(t, float64(42), d.GetGauge().GetValue())
+		emitted++
+	}
+	// One series per curated (malware_status, anomaly_status) combination.
+	require.Equal(t, len(catalogMalwareStatuses)*len(catalogAnomalyStatuses), emitted)
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `go test ./internal/exporter -run TestCatalogCollector -v`
+Expected: FAIL (`newCatalogCollector` undefined).
+
+- [ ] **Step 5: Implement** — `internal/exporter/collector_catalog.go`. Curated enum subsets bound cardinality.
+
+```go
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const catalogPath = "/catalog/images"
+
+// Curated subsets keep label cardinality bounded (full cross-product is large).
+var catalogMalwareStatuses = []string{"CLEAN", "INFECTION_DETECTED_BY_MALWARE_SCAN", "NOT_SCANNED"}
+var catalogAnomalyStatuses = []string{"ANOMALOUS", "NOT_ANOMALOUS", "NOT_PROCESSED"}
+
+type catalogCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newCatalogCollector(client NetBackupClient, cfg models.Config) *catalogCollector {
+	return &catalogCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_catalog_images_count",
+			"Number of catalog images (last 24h) by malware and anomaly status",
+			[]string{"malware_status", "anomaly_status"}, nil,
+		),
+	}
+}
+
+func (c *catalogCollector) Name() string { return "catalog" }
+
+func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	var firstErr error
+	for _, mw := range catalogMalwareStatuses {
+		for _, an := range catalogAnomalyStatuses {
+			url := c.cfg.BuildURL(catalogPath, map[string]string{
+				QueryParamLimit:  "1",
+				QueryParamFilter: "malwareStatus eq " + mw + " and anomalyStatus eq " + an,
+			})
+			var resp models.CatalogImagesCount
+			if err := c.client.FetchData(ctx, url, &resp); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.desc, prometheus.GaugeValue,
+				float64(resp.Meta.Pagination.Count), mw, an,
+			)
+		}
+	}
+	return firstErr
+}
+```
+
+(With the single-fixture mock, every combination returns count=42; the test asserts one series per combination. If the existing mock can only serve one fixture per client, that is fine — all 9 calls read the same fixture.)
+
+- [ ] **Step 6: Register** in `buildSubCollectors`:
+
+```go
+	if c.cfg.Collectors.Catalog.Enabled {
+		subs = append(subs, newCatalogCollector(c.client, c.cfg))
+	}
+```
+
+- [ ] **Step 7: Run tests** — `go test ./internal/exporter -run TestCatalogCollector -v && go build ./...` → PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/models/CatalogImages.go internal/exporter/collector_catalog.go internal/exporter/collector_catalog_test.go testdata/api-versions/catalog-count-response.json internal/exporter/prometheus.go
+git commit -m "feat(metrics): add opt-in catalog posture collector"
+```
+
+### Task 8: SLO collector (`/servicecatalog/slos`)
+
+**Files:**
+- Create: `internal/models/Slos.go`, `internal/exporter/collector_slo.go`, `internal/exporter/collector_slo_test.go`, `testdata/api-versions/slo-response.json`
+- Modify: `internal/exporter/prometheus.go` (`buildSubCollectors`)
+
+- [ ] **Step 1: Model** — `internal/models/Slos.go`:
+
+```go
+package models
+
+// Slos is the response from GET /servicecatalog/slos.
+type Slos struct {
+	Data []struct {
+		Attributes struct {
+			EnforcementType string `json:"enforcementType"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+```
+
+(Verify `enforcementType` against `docs/veritas-11.2/servicecatalog.yaml` SLO schema during implementation; if the field is nested differently, adjust the struct and keep the metric label `enforcement_type`. If no enforcement field exists, drop the label and emit a single unlabeled `nbu_slo_count` — update the test accordingly.)
+
+- [ ] **Step 2: Fixture** — `testdata/api-versions/slo-response.json`:
+
+```json
+{
+  "data": [
+    { "attributes": { "enforcementType": "MANDATORY" } },
+    { "attributes": { "enforcementType": "MANDATORY" } },
+    { "attributes": { "enforcementType": "OPTIONAL" } }
+  ]
+}
+```
+
+- [ ] **Step 3: Failing test** — `internal/exporter/collector_slo_test.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSLOCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "testdata/api-versions/slo-response.json")
+	c := newSLOCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	counts := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		counts[labelValue(&d, "enforcement_type")] = d.GetGauge().GetValue()
+	}
+	require.Equal(t, float64(2), counts["MANDATORY"])
+	require.Equal(t, float64(1), counts["OPTIONAL"])
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `go test ./internal/exporter -run TestSLOCollector -v`
+Expected: FAIL (`newSLOCollector` undefined).
+
+- [ ] **Step 5: Implement** — `internal/exporter/collector_slo.go`:
+
+```go
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const sloPath = "/servicecatalog/slos"
+
+type sloCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newSLOCollector(client NetBackupClient, cfg models.Config) *sloCollector {
+	return &sloCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_slo_count",
+			"Number of configured NetBackup SLOs by enforcement type",
+			[]string{"enforcement_type"}, nil,
+		),
+	}
+}
+
+func (s *sloCollector) Name() string { return "slo" }
+
+func (s *sloCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := s.cfg.BuildURL(sloPath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.Slos
+	if err := s.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	counts := map[string]float64{}
+	for _, d := range resp.Data {
+		counts[d.Attributes.EnforcementType]++
+	}
+	for et, v := range counts {
+		ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, v, et)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Register** in `buildSubCollectors`:
+
+```go
+	if c.cfg.Collectors.SLO.Enabled {
+		subs = append(subs, newSLOCollector(c.client, c.cfg))
+	}
+```
+
+- [ ] **Step 7: Run tests** — `go test ./internal/exporter -run TestSLOCollector -v && go build ./...` → PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/models/Slos.go internal/exporter/collector_slo.go internal/exporter/collector_slo_test.go testdata/api-versions/slo-response.json internal/exporter/prometheus.go
+git commit -m "feat(metrics): add opt-in SLO collector (nbu_slo_count)"
+```
+
+---
+
+## Phase 5 — Grafana + docs
+
+### Task 9: Add new-metric panels to `nbu-overview.json`
+
+**Files:**
+- Modify: `grafana/nbu-overview.json`
+
+- [ ] **Step 1: Add a "NetBackup 11.2 (opt-in collectors)" row** with four panels. Append panel objects to the dashboard `panels` array, giving each a unique `id` and `gridPos` below the existing panels. Use these `expr` values:
+  - Alerts by severity (barchart): `sum by (severity) (nbu_alerts_count)`
+  - Malware infected vs scanned (timeseries, two targets): `nbu_malware_files_infected` and `nbu_malware_files_scanned`
+  - Catalog posture (barchart): `sum by (malware_status) (nbu_catalog_images_count)`
+  - SLO count (stat): `sum(nbu_slo_count)`
+  Set each panel's `datasource` to the existing `${datasource}` variable used by other panels (copy the `datasource` object from an existing panel).
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `python3 -m json.tool grafana/nbu-overview.json > /dev/null && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add grafana/nbu-overview.json
+git commit -m "feat(grafana): add panels for alerts/malware/catalog/SLO metrics"
+```
+
+### Task 10: Templatize the legacy dashboard's hardcoded storage units
+
+**Files:**
+- Modify: `grafana/NBU Statistics-1629904585394.json`
+
+- [ ] **Step 1: Add template variables**
+
+Add a `templating.list` with a `datasource` variable and a `storage_unit` query variable:
+`label_values(nbu_disk_bytes, name)`. (Copy the variable definitions from `grafana/nbu-overview.json` to stay consistent.)
+
+- [ ] **Step 2: Replace hardcoded names in queries**
+
+Find every `expr` referencing `stu_adv_prod-mebck-srv1` and `stu_dedup_prod-mebck-srv1` and replace the literal storage-unit name with `$storage_unit` (e.g. `nbu_disk_bytes{name="$storage_unit", size="used"}`). Run:
+`grep -n 'stu_adv_prod-mebck-srv1\|stu_dedup_prod-mebck-srv1' "grafana/NBU Statistics-1629904585394.json"`
+Expected after edit: no matches.
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `python3 -m json.tool "grafana/NBU Statistics-1629904585394.json" > /dev/null && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "grafana/NBU Statistics-1629904585394.json"
+git commit -m "fix(grafana): templatize hardcoded storage units in legacy dashboard"
+```
+
+### Task 11: Document new metrics, config, and the admin.yaml gap
+
+**Files:**
+- Modify: `docs/metrics.md`
+
+- [ ] **Step 1: Add a "NetBackup 11.2 opt-in collectors" section** documenting each new metric (name, type, labels, source endpoint) and the `collectors` config block, noting all default to disabled.
+
+- [ ] **Step 2: Add a note** that job metrics (`/admin/jobs`) are validated against the 11.0 (`version=13.0`) spec because `admin.yaml` is absent from the local 11.2 bundle, that the endpoint is backward-compatible under `version=14.0`, and that obtaining the 11.2 `admin.yaml` is a follow-up to confirm no new job attributes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/metrics.md
+git commit -m "docs(metrics): document 11.2 collectors, config, and admin.yaml gap"
+```
+
+---
+
+## Phase 6 — Final gate
+
+### Task 12: Full CI gate + Describe registration check
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Confirm new Descs are reachable.** Sub-collector Descs are created per-collector and emitted as const metrics, so they need not be in `NbuCollector.Describe`. Confirm `go vet` and the registry don't complain about unchecked collectors (the exporter uses an unchecked collector pattern — verify metrics still register by running the binary against a mock or the existing `main_test.go`).
+
+- [ ] **Step 2: Run the full local CI gate**
+
+Run: `make ci`
+Expected: fmt-check, vet, lint, test-race, govulncheck all pass.
+
+- [ ] **Step 3: Confirm coverage gate**
+
+Run: `make test-coverage` (or the `vladopajic/go-test-coverage` step in `make ci`)
+Expected: total coverage ≥ 70%. If a new collector drops coverage, add a graceful-degradation test (mock `FetchData` returning an error, assert `Collect` returns the error and emits nothing).
+
+- [ ] **Step 4: Final commit if any fixups were needed**
+
+```bash
+git add -A
+git commit -m "test(exporter): cover collector error paths to hold 70% gate"
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- The mock helpers `newMockClientFromFixture`, `testConfig`, and `labelValue` are referenced by Tasks 5–8. Implement them **once** in Task 5 (or in a shared `internal/exporter/collector_test_helpers_test.go`) and reuse — do not redefine per file (Go will error on redeclaration in the same package).
+- All four collectors take the `NetBackupClient` interface (not `*NbuClient`) for testability; `buildSubCollectors` passes `c.client` (a `*NbuClient`, which satisfies the interface).
+- Model field names marked "confirm against the spec" (malware `scanStatus`, catalog `meta.pagination.count`, SLO `enforcementType`) must be checked against `docs/veritas-11.2/*.yaml` before finalizing each collector; the metric/label names stay as specified regardless.
+- New collectors must never flip `nbu_up` to 0 — that signal stays tied to storage/jobs only.

--- a/docs/superpowers/specs/2026-06-14-nbu-11.2-validation-design.md
+++ b/docs/superpowers/specs/2026-06-14-nbu-11.2-validation-design.md
@@ -1,0 +1,145 @@
+# NetBackup 11.2 Validation Fixes + Expanded Metrics — Design
+
+**Date:** 2026-06-14
+**Status:** Approved (pending implementation plan)
+**Scope:** Make the exporter 11.2-native, add four opt-in collectors, fix the Grafana dashboards.
+
+## Background
+
+The exporter was validated against the Veritas NetBackup 11.2 OpenAPI specs in
+`docs/veritas-11.2/`. Findings:
+
+1. **Version gap (correctness).** NBU 11.2 = API `version=14.0` (confirmed across all
+   11.2 specs). The detector (`internal/exporter/version_detector.go`,
+   `models.SupportedAPIVersions`) only probes `13.0 → 12.0 → 3.0`, so it never offers
+   `14.0` and falls back to 13.0 against an 11.2 appliance. Backward-compatible, but not
+   11.2-native.
+2. **Storage — aligned.** `/storage/storage-units` exists in 11.2 `storage.yaml` at
+   `version=14.0`; every attribute the exporter parses is present and correctly named.
+3. **Jobs — unverifiable locally.** `/admin/jobs` drives the job metrics, but `admin.yaml`
+   is absent from the local 11.2 bundle (only `manage.yaml` is present). The admin/activity
+   API is foundational and almost certainly unchanged in 11.2; the local download is
+   incomplete.
+4. **Grafana — aligned.** `nbu-overview.json` references all 16 exporter metrics with
+   correct names/labels and uses template variables. Legacy `NBU Statistics-*.json` uses 4
+   valid metrics but **hardcodes** storage-unit names (`stu_adv_prod-mebck-srv1`,
+   `stu_dedup_prod-mebck-srv1`).
+5. **Enhancement opportunities (not gaps):** alerts, malware scan results, catalog posture,
+   SLO compliance.
+
+## Goals
+
+- Negotiate API `version=14.0` (auto-detect, fall back as today).
+- Add four opt-in collectors: alerts, malware, catalog posture, SLO.
+- Fix the legacy dashboard's hardcoded storage units; surface new metrics in the overview.
+- Document the `admin.yaml` gap and keep job metrics working.
+
+## Non-goals
+
+- No change to the existing storage/jobs collection logic or metric names.
+- No new exporter binaries.
+- Not building out full SLO subscription analytics in v1 (baseline count first).
+
+## Architecture
+
+Introduce a pluggable sub-collector contract so each new area is one focused, independently
+testable file, opt-in via config, and failing independently (consistent with the existing
+graceful-degradation principle and the `NetBackupClient` interface pattern).
+
+```go
+// internal/exporter/subcollector.go
+type subCollector interface {
+    Name() string
+    Collect(ctx context.Context, ch chan<- prometheus.Metric) error
+}
+```
+
+`NbuCollector.Collect` iterates the enabled sub-collectors (storage and jobs remain as
+today; new ones are added behind config flags). Each sub-collector:
+
+- Uses the versioned `Accept` header (`application/vnd.netbackup+json;version=<detected>`).
+- Runs under its own tracing span beneath `prometheus.scrape`.
+- Reuses the existing TTL cache (`internal/exporter/cache.go`).
+- On endpoint error (404/406/5xx) logs and skips; `nbu_up` stays 1 if any collection
+  succeeds.
+
+New files: `collector_alerts.go`, `collector_malware.go`, `collector_catalog.go`,
+`collector_slo.go` (+ matching `_test.go`).
+
+## Version negotiation fix
+
+- Prepend `14.0` to `models.SupportedAPIVersions` → probe order `14.0 → 13.0 → 12.0 → 3.0`.
+- Bump the default/fallback API-version constant to `14.0` (still negotiates down on HTTP 406).
+- Add fixtures `testdata/api-versions/jobs-response-v14.json` and
+  `storage-response-v14.json`; extend the version-detection table test.
+
+## Configuration
+
+New `collectors` section; new collectors **default off** so existing deployments and older
+NBU versions are unaffected. Add validation in `models/Config.go` `Validate()` and document
+in `docs/`.
+
+```yaml
+collectors:
+  alerts:  { enabled: false }
+  malware: { enabled: false }
+  catalog: { enabled: false }
+  slo:     { enabled: false }
+```
+
+## New metrics
+
+| Collector | Endpoint | Metric(s) | Type | Labels | Source |
+|---|---|---|---|---|---|
+| Alerts | `GET /manage/alerts` | `nbu_alerts_count` | Gauge | `severity`, `category` | count per (severity ∈ INFO/WARNING/ERROR, category) |
+| Malware | `GET /malware/latest-scan-results` | `nbu_malware_files_infected` | Gauge | — (or per scan host) | sum `numberOfFilesInfected` |
+| Malware | same | `nbu_malware_files_scanned` | Gauge | — | sum `numberOfFilesScanned` |
+| Malware | same | `nbu_malware_scan_count` | Gauge | `status` | count per scan status |
+| Catalog | `GET /catalog/images` (`page[limit]=1` per filter value, read `Meta.Pagination.count`) | `nbu_catalog_images_count` | Gauge | `malware_status`, `anomaly_status` | pagination count per filter combination, default 24h window |
+| SLO | `GET /servicecatalog/slos` | `nbu_slo_count` | Gauge | `enforcement_type` | number of configured SLOs |
+
+Notes:
+- Catalog uses count-only calls (`page[limit]=1`) per filter value — cheap, no full
+  pagination. Filter enums: `malwareStatus` ∈
+  {NOT_SCANNED, INFECTION_DETECTED_BY_MALWARE_SCAN, CLEAN, NOT_SUPPORTED, UNKNOWN_TYPE,
+  INFECTION_DETECTED_BY_FILE_HASH_SEARCH}; `anomalyStatus` ∈
+  {NOT_PROCESSED, ANOMALOUS, NOT_ANOMALOUS, NOT_REVIEWED, FALSE_POSITIVE, IGNORED}.
+  Restrict to a curated subset to bound cardinality (e.g. CLEAN / INFECTION_DETECTED /
+  NOT_SCANNED × ANOMALOUS / NOT_ANOMALOUS / NOT_PROCESSED).
+- SLO list responses are subscription-shaped; v1 ships the baseline `nbu_slo_count`.
+  Per-SLO compliance metrics are a documented stretch handled inside the collector if the
+  subscription payload supports it cleanly.
+
+## Jobs / `admin.yaml` gap
+
+No code change. Document in `docs/metrics.md` (or an ADR note) that job metrics are
+validated against the 11.0 (`version=13.0`) spec and `/admin/jobs` is unchanged and
+backward-compatible in 14.0. Track "obtain 11.2 `admin.yaml`" as a follow-up so a future
+diff can confirm no new job attributes were added in 14.0.
+
+## Grafana
+
+- **`nbu-overview.json`**: add panels for the new metrics — alerts by severity (stat/bar),
+  malware infected vs scanned (timeseries/stat), catalog posture (bar by malware/anomaly
+  status), SLO count (stat). Panels render empty when collectors are off.
+- **`NBU Statistics-*.json`**: replace hardcoded storage-unit names with the existing
+  `$storage_unit` template variable (add the variable + datasource variable). Keeps its
+  per-policy-type breakdown panels that the overview lacks.
+
+## Testing & CI
+
+- Per-collector unit tests with mocked `NetBackupClient` and JSON fixtures under
+  `testdata/api-versions/`.
+- Table tests asserting metric label cardinality and graceful degradation (endpoint
+  404/406 → skip, `nbu_up` still 1 when another collector succeeds).
+- Extend version-detection tests for `14.0`.
+- Keep the 70% coverage gate (`.testcoverage.yml`) green.
+- Update `docs/metrics.md` with the new metrics and the `collectors` config section.
+
+## Risks
+
+- **Cardinality:** catalog filter combinations and alert categories must be bounded — use
+  curated enum subsets, not full cross-products.
+- **Endpoint availability on older NBU:** mitigated by opt-in defaults and per-collector
+  graceful degradation.
+- **SLO payload shape:** baseline-count-first de-risks an unknown response structure.

--- a/grafana/NBU Statistics-1629904585394.json
+++ b/grafana/NBU Statistics-1629904585394.json
@@ -115,7 +115,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(nbu_disk_bytes{name=\"stu_adv_prod-mebck-srv1\",size=\"used\"})/sum(nbu_disk_bytes{name=\"stu_adv_prod-mebck-srv1\"})*100",
+          "expr": "sum(nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\"})/sum(nbu_disk_bytes{name=~\"$storage_unit\"})*100",
           "hide": false,
           "interval": "",
           "legendFormat": "% Used",
@@ -178,7 +178,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(nbu_disk_bytes{name=\"stu_dedup_prod-mebck-srv1\",size=\"used\"})/sum(nbu_disk_bytes{name=\"stu_dedup_prod-mebck-srv1\"})*100",
+          "expr": "sum(nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\"})/sum(nbu_disk_bytes{name=~\"$storage_unit\"})*100",
           "hide": false,
           "interval": "",
           "legendFormat": "% Used",
@@ -1627,7 +1627,39 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "storage_unit",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Storage unit",
+        "query": {
+          "query": "label_values(nbu_disk_bytes, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
   },
   "time": {
     "from": "now-24h",

--- a/grafana/nbu-overview.json
+++ b/grafana/nbu-overview.json
@@ -1135,6 +1135,238 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "type": "row",
+      "id": 21,
+      "title": "NetBackup 11.2 (opt-in collectors)",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 47,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "barchart",
+      "id": 22,
+      "title": "Alertes par s\u00e9v\u00e9rit\u00e9 / Alerts by severity",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 48,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (severity) (nbu_alerts_count)",
+          "legendFormat": "{{severity}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 23,
+      "title": "Malware infect\u00e9s vs scann\u00e9s / Malware infected vs scanned",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 48,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "nbu_malware_files_infected",
+          "legendFormat": "infected",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "nbu_malware_files_scanned",
+          "legendFormat": "scanned",
+          "range": true,
+          "instant": false,
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 24,
+      "title": "Posture catalogue / Catalog posture",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 48,
+        "w": 4,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (malware_status) (nbu_catalog_images_count)",
+          "legendFormat": "{{malware_status}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 25,
+      "title": "SLO count",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 48,
+        "w": 4,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_slo_count)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/internal/exporter/backward_compatibility_test.go
+++ b/internal/exporter/backward_compatibility_test.go
@@ -234,8 +234,8 @@ func TestBackwardCompatibilityNoBreakingChanges(t *testing.T) {
 		cfg := models.Config{}
 		cfg.SetDefaults()
 
-		// Default should be 13.0 for new deployments
-		assert.Equal(t, "13.0", cfg.NbuServer.APIVersion, "Default API version should be 13.0")
+		// Default should be 14.0 for new deployments
+		assert.Equal(t, "14.0", cfg.NbuServer.APIVersion, "Default API version should be 14.0")
 	})
 }
 

--- a/internal/exporter/collector_alerts.go
+++ b/internal/exporter/collector_alerts.go
@@ -1,0 +1,51 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const alertsPath = "/manage/alerts"
+
+// alertsCollector is an opt-in sub-collector that emits nbu_alerts_count from
+// GET /manage/alerts, grouped by severity and category.
+type alertsCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newAlertsCollector(client NetBackupClient, cfg models.Config) *alertsCollector {
+	return &alertsCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_alerts_count",
+			"Number of NetBackup alerts by severity and category",
+			[]string{"severity", "category"}, nil,
+		),
+	}
+}
+
+func (a *alertsCollector) Name() string { return "alerts" }
+
+func (a *alertsCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := a.cfg.BuildURL(alertsPath, map[string]string{
+		QueryParamLimit: pageLimit,
+	})
+	var resp models.Alerts
+	if err := a.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	type key struct{ severity, category string }
+	counts := map[key]float64{}
+	for _, d := range resp.Data {
+		counts[key{d.Attributes.Severity, d.Attributes.Category}]++
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(a.desc, prometheus.GaugeValue, v, k.severity, k.category)
+	}
+	return nil
+}

--- a/internal/exporter/collector_alerts_test.go
+++ b/internal/exporter/collector_alerts_test.go
@@ -1,0 +1,28 @@
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertsCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "../../testdata/api-versions/alerts-response.json")
+	c := newAlertsCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	counts := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		key := labelValue(&d, "severity") + "/" + labelValue(&d, "category")
+		counts[key] = d.GetGauge().GetValue()
+	}
+	require.Equal(t, float64(2), counts["ERROR/JOB"])
+	require.Equal(t, float64(1), counts["WARNING/JOB"])
+}

--- a/internal/exporter/collector_alerts_test.go
+++ b/internal/exporter/collector_alerts_test.go
@@ -26,3 +26,12 @@ func TestAlertsCollector(t *testing.T) {
 	require.Equal(t, float64(2), counts["ERROR/JOB"])
 	require.Equal(t, float64(1), counts["WARNING/JOB"])
 }
+
+func TestAlertsCollectorError(t *testing.T) {
+	client := &errClient{}
+	c := newAlertsCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 4)
+	require.Error(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
+}

--- a/internal/exporter/collector_catalog.go
+++ b/internal/exporter/collector_catalog.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 const catalogPath = "/catalog/images"
@@ -38,7 +39,6 @@ func newCatalogCollector(client NetBackupClient, cfg models.Config) *catalogColl
 func (c *catalogCollector) Name() string { return "catalog" }
 
 func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
-	var firstErr error
 	for _, mw := range catalogMalwareStatuses {
 		for _, an := range catalogAnomalyStatuses {
 			url := c.cfg.BuildURL(catalogPath, map[string]string{
@@ -47,9 +47,12 @@ func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Met
 			})
 			var resp models.CatalogImagesCount
 			if err := c.client.FetchData(ctx, url, &resp); err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
+				// Per-combination graceful degradation: log and skip this
+				// combination so successful combinations are still emitted.
+				log.WithError(err).
+					WithField("malware_status", mw).
+					WithField("anomaly_status", an).
+					Warn("catalog count fetch failed; skipping combination")
 				continue
 			}
 			ch <- prometheus.MustNewConstMetric(
@@ -58,5 +61,5 @@ func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Met
 			)
 		}
 	}
-	return firstErr
+	return nil
 }

--- a/internal/exporter/collector_catalog.go
+++ b/internal/exporter/collector_catalog.go
@@ -1,0 +1,62 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const catalogPath = "/catalog/images"
+
+// Curated subsets keep label cardinality bounded (the full cross-product of the
+// malwareStatus/anomalyStatus enums is large). Values are valid per
+// docs/veritas-11.2/catalog.yaml (/catalog/images filter attributes).
+var catalogMalwareStatuses = []string{"CLEAN", "INFECTION_DETECTED_BY_MALWARE_SCAN", "NOT_SCANNED"}
+var catalogAnomalyStatuses = []string{"ANOMALOUS", "NOT_ANOMALOUS", "NOT_PROCESSED"}
+
+// catalogCollector is an opt-in sub-collector that emits catalog posture metrics
+// from GET /catalog/images using count-only queries (page[limit]=1 + filter).
+type catalogCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newCatalogCollector(client NetBackupClient, cfg models.Config) *catalogCollector {
+	return &catalogCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_catalog_images_count",
+			"Number of catalog images by malware and anomaly status",
+			[]string{"malware_status", "anomaly_status"}, nil,
+		),
+	}
+}
+
+func (c *catalogCollector) Name() string { return "catalog" }
+
+func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	var firstErr error
+	for _, mw := range catalogMalwareStatuses {
+		for _, an := range catalogAnomalyStatuses {
+			url := c.cfg.BuildURL(catalogPath, map[string]string{
+				QueryParamLimit:  "1",
+				QueryParamFilter: "malwareStatus eq " + mw + " and anomalyStatus eq " + an,
+			})
+			var resp models.CatalogImagesCount
+			if err := c.client.FetchData(ctx, url, &resp); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.desc, prometheus.GaugeValue,
+				float64(resp.Meta.Pagination.Count), mw, an,
+			)
+		}
+	}
+	return firstErr
+}

--- a/internal/exporter/collector_catalog_test.go
+++ b/internal/exporter/collector_catalog_test.go
@@ -28,3 +28,14 @@ func TestCatalogCollector(t *testing.T) {
 	// One series per curated (malware_status, anomaly_status) combination.
 	require.Equal(t, len(catalogMalwareStatuses)*len(catalogAnomalyStatuses), emitted)
 }
+
+func TestCatalogCollectorError(t *testing.T) {
+	// After per-combination graceful degradation, every sub-call failing leaves
+	// Collect returning nil while emitting no metrics.
+	client := &errClient{}
+	c := newCatalogCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
+}

--- a/internal/exporter/collector_catalog_test.go
+++ b/internal/exporter/collector_catalog_test.go
@@ -1,0 +1,30 @@
+package exporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "../../testdata/api-versions/catalog-count-response.json")
+	c := newCatalogCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	emitted := 0
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.True(t, strings.Contains(m.Desc().String(), "nbu_catalog_images_count"))
+		require.Equal(t, float64(42), d.GetGauge().GetValue())
+		emitted++
+	}
+	// One series per curated (malware_status, anomaly_status) combination.
+	require.Equal(t, len(catalogMalwareStatuses)*len(catalogAnomalyStatuses), emitted)
+}

--- a/internal/exporter/collector_malware.go
+++ b/internal/exporter/collector_malware.go
@@ -1,0 +1,53 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const malwarePath = "/malware/latest-scan-results"
+
+// malwareCollector is an opt-in sub-collector that emits malware scan posture
+// metrics from GET /malware/latest-scan-results.
+type malwareCollector struct {
+	client       NetBackupClient
+	cfg          models.Config
+	scannedDesc  *prometheus.Desc
+	infectedDesc *prometheus.Desc
+	scanDesc     *prometheus.Desc
+}
+
+func newMalwareCollector(client NetBackupClient, cfg models.Config) *malwareCollector {
+	return &malwareCollector{
+		client:       client,
+		cfg:          cfg,
+		scannedDesc:  prometheus.NewDesc("nbu_malware_files_scanned", "Total files scanned by malware scans", nil, nil),
+		infectedDesc: prometheus.NewDesc("nbu_malware_files_infected", "Total infected files found by malware scans", nil, nil),
+		scanDesc:     prometheus.NewDesc("nbu_malware_scan_count", "Number of malware scan results by status", []string{"status"}, nil),
+	}
+}
+
+func (m *malwareCollector) Name() string { return "malware" }
+
+func (m *malwareCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := m.cfg.BuildURL(malwarePath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.MalwareScanResults
+	if err := m.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	var scanned, infected float64
+	statusCounts := map[string]float64{}
+	for _, d := range resp.Data {
+		scanned += float64(d.Attributes.NumberOfFilesScanned)
+		infected += float64(d.Attributes.NumberOfFilesImpacted)
+		statusCounts[d.Attributes.ScanState]++
+	}
+	ch <- prometheus.MustNewConstMetric(m.scannedDesc, prometheus.GaugeValue, scanned)
+	ch <- prometheus.MustNewConstMetric(m.infectedDesc, prometheus.GaugeValue, infected)
+	for status, v := range statusCounts {
+		ch <- prometheus.MustNewConstMetric(m.scanDesc, prometheus.GaugeValue, v, status)
+	}
+	return nil
+}

--- a/internal/exporter/collector_malware_test.go
+++ b/internal/exporter/collector_malware_test.go
@@ -1,0 +1,42 @@
+package exporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMalwareCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "../../testdata/api-versions/malware-response.json")
+	c := newMalwareCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	var scanned, infected float64
+	statusCounts := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "nbu_malware_files_scanned"):
+			scanned = d.GetGauge().GetValue()
+		case strings.Contains(desc, "nbu_malware_files_infected"):
+			infected = d.GetGauge().GetValue()
+		case strings.Contains(desc, "nbu_malware_scan_count"):
+			statusCounts[labelValue(&d, "status")] = d.GetGauge().GetValue()
+		default:
+			t.Fatalf("unexpected metric: %s", desc)
+		}
+	}
+
+	require.Equal(t, float64(1500), scanned)
+	require.Equal(t, float64(2), infected)
+	require.Equal(t, float64(2), statusCounts["Completed"])
+	require.Equal(t, float64(1), statusCounts["Failed"])
+}

--- a/internal/exporter/collector_malware_test.go
+++ b/internal/exporter/collector_malware_test.go
@@ -37,6 +37,15 @@ func TestMalwareCollector(t *testing.T) {
 
 	require.Equal(t, float64(1500), scanned)
 	require.Equal(t, float64(2), infected)
-	require.Equal(t, float64(2), statusCounts["Completed"])
-	require.Equal(t, float64(1), statusCounts["Failed"])
+	require.Equal(t, float64(2), statusCounts["SCAN_COMPLETED"])
+	require.Equal(t, float64(1), statusCounts["SCAN_FAILED"])
+}
+
+func TestMalwareCollectorError(t *testing.T) {
+	client := &errClient{}
+	c := newMalwareCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 4)
+	require.Error(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
 }

--- a/internal/exporter/collector_slo.go
+++ b/internal/exporter/collector_slo.go
@@ -1,0 +1,47 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const sloPath = "/servicecatalog/slos"
+
+// sloCollector is an opt-in sub-collector that emits nbu_slo_count from
+// GET /servicecatalog/slos.
+//
+// The 11.2 servicecatalog.yaml SLO schema has no per-SLO enforcement-type
+// attribute (the spec's "Enforcement Type" text describes the endpoint's
+// access-control model, not response data), so the metric is a single unlabeled
+// gauge holding the total number of configured SLOs.
+type sloCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	desc   *prometheus.Desc
+}
+
+func newSLOCollector(client NetBackupClient, cfg models.Config) *sloCollector {
+	return &sloCollector{
+		client: client,
+		cfg:    cfg,
+		desc: prometheus.NewDesc(
+			"nbu_slo_count",
+			"Number of configured NetBackup SLOs",
+			nil, nil,
+		),
+	}
+}
+
+func (s *sloCollector) Name() string { return "slo" }
+
+func (s *sloCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	url := s.cfg.BuildURL(sloPath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.Slos
+	if err := s.client.FetchData(ctx, url, &resp); err != nil {
+		return err
+	}
+	ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, float64(len(resp.Data)))
+	return nil
+}

--- a/internal/exporter/collector_slo_test.go
+++ b/internal/exporter/collector_slo_test.go
@@ -1,0 +1,39 @@
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSLOCollector(t *testing.T) {
+	client := newMockClientFromFixture(t, "../../testdata/api-versions/slo-response.json")
+	c := newSLOCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	var total float64
+	emitted := 0
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.Empty(t, d.GetLabel(), "nbu_slo_count must be unlabeled")
+		total = d.GetGauge().GetValue()
+		emitted++
+	}
+	require.Equal(t, 1, emitted, "exactly one nbu_slo_count series expected")
+	require.Equal(t, float64(3), total)
+}
+
+func TestSLOCollectorError(t *testing.T) {
+	client := &errClient{}
+	c := newSLOCollector(client, testConfig())
+	ch := make(chan prometheus.Metric, 4)
+	require.Error(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
+}

--- a/internal/exporter/collector_test_helpers_test.go
+++ b/internal/exporter/collector_test_helpers_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 
@@ -40,6 +41,18 @@ func (f *fixtureClient) DetectAPIVersion(context.Context) (string, error) {
 }
 
 func (f *fixtureClient) Close() error { return nil }
+
+// errClient is a NetBackupClient mock whose FetchData always fails, used to
+// exercise sub-collector graceful-degradation/error paths.
+type errClient struct{}
+
+func (errClient) FetchData(context.Context, string, interface{}) error {
+	return errors.New("fetch failed")
+}
+func (errClient) DetectAPIVersion(context.Context) (string, error) {
+	return models.APIVersion140, nil
+}
+func (errClient) Close() error { return nil }
 
 // testConfig returns a minimal valid config with a base URL set, enough for
 // sub-collectors to build request URLs.

--- a/internal/exporter/collector_test_helpers_test.go
+++ b/internal/exporter/collector_test_helpers_test.go
@@ -1,0 +1,64 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureClient is a minimal NetBackupClient mock whose FetchData reads a JSON
+// fixture from disk and unmarshals it into the supplied target. It is shared by
+// the opt-in sub-collector tests (alerts, malware, catalog, SLO).
+type fixtureClient struct {
+	t    *testing.T
+	path string
+}
+
+// newMockClientFromFixture returns a NetBackupClient whose FetchData serves the
+// given fixture file. The path is resolved relative to the test package
+// directory (internal/exporter), so callers pass e.g.
+// "../../testdata/api-versions/alerts-response.json".
+func newMockClientFromFixture(t *testing.T, path string) NetBackupClient {
+	t.Helper()
+	return &fixtureClient{t: t, path: path}
+}
+
+func (f *fixtureClient) FetchData(_ context.Context, _ string, target interface{}) error {
+	f.t.Helper()
+	data, err := os.ReadFile(f.path)
+	require.NoError(f.t, err)
+	return json.Unmarshal(data, target)
+}
+
+func (f *fixtureClient) DetectAPIVersion(context.Context) (string, error) {
+	return models.APIVersion140, nil
+}
+
+func (f *fixtureClient) Close() error { return nil }
+
+// testConfig returns a minimal valid config with a base URL set, enough for
+// sub-collectors to build request URLs.
+func testConfig() models.Config {
+	var cfg models.Config
+	cfg.NbuServer.Scheme = "https"
+	cfg.NbuServer.Host = "nbu.example.com"
+	cfg.NbuServer.Port = "1556"
+	cfg.NbuServer.URI = "/netbackup"
+	cfg.NbuServer.APIVersion = models.APIVersion140
+	return cfg
+}
+
+// labelValue returns the value of the named label on a written metric, or "".
+func labelValue(d *dto.Metric, name string) string {
+	for _, l := range d.GetLabel() {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	return ""
+}

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -256,6 +256,9 @@ func buildSubCollectors(c *NbuCollector) []subCollector {
 	if c.cfg.Collectors.Malware.Enabled {
 		subs = append(subs, newMalwareCollector(c.client, c.cfg))
 	}
+	if c.cfg.Collectors.Catalog.Enabled {
+		subs = append(subs, newCatalogCollector(c.client, c.cfg))
+	}
 	return subs
 }
 

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -113,7 +113,7 @@ type NbuCollector struct {
 //
 // Version Detection:
 //   - If apiVersion is not configured, automatic detection is performed
-//   - Detection tries versions in descending order: 13.0 → 12.0 → 3.0
+//   - Detection tries versions in descending order: 14.0 → 13.0 → 12.0 → 3.0
 //   - If detection fails, an error is returned and collector creation fails
 //   - If apiVersion is explicitly configured, detection is bypassed
 //

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -70,7 +70,8 @@ type NbuCollector struct {
 	cfg                models.Config
 	client             *NbuClient
 	tracing            *TracerWrapper
-	storageCache       *StorageCache // TTL cache for storage metrics
+	storageCache       *StorageCache  // TTL cache for storage metrics
+	subCollectors      []subCollector // Enabled opt-in metric collectors
 	nbuDiskSize        *prometheus.Desc
 	nbuResponseTime    *prometheus.Desc
 	nbuJobsSize        *prometheus.Desc
@@ -148,7 +149,7 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 	// Create storage cache with configured TTL
 	storageCache := NewStorageCache(cfg.GetCacheTTL())
 
-	return &NbuCollector{
+	c := &NbuCollector{
 		cfg:          cfg,
 		client:       client,
 		tracing:      tracing,
@@ -238,7 +239,18 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 			"Histogram of completed job durations in seconds",
 			[]string{"action", "policy_type"}, nil,
 		),
-	}, nil
+	}
+
+	// Populate enabled opt-in collectors from config (empty until Phase 4).
+	c.subCollectors = buildSubCollectors(c)
+
+	return c, nil
+}
+
+// buildSubCollectors returns the enabled optional collectors based on config.
+func buildSubCollectors(c *NbuCollector) []subCollector {
+	var subs []subCollector
+	return subs
 }
 
 // Describe sends the descriptors of each metric to the provided channel.
@@ -327,6 +339,9 @@ func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// Expose all collected metrics (pass errors for nbu_up calculation)
 	c.exposeMetrics(ch, storageMetrics, storageUnits, jobAgg, storageErr, jobsErr)
+
+	// Run enabled opt-in sub-collectors (graceful degradation: errors logged, never propagated).
+	runSubCollectors(ctx, c.subCollectors, ch, c.tracing)
 
 	log.Debugf("Collected %d storage, %d storage units, %d job metric keys",
 		len(storageMetrics), len(storageUnits), jobMetricCount)

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -250,6 +250,9 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 // buildSubCollectors returns the enabled optional collectors based on config.
 func buildSubCollectors(c *NbuCollector) []subCollector {
 	var subs []subCollector
+	if c.cfg.Collectors.Alerts.Enabled {
+		subs = append(subs, newAlertsCollector(c.client, c.cfg))
+	}
 	return subs
 }
 

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -259,6 +259,9 @@ func buildSubCollectors(c *NbuCollector) []subCollector {
 	if c.cfg.Collectors.Catalog.Enabled {
 		subs = append(subs, newCatalogCollector(c.client, c.cfg))
 	}
+	if c.cfg.Collectors.SLO.Enabled {
+		subs = append(subs, newSLOCollector(c.client, c.cfg))
+	}
 	return subs
 }
 

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -253,6 +253,9 @@ func buildSubCollectors(c *NbuCollector) []subCollector {
 	if c.cfg.Collectors.Alerts.Enabled {
 		subs = append(subs, newAlertsCollector(c.client, c.cfg))
 	}
+	if c.cfg.Collectors.Malware.Enabled {
+		subs = append(subs, newMalwareCollector(c.client, c.cfg))
+	}
 	return subs
 }
 

--- a/internal/exporter/subcollector.go
+++ b/internal/exporter/subcollector.go
@@ -1,0 +1,39 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+)
+
+// subCollector is an optional, opt-in metric source (alerts, malware, catalog, SLO).
+// Each runs independently; a failure is logged and skipped so other collectors and
+// the core storage/jobs metrics are unaffected (graceful degradation).
+type subCollector interface {
+	Name() string
+	Collect(ctx context.Context, ch chan<- prometheus.Metric) error
+}
+
+// runSubCollectors runs every sub-collector concurrently. Errors are logged, never
+// propagated, so one failing endpoint cannot suppress the others.
+func runSubCollectors(ctx context.Context, collectors []subCollector, ch chan<- prometheus.Metric, tracing *TracerWrapper) {
+	if len(collectors) == 0 {
+		return
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, sc := range collectors {
+		sc := sc
+		g.Go(func() error {
+			spanCtx, span := tracing.StartSpan(gCtx, "subcollector."+sc.Name(), trace.SpanKindClient)
+			defer span.End()
+			if err := sc.Collect(spanCtx, ch); err != nil {
+				log.WithField("collector", sc.Name()).WithError(err).Warn("sub-collector failed; skipping")
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+}

--- a/internal/exporter/subcollector_test.go
+++ b/internal/exporter/subcollector_test.go
@@ -1,0 +1,32 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type fakeSub struct {
+	name string
+	err  error
+	ran  bool
+}
+
+func (f *fakeSub) Name() string { return f.name }
+func (f *fakeSub) Collect(_ context.Context, _ chan<- prometheus.Metric) error {
+	f.ran = true
+	return f.err
+}
+
+func TestRunSubCollectorsGracefulDegradation(t *testing.T) {
+	ok := &fakeSub{name: "ok"}
+	bad := &fakeSub{name: "bad", err: errors.New("boom")}
+	ch := make(chan prometheus.Metric, 8)
+	tracing := NewTracerWrapper(nil, "test-collector") // noop tracer
+	runSubCollectors(context.Background(), []subCollector{ok, bad}, ch, tracing)
+	if !ok.ran || !bad.ran {
+		t.Fatalf("all sub-collectors must run despite one failing: ok=%v bad=%v", ok.ran, bad.ran)
+	}
+}

--- a/internal/exporter/version_detection_integration_test.go
+++ b/internal/exporter/version_detection_integration_test.go
@@ -136,7 +136,9 @@ func TestFallbackBehavior(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		acceptHeader := r.Header.Get("Accept")
 		requestedVersion := ""
-		if strings.Contains(acceptHeader, testutil.APIVersion130) {
+		if strings.Contains(acceptHeader, testutil.APIVersion140) {
+			requestedVersion = "14.0"
+		} else if strings.Contains(acceptHeader, testutil.APIVersion130) {
 			requestedVersion = "13.0"
 		} else if strings.Contains(acceptHeader, testutil.APIVersion120) {
 			requestedVersion = "12.0"
@@ -180,8 +182,8 @@ func TestFallbackBehavior(t *testing.T) {
 		t.Errorf("Expected version 3.0, got %s", detectedVersion)
 	}
 
-	// Verify fallback order: 13.0 -> 12.0 -> 3.0
-	expectedOrder := []string{"13.0", "12.0", "3.0"}
+	// Verify fallback order: 14.0 -> 13.0 -> 12.0 -> 3.0
+	expectedOrder := []string{"14.0", "13.0", "12.0", "3.0"}
 	if len(attemptedVersions) != len(expectedOrder) {
 		t.Errorf("Expected %d version attempts, got %d", len(expectedOrder), len(attemptedVersions))
 	}

--- a/internal/exporter/version_detector.go
+++ b/internal/exporter/version_detector.go
@@ -1,6 +1,6 @@
 // Package exporter provides API version detection functionality for NetBackup.
 // It implements automatic version detection with fallback logic to support
-// multiple NetBackup versions (10.0, 10.5, and 11.0).
+// multiple NetBackup versions (10.0, 10.5, 11.0, and 11.2).
 package exporter
 
 import (
@@ -39,8 +39,8 @@ var DefaultRetryConfig = RetryConfig{
 }
 
 // APIVersionDetector handles automatic detection of supported NetBackup API versions.
-// It tests versions in descending order (13.0 → 12.0 → 3.0) and returns the first
-// working version. This allows the exporter to work with NetBackup 10.0, 10.5, and 11.0
+// It tests versions in descending order (14.0 → 13.0 → 12.0 → 3.0) and returns the first
+// working version. This allows the exporter to work with NetBackup 10.0, 10.5, 11.0, and 11.2
 // without manual configuration.
 //
 // The detector is immutable - it does not modify any configuration during detection.
@@ -81,14 +81,15 @@ func NewAPIVersionDetector(client *NbuClient, baseURL, apiKey string) *APIVersio
 }
 
 // DetectVersion attempts to detect the highest supported API version by testing
-// versions in descending order (13.0 → 12.0 → 3.0). It returns the first version
+// versions in descending order (14.0 → 13.0 → 12.0 → 3.0). It returns the first version
 // that successfully responds to a test request.
 //
 // The detection process:
-// 1. Try API version 13.0 (NetBackup 11.0)
-// 2. If HTTP 406, try API version 12.0 (NetBackup 10.5)
-// 3. If HTTP 406, try API version 3.0 (NetBackup 10.0-10.4)
-// 4. If all fail, return detailed error with troubleshooting steps
+// 1. Try API version 14.0 (NetBackup 11.2)
+// 2. If HTTP 406, try API version 13.0 (NetBackup 11.0)
+// 3. If HTTP 406, try API version 12.0 (NetBackup 10.5)
+// 4. If HTTP 406, try API version 3.0 (NetBackup 10.0-10.4)
+// 5. If all fail, return detailed error with troubleshooting steps
 //
 // Authentication errors (HTTP 401) cause immediate failure as they indicate
 // a configuration problem, not a version compatibility issue.

--- a/internal/models/Alerts.go
+++ b/internal/models/Alerts.go
@@ -1,0 +1,12 @@
+package models
+
+// Alerts is the response from GET /manage/alerts (JSON:API).
+type Alerts struct {
+	Data []struct {
+		Attributes struct {
+			Severity    string `json:"severity"` // INFO, WARNING, ERROR
+			Category    string `json:"category"` // e.g. JOB
+			SubCategory string `json:"subCategory"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/internal/models/CatalogImages.go
+++ b/internal/models/CatalogImages.go
@@ -1,0 +1,16 @@
+package models
+
+// CatalogImagesCount captures only the pagination count from GET /catalog/images
+// (queried with page[limit]=1 per filter combination to read the total cheaply).
+//
+// The JSON shape mirrors the existing Storages/Jobs response models: a top-level
+// "meta" object containing a "pagination" object with a "count" field. This was
+// verified against docs/veritas-11.2/catalog.yaml (the imageList schema's meta ->
+// pagination -> paginationValues.count).
+type CatalogImagesCount struct {
+	Meta struct {
+		Pagination struct {
+			Count int64 `json:"count"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -59,6 +59,19 @@ type Config struct {
 		Insecure     bool    `yaml:"insecure"`
 		SamplingRate float64 `yaml:"samplingRate"`
 	} `yaml:"opentelemetry"`
+
+	Collectors struct {
+		Alerts  CollectorToggle `yaml:"alerts"`
+		Malware CollectorToggle `yaml:"malware"`
+		Catalog CollectorToggle `yaml:"catalog"`
+		SLO     CollectorToggle `yaml:"slo"`
+	} `yaml:"collectors"`
+}
+
+// CollectorToggle enables an optional metric collector. New collectors default
+// to disabled so existing deployments and older NetBackup versions are unaffected.
+type CollectorToggle struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // SetDefaults sets default values for optional configuration fields.

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -20,11 +20,13 @@ const (
 	APIVersion120 = "12.0"
 	// APIVersion130 represents NetBackup 11.0 API version
 	APIVersion130 = "13.0"
+	// APIVersion140 represents NetBackup 11.2 API version
+	APIVersion140 = "14.0"
 )
 
 // SupportedAPIVersions contains all supported NetBackup API versions in descending order.
 // This list is used for version detection fallback (newest to oldest).
-var SupportedAPIVersions = []string{APIVersion130, APIVersion120, APIVersion30}
+var SupportedAPIVersions = []string{APIVersion140, APIVersion130, APIVersion120, APIVersion30}
 
 // Config represents the complete application configuration for the NBU exporter.
 // It includes settings for the server and the NBU server.
@@ -61,15 +63,15 @@ type Config struct {
 
 // SetDefaults sets default values for optional configuration fields.
 // Currently sets:
-//   - Default API version to "13.0" (NetBackup 11.0) if not specified
+//   - Default API version to "14.0" (NetBackup 11.2) if not specified
 //   - Default NBU server URI to "/netbackup" if not specified
 //   - Default storage cache TTL to "5m" if not specified
 //
 // This method is called automatically by Validate() before validation checks.
 func (c *Config) SetDefaults() {
-	// Set default API version for NetBackup 11.0
+	// Set default API version for NetBackup 11.2
 	if c.NbuServer.APIVersion == "" {
-		c.NbuServer.APIVersion = APIVersion130
+		c.NbuServer.APIVersion = APIVersion140
 	}
 
 	// Set default NBU server URI

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -1809,3 +1809,12 @@ func TestSetDefaults_CacheTTL_Preserves(t *testing.T) {
 		t.Errorf("SetDefaults() should preserve existing CacheTTL, got %v, want '1h'", cfg.Server.CacheTTL)
 	}
 }
+
+func TestCollectorsConfigDefaults(t *testing.T) {
+	var c Config
+	c.SetDefaults()
+	if c.Collectors.Alerts.Enabled || c.Collectors.Malware.Enabled ||
+		c.Collectors.Catalog.Enabled || c.Collectors.SLO.Enabled {
+		t.Errorf("new collectors must default to disabled, got %+v", c.Collectors)
+	}
+}

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -32,7 +32,7 @@ func TestConfigSetDefaults(t *testing.T) {
 					APIVersion: "",
 				},
 			},
-			expectedAPIVer: "13.0",
+			expectedAPIVer: "14.0",
 		},
 		{
 			name: "preserves existing API version",
@@ -120,8 +120,8 @@ func assertAPIVersionValidation(t *testing.T, config *Config, err error, apiVers
 			t.Errorf(testErrorValidateUnexpected, err)
 		}
 		// Verify default was set if empty
-		if apiVersion == "" && config.NbuServer.APIVersion != "13.0" {
-			t.Errorf("Validate() APIVersion = %v, want default 13.0", config.NbuServer.APIVersion)
+		if apiVersion == "" && config.NbuServer.APIVersion != "14.0" {
+			t.Errorf("Validate() APIVersion = %v, want default 14.0", config.NbuServer.APIVersion)
 		}
 	}
 }
@@ -330,7 +330,7 @@ nbuserver:
   apiKey: "test-key"
   contentType: "application/json"
 `,
-			expectedAPIVer: "13.0",
+			expectedAPIVer: "14.0",
 			shouldValidate: true,
 		},
 		{
@@ -353,7 +353,7 @@ nbuserver:
   contentType: "application/json"
   insecureSkipVerify: false
 `,
-			expectedAPIVer: "13.0",
+			expectedAPIVer: "14.0",
 			shouldValidate: true,
 		},
 	}
@@ -368,7 +368,7 @@ nbuserver:
 
 func TestSupportedAPIVersions(t *testing.T) {
 	// Test that the supported versions list contains expected versions
-	expectedVersions := []string{"13.0", "12.0", "3.0"}
+	expectedVersions := []string{"14.0", "13.0", "12.0", "3.0"}
 
 	if len(SupportedAPIVersions) != len(expectedVersions) {
 		t.Errorf("SupportedAPIVersions length = %d, want %d", len(SupportedAPIVersions), len(expectedVersions))
@@ -401,6 +401,11 @@ func TestAPIVersionConstants(t *testing.T) {
 			name:     "APIVersion130 constant",
 			constant: APIVersion130,
 			expected: "13.0",
+		},
+		{
+			name:     "APIVersion140 constant",
+			constant: APIVersion140,
+			expected: "14.0",
 		},
 	}
 
@@ -963,10 +968,15 @@ func TestConfigValidateSupportedVersions(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "unsupported version 14.0",
+			name:       "supported version 14.0",
 			apiVersion: "14.0",
+			wantErr:    false,
+		},
+		{
+			name:       "unsupported version 99.0",
+			apiVersion: "99.0",
 			wantErr:    true,
-			errMsg:     "unsupported API version: 14.0",
+			errMsg:     "unsupported API version: 99.0",
 		},
 		{
 			name:       "unsupported version 2.0",

--- a/internal/models/MalwareScans.go
+++ b/internal/models/MalwareScans.go
@@ -1,0 +1,17 @@
+package models
+
+// MalwareScanResults is the response from GET /malware/latest-scan-results.
+//
+// Field names mirror the NetBackup 11.2 malware.yaml latest-scan-results
+// response schema (version=14.0): the scan-status field is named scanState
+// (enum SCAN_COMPLETED/SCAN_FAILED/...), and the infected-files count is
+// numberOfFilesImpacted. numberOfFilesScanned is named as-is in the schema.
+type MalwareScanResults struct {
+	Data []struct {
+		Attributes struct {
+			ScanState             string `json:"scanState"`
+			NumberOfFilesScanned  int64  `json:"numberOfFilesScanned"`
+			NumberOfFilesImpacted int64  `json:"numberOfFilesImpacted"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/internal/models/Slos.go
+++ b/internal/models/Slos.go
@@ -1,0 +1,19 @@
+package models
+
+// Slos is the response from GET /servicecatalog/slos (JSON:API).
+//
+// The 11.2 servicecatalog.yaml SLO schema (data[].attributes) exposes name,
+// description, policyNamePrefix, workloadType, subscribeAllowed,
+// subscriptionCount, schedules, capabilities and policyDefinition. There is NO
+// per-SLO enforcement-type attribute: the "Enforcement Type" text in the spec
+// refers to the endpoint's access-control model (Object-Level), not response
+// data. The collector therefore emits a single unlabeled total count.
+type Slos struct {
+	Data []struct {
+		ID         string `json:"id"`
+		Type       string `json:"type"`
+		Attributes struct {
+			Name string `json:"name"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/internal/testutil/constants.go
+++ b/internal/testutil/constants.go
@@ -58,6 +58,7 @@ const (
 	APIVersion30  = "version=3.0"
 	APIVersion120 = "version=12.0"
 	APIVersion130 = "version=13.0"
+	APIVersion140 = "version=14.0"
 )
 
 // Test endpoints and paths

--- a/testdata/api-versions/alerts-response.json
+++ b/testdata/api-versions/alerts-response.json
@@ -1,0 +1,7 @@
+{
+  "data": [
+    { "attributes": { "severity": "ERROR",   "category": "JOB", "subCategory": "STANDARD" } },
+    { "attributes": { "severity": "ERROR",   "category": "JOB", "subCategory": "ORACLE" } },
+    { "attributes": { "severity": "WARNING", "category": "JOB", "subCategory": "ANY" } }
+  ]
+}

--- a/testdata/api-versions/catalog-count-response.json
+++ b/testdata/api-versions/catalog-count-response.json
@@ -1,0 +1,1 @@
+{ "meta": { "pagination": { "count": 42 } } }

--- a/testdata/api-versions/jobs-response-v14.json
+++ b/testdata/api-versions/jobs-response-v14.json
@@ -1,0 +1,204 @@
+{
+  "data": [
+    {
+      "type": "job",
+      "id": "12345",
+      "links": {
+        "self": {
+          "href": "/netbackup/admin/jobs/12345"
+        },
+        "file-lists": {
+          "href": "/netbackup/admin/jobs/12345/file-lists"
+        },
+        "try-logs": {
+          "href": "/netbackup/admin/jobs/12345/try-logs"
+        }
+      },
+      "attributes": {
+        "jobId": 12345,
+        "parentJobId": 0,
+        "activeProcessId": 54321,
+        "jobType": "BACKUP",
+        "jobSubType": "FULL",
+        "policyType": "VMWARE",
+        "policyName": "VMware-Policy-1",
+        "scheduleType": "FULL",
+        "scheduleName": "Full-Schedule",
+        "clientName": "vm-client-01.example.com",
+        "controlHost": "master.example.com",
+        "jobOwner": "admin",
+        "jobGroup": "default",
+        "backupId": "backup_12345_1234567890_FULL",
+        "sourceMediaId": "",
+        "sourceStorageUnitName": "",
+        "sourceMediaServerName": "",
+        "destinationMediaId": "media-001",
+        "destinationStorageUnitName": "disk-pool-1",
+        "destinationMediaServerName": "media-server-01.example.com",
+        "dataMovement": "STANDARD",
+        "streamNumber": 1,
+        "copyNumber": 1,
+        "priority": 9999,
+        "compression": 0,
+        "status": 0,
+        "state": "DONE",
+        "numberOfFiles": 1250,
+        "estimatedFiles": 1200,
+        "kilobytesTransferred": 52428800,
+        "kilobytesDataTransferred": 48234567,
+        "kilobytesToTransfer": 52428800,
+        "transferRate": 102400,
+        "percentComplete": 100,
+        "restartable": 0,
+        "suspendable": 0,
+        "resumable": 0,
+        "frozenImage": 0,
+        "transportType": "LAN",
+        "dedupRatio": 2.5,
+        "currentOperation": 0,
+        "robotName": "",
+        "vaultName": "",
+        "profileName": "",
+        "sessionId": 987654,
+        "numberOfTapeToEject": 0,
+        "submissionType": 0,
+        "acceleratorOptimization": 0,
+        "dumpHost": "",
+        "instanceDatabaseName": "",
+        "auditUserName": "admin",
+        "auditDomainName": "DOMAIN",
+        "auditDomainType": 0,
+        "restoreBackupIDs": "",
+        "startTime": "2024-11-08T10:00:00Z",
+        "endTime": "2024-11-08T11:30:00Z",
+        "activeTryStartTime": "2024-11-08T10:00:00Z",
+        "lastUpdateTime": "2024-11-08T11:30:00Z",
+        "initiatorId": "admin",
+        "retentionLevel": 1,
+        "try": 1,
+        "cancellable": 0,
+        "jobQueueReason": 0,
+        "jobQueueResource": "",
+        "elapsedTime": "PT1H30M",
+        "offHostType": "STANDARD",
+        "cloudProvider": "AWS",
+        "cloudRegion": "us-east-1",
+        "immutabilityEnabled": true,
+        "aiDrivenOptimization": true
+      }
+    },
+    {
+      "type": "job",
+      "id": "12346",
+      "links": {
+        "self": {
+          "href": "/netbackup/admin/jobs/12346"
+        },
+        "file-lists": {
+          "href": "/netbackup/admin/jobs/12346/file-lists"
+        },
+        "try-logs": {
+          "href": "/netbackup/admin/jobs/12346/try-logs"
+        }
+      },
+      "attributes": {
+        "jobId": 12346,
+        "parentJobId": 0,
+        "activeProcessId": 54322,
+        "jobType": "RESTORE",
+        "jobSubType": "RESTORE",
+        "policyType": "STANDARD",
+        "policyName": "Standard-Policy-1",
+        "scheduleType": "",
+        "scheduleName": "",
+        "clientName": "client-02.example.com",
+        "controlHost": "master.example.com",
+        "jobOwner": "operator",
+        "jobGroup": "default",
+        "backupId": "backup_12340_1234567800_FULL",
+        "sourceMediaId": "media-001",
+        "sourceStorageUnitName": "disk-pool-1",
+        "sourceMediaServerName": "media-server-01.example.com",
+        "destinationMediaId": "",
+        "destinationStorageUnitName": "",
+        "destinationMediaServerName": "",
+        "dataMovement": "STANDARD",
+        "streamNumber": 1,
+        "copyNumber": 1,
+        "priority": 50000,
+        "compression": 0,
+        "status": 1,
+        "state": "ACTIVE",
+        "numberOfFiles": 500,
+        "estimatedFiles": 500,
+        "kilobytesTransferred": 10485760,
+        "kilobytesDataTransferred": 9876543,
+        "kilobytesToTransfer": 20971520,
+        "transferRate": 51200,
+        "percentComplete": 50,
+        "restartable": 1,
+        "suspendable": 1,
+        "resumable": 0,
+        "frozenImage": 0,
+        "transportType": "LAN",
+        "dedupRatio": 1.0,
+        "currentOperation": 14,
+        "robotName": "",
+        "vaultName": "",
+        "profileName": "",
+        "sessionId": 987655,
+        "numberOfTapeToEject": 0,
+        "submissionType": 0,
+        "acceleratorOptimization": 0,
+        "dumpHost": "",
+        "instanceDatabaseName": "",
+        "auditUserName": "operator",
+        "auditDomainName": "DOMAIN",
+        "auditDomainType": 0,
+        "restoreBackupIDs": "backup_12340_1234567800_FULL",
+        "startTime": "2024-11-08T12:00:00Z",
+        "endTime": "0001-01-01T00:00:00Z",
+        "activeTryStartTime": "2024-11-08T12:00:00Z",
+        "lastUpdateTime": "2024-11-08T12:15:00Z",
+        "initiatorId": "operator",
+        "retentionLevel": 0,
+        "try": 1,
+        "cancellable": 1,
+        "jobQueueReason": 0,
+        "jobQueueResource": "",
+        "elapsedTime": "PT15M",
+        "offHostType": "STANDARD",
+        "cloudProvider": "",
+        "cloudRegion": "",
+        "immutabilityEnabled": false,
+        "aiDrivenOptimization": false
+      }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "count": 2,
+      "offset": 0,
+      "limit": 100,
+      "first": 0,
+      "last": 1,
+      "page": 1,
+      "pages": 1,
+      "next": 0
+    }
+  },
+  "links": {
+    "self": {
+      "href": "/netbackup/admin/jobs?page[limit]=100&page[offset]=0"
+    },
+    "first": {
+      "href": "/netbackup/admin/jobs?page[limit]=100&page[offset]=0"
+    },
+    "last": {
+      "href": "/netbackup/admin/jobs?page[limit]=100&page[offset]=0"
+    },
+    "next": {
+      "href": ""
+    }
+  }
+}

--- a/testdata/api-versions/malware-response.json
+++ b/testdata/api-versions/malware-response.json
@@ -1,7 +1,7 @@
 {
   "data": [
-    { "attributes": { "scanState": "Completed", "numberOfFilesScanned": 1000, "numberOfFilesImpacted": 2 } },
-    { "attributes": { "scanState": "Completed", "numberOfFilesScanned": 500,  "numberOfFilesImpacted": 0 } },
-    { "attributes": { "scanState": "Failed",    "numberOfFilesScanned": 0,    "numberOfFilesImpacted": 0 } }
+    { "attributes": { "scanState": "SCAN_COMPLETED", "numberOfFilesScanned": 1000, "numberOfFilesImpacted": 2 } },
+    { "attributes": { "scanState": "SCAN_COMPLETED", "numberOfFilesScanned": 500,  "numberOfFilesImpacted": 0 } },
+    { "attributes": { "scanState": "SCAN_FAILED",    "numberOfFilesScanned": 0,    "numberOfFilesImpacted": 0 } }
   ]
 }

--- a/testdata/api-versions/malware-response.json
+++ b/testdata/api-versions/malware-response.json
@@ -1,0 +1,7 @@
+{
+  "data": [
+    { "attributes": { "scanState": "Completed", "numberOfFilesScanned": 1000, "numberOfFilesImpacted": 2 } },
+    { "attributes": { "scanState": "Completed", "numberOfFilesScanned": 500,  "numberOfFilesImpacted": 0 } },
+    { "attributes": { "scanState": "Failed",    "numberOfFilesScanned": 0,    "numberOfFilesImpacted": 0 } }
+  ]
+}

--- a/testdata/api-versions/slo-response.json
+++ b/testdata/api-versions/slo-response.json
@@ -1,0 +1,7 @@
+{
+  "data": [
+    { "id": "slo-1", "type": "slov3", "attributes": { "name": "Gold" } },
+    { "id": "slo-2", "type": "slov3", "attributes": { "name": "Silver" } },
+    { "id": "slo-3", "type": "slov3", "attributes": { "name": "Bronze" } }
+  ]
+}

--- a/testdata/api-versions/storage-response-v14.json
+++ b/testdata/api-versions/storage-response-v14.json
@@ -1,0 +1,171 @@
+{
+  "data": [
+    {
+      "type": "storageUnit",
+      "id": "disk-pool-1",
+      "links": {
+        "self": {
+          "href": "/netbackup/storage/storage-units/disk-pool-1"
+        }
+      },
+      "attributes": {
+        "name": "disk-pool-1",
+        "storageType": "DISK",
+        "storageSubType": "AdvancedDisk",
+        "storageServerType": "MEDIA_SERVER",
+        "useAnyAvailableMediaServer": true,
+        "accelerator": false,
+        "instantAccessEnabled": false,
+        "isCloudSTU": false,
+        "freeCapacityBytes": 5368709120000,
+        "totalCapacityBytes": 10737418240000,
+        "usedCapacityBytes": 5368709120000,
+        "maxFragmentSizeMegabytes": 2048,
+        "maxConcurrentJobs": 4,
+        "onDemandOnly": false,
+        "storageCategory": "PRIMARY",
+        "replicationCapable": true,
+        "replicationSourceCapable": true,
+        "replicationTargetCapable": false,
+        "snapshot": false,
+        "mirror": false,
+        "independent": true,
+        "primary": true,
+        "scaleOutEnabled": false,
+        "wormCapable": false,
+        "useWorm": false,
+        "immutabilityEnabled": true,
+        "aiOptimizedStorage": true,
+        "sustainabilityScore": 85
+      },
+      "relationships": {
+        "diskPool": {
+          "links": {
+            "related": {
+              "href": "/netbackup/storage/disk-pools/dp-1"
+            }
+          },
+          "data": {
+            "type": "diskPool",
+            "id": "dp-1"
+          }
+        }
+      }
+    },
+    {
+      "type": "storageUnit",
+      "id": "cloud-stu-1",
+      "links": {
+        "self": {
+          "href": "/netbackup/storage/storage-units/cloud-stu-1"
+        }
+      },
+      "attributes": {
+        "name": "cloud-stu-1",
+        "storageType": "CLOUD",
+        "storageSubType": "CloudCatalyst",
+        "storageServerType": "MEDIA_SERVER",
+        "useAnyAvailableMediaServer": false,
+        "accelerator": true,
+        "instantAccessEnabled": true,
+        "isCloudSTU": true,
+        "freeCapacityBytes": 107374182400000,
+        "totalCapacityBytes": 214748364800000,
+        "usedCapacityBytes": 107374182400000,
+        "maxFragmentSizeMegabytes": 4096,
+        "maxConcurrentJobs": 8,
+        "onDemandOnly": false,
+        "storageCategory": "CLOUD",
+        "replicationCapable": true,
+        "replicationSourceCapable": false,
+        "replicationTargetCapable": true,
+        "snapshot": true,
+        "mirror": false,
+        "independent": false,
+        "primary": false,
+        "scaleOutEnabled": true,
+        "wormCapable": true,
+        "useWorm": true,
+        "immutabilityEnabled": true,
+        "aiOptimizedStorage": true,
+        "sustainabilityScore": 92
+      },
+      "relationships": {
+        "diskPool": {
+          "links": {
+            "related": {
+              "href": "/netbackup/storage/disk-pools/dp-2"
+            }
+          },
+          "data": {
+            "type": "diskPool",
+            "id": "dp-2"
+          }
+        }
+      }
+    },
+    {
+      "type": "storageUnit",
+      "id": "tape-stu-1",
+      "links": {
+        "self": {
+          "href": "/netbackup/storage/storage-units/tape-stu-1"
+        }
+      },
+      "attributes": {
+        "name": "tape-stu-1",
+        "storageType": "Tape",
+        "storageSubType": "LTO",
+        "storageServerType": "MEDIA_SERVER",
+        "useAnyAvailableMediaServer": false,
+        "accelerator": false,
+        "instantAccessEnabled": false,
+        "isCloudSTU": false,
+        "freeCapacityBytes": 0,
+        "totalCapacityBytes": 0,
+        "usedCapacityBytes": 0,
+        "maxFragmentSizeMegabytes": 0,
+        "maxConcurrentJobs": 2,
+        "onDemandOnly": true,
+        "immutabilityEnabled": false,
+        "aiOptimizedStorage": false,
+        "sustainabilityScore": 0
+      },
+      "relationships": {
+        "diskPool": {
+          "links": {
+            "related": {
+              "href": ""
+            }
+          },
+          "data": {
+            "type": "",
+            "id": ""
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "count": 3,
+      "offset": 0,
+      "limit": 100,
+      "first": 0,
+      "last": 2,
+      "page": 1,
+      "pages": 1
+    }
+  },
+  "links": {
+    "self": {
+      "href": "/netbackup/storage/storage-units?page[limit]=100&page[offset]=0"
+    },
+    "first": {
+      "href": "/netbackup/storage/storage-units?page[limit]=100&page[offset]=0"
+    },
+    "last": {
+      "href": "/netbackup/storage/storage-units?page[limit]=100&page[offset]=0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Validates the exporter against the Veritas NetBackup 11.2 OpenAPI specs (`docs/veritas-11.2/`) and closes the gaps found, adding four opt-in collectors. Specs: `docs/superpowers/specs/2026-06-14-nbu-11.2-validation-design.md`, plan: `docs/superpowers/plans/2026-06-14-nbu-11.2-validation.md`, ADR: `docs/adr/0002-opt-in-sub-collector-framework.md`.

- **API version 14.0 (11.2-native).** Detector now probes `14.0 → 13.0 → 12.0 → 3.0`; default bumped; v14 fixtures added. (Previously topped out at 13.0 and fell back against an 11.2 appliance.)
- **Pluggable opt-in sub-collector framework** (ADR-0002): `subCollector` interface + `runSubCollectors`, per-collector graceful degradation, `nbu_up` stays tied to storage/jobs only.
- **Four new collectors, all default-off** via a new `collectors:` config section:
  - `nbu_alerts_count{severity,category}` — `GET /manage/alerts`
  - `nbu_malware_files_scanned` / `nbu_malware_files_infected` / `nbu_malware_scan_count{status}` — `GET /malware/latest-scan-results`
  - `nbu_catalog_images_count{malware_status,anomaly_status}` — `GET /catalog/images` (count-only, bounded cardinality)
  - `nbu_slo_count` — `GET /servicecatalog/slos`
- **Spec-validation catches** baked into the code: real 11.2 fields are `scanState` / `numberOfFilesImpacted` (not the assumed names), and SLO responses have no enforcement-type field (so `nbu_slo_count` is unlabeled).
- **Grafana**: new overview panels for the four collectors; legacy dashboard de-hardcoded onto a `$storage_unit` template variable.
- **Docs**: `metrics.md` updated; `/admin/jobs` validation gap documented (`admin.yaml` absent from the local 11.2 bundle — job metrics validated against 11.0/`version=13.0`, backward-compatible under 14.0).

Storage (`/storage/storage-units`) and dashboards were already aligned — no changes needed there.

## Test Plan

- [x] `make ci` green — vet, golangci-lint (0 issues), `go test -race`, govulncheck (no vulns)
- [x] Total coverage 86.0% (exporter pkg 92.8%), above the 70% gate
- [x] Each collector has a success and an error-path unit test (graceful degradation)
- [ ] Enable each collector against a live NBU 11.2 appliance and confirm metric values

🤖 Generated with [Claude Code](https://claude.com/claude-code)