### PR TITLE
fix(demo): stdout logging + overridable host ports for the compose stack

### DIFF
--- a/config-auto-detect.yaml
+++ b/config-auto-detect.yaml
@@ -1,12 +1,12 @@
 ---
 # Example configuration with automatic API version detection
-# The exporter will try versions in order: 13.0 -> 12.0 -> 3.0
+# The exporter will try versions in order: 14.0 -> 13.0 -> 12.0 -> 3.0
 server:
   host: "localhost"
   port: "2112"
   uri: "/metrics"
   scrapingInterval: "1h"
-  logName: "log/nbu-exporter.log"
+  logName: "stdout" # stdout-only logging (see config.yaml for file-logging notes)
 nbuserver:
   scheme: "https"
   uri: "/netbackup"

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,11 @@ server:
   port: "2112"
   uri: "/metrics"
   scrapingInterval: "1h" # Changed from scrappingInterval (typo fix)
-  logName: "log/nbu-exporter.log"
+  # "stdout" (also "" or "-") logs to stdout only — ideal for containers
+  # (captured by `docker logs`), systemd/journald, and Kubernetes. Set a file
+  # path (e.g. "/var/log/nbu_exporter/nbu-exporter.log") to also write a file;
+  # its parent directory must already exist and be writable.
+  logName: "stdout"
 nbuserver:
   scheme: "https"
   uri: "/netbackup"

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -5,10 +5,9 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "2112:2112"
+      - "${NBU_EXPORTER_PORT:-2112}:2112"
     volumes:
       - ./config.yaml:/etc/nbu_exporter/config.yaml:ro
-      - ./log:/var/log/nbu_exporter
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:2112/health"]
@@ -37,7 +36,7 @@ services:
       - ./deploy/prometheus/nbu.rules.yml:/etc/prometheus/rules/nbu.rules.yml:ro
       - prometheus-data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_PORT:-9090}:9090"
     restart: unless-stopped
     depends_on:
       - nbu_exporter
@@ -50,7 +49,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "3000:3000"
+      - "${GRAFANA_PORT:-3000}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,10 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "2112:2112"
+      - "${NBU_EXPORTER_PORT:-2112}:2112"
     volumes:
       # Mount configuration file (read-only)
       - ./config.yaml:/etc/nbu_exporter/config.yaml:ro
-      # Mount log directory for persistent logs
-      - ./log:/var/log/nbu_exporter
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:2112/health"]
@@ -54,7 +52,7 @@ services:
       - ./deploy/prometheus/nbu.rules.yml:/etc/prometheus/rules/nbu.rules.yml:ro
       - prometheus-data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_PORT:-9090}:9090"
     restart: unless-stopped
     depends_on:
       - nbu_exporter
@@ -67,7 +65,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "3000:3000"
+      - "${GRAFANA_PORT:-3000}:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -83,6 +83,23 @@ files are otherwise identical.
 Override the Grafana credentials with the `GF_ADMIN_USER` and `GF_ADMIN_PASSWORD` environment
 variables (for example in a gitignored `.env` file).
 
+### Host ports
+
+If a host port is already in use (for example another Prometheus on `9090`), override the published
+port without editing the compose files:
+
+```bash
+NBU_EXPORTER_PORT=12112 PROMETHEUS_PORT=19090 GRAFANA_PORT=13000 docker compose up -d
+```
+
+The defaults are `2112` (exporter), `9090` (Prometheus), and `3000` (Grafana).
+
+### Logs
+
+The exporter logs to stdout (`logName: "stdout"` in `config.yaml`), so view logs with
+`docker compose logs -f nbu_exporter`. No log directory or bind mount is required; set `logName` to a
+file path in `config.yaml` if you also want a log file.
+
 ### Auto-provisioning
 
 The Grafana datasource and the NetBackup dashboards are provisioned automatically — no manual import

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -52,17 +52,28 @@ func LogError(msg string) {
 // PrepareLogs initializes the logging system with the specified log file.
 // It configures logging to write to both stdout and the log file with JSON formatting.
 //
+// If logName is empty, "stdout", or "-", logging is sent to stdout only and no
+// file is opened. This is the recommended mode for containers (logs are captured
+// by the runtime, e.g. `docker logs`) and avoids requiring a writable log
+// directory. Otherwise logs are written to both stdout and the named file; the
+// file's parent directory must already exist.
+//
 // Parameters:
-//   - logName: Path to the log file (will be created if it doesn't exist)
+//   - logName: Path to the log file, or "" / "stdout" / "-" for stdout only.
 //
 // Returns an error if the log file cannot be opened or created.
 func PrepareLogs(logName string) error {
+	log.SetFormatter(&log.JSONFormatter{PrettyPrint: true})
+
+	if logName == "" || logName == "stdout" || logName == "-" {
+		log.SetOutput(os.Stdout)
+		return nil
+	}
+
 	logFile, err := os.OpenFile(logName, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %v", err)
 	}
-	mw := io.MultiWriter(os.Stdout, logFile)
-	log.SetOutput(mw)
-	log.SetFormatter(&log.JSONFormatter{PrettyPrint: true})
+	log.SetOutput(io.MultiWriter(os.Stdout, logFile))
 	return nil
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -153,6 +153,33 @@ func TestPrepareLogs(t *testing.T) {
 	}
 }
 
+func TestPrepareLogsStdout(t *testing.T) {
+	// Empty / "stdout" / "-" select stdout-only mode: no file, no error.
+	for _, logName := range []string{"", "stdout", "-"} {
+		t.Run("logName="+logName, func(t *testing.T) {
+			if err := PrepareLogs(logName); err != nil {
+				t.Fatalf("PrepareLogs(%q) returned error: %v", logName, err)
+			}
+
+			// Logging still works (route to a buffer to capture output).
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			LogInfo("stdout mode works")
+			if !strings.Contains(buf.String(), "stdout mode works") {
+				t.Errorf("logging did not work in stdout mode for %q", logName)
+			}
+
+			// No file named "stdout"/"-" should be created in the working dir.
+			if logName == "stdout" || logName == "-" {
+				if _, err := os.Stat(logName); err == nil {
+					_ = os.Remove(logName)
+					t.Errorf("PrepareLogs(%q) unexpectedly created a file", logName)
+				}
+			}
+		})
+	}
+}
+
 func TestPrepareLogsInvalidPath(t *testing.T) {
 	// Test with invalid path (directory that doesn't exist)
 	err := PrepareLogs("/nonexistent/directory/test.log")


### PR DESCRIPTION
## Problem

`docker compose up` failed two ways:

1. **Exporter crash:** `failed to open log file: open log/nbu-exporter.log: no such file or directory`. `config.yaml`'s relative `logName` has no writable parent dir in the container (CWD `/`, non-root `nbu` user), and `PrepareLogs` doesn't create directories. Logs already go to stdout via `MultiWriter`, so the file was redundant in a container.
2. **Prometheus crash:** `bind: address already in use` on `:9090` — fixed host ports collide with whatever is already running on the host.

## Fix

- **`logging.PrepareLogs`**: treat `""` / `"stdout"` / `"-"` as stdout-only (no file opened), with unit tests. File logging still works when a path is given.
- **`config.yaml` + `config-auto-detect.yaml`**: default `logName` to `"stdout"` — works identically for bare-metal, Docker, systemd, and Kubernetes; resolves the bare-metal-vs-container path conflict.
- **`docker-compose.yml` + `docker-compose.ghcr.yml`**: drop the now-redundant `./log` mount; make `NBU_EXPORTER_PORT` / `PROMETHEUS_PORT` / `GRAFANA_PORT` overridable so host conflicts (e.g. an existing `:9090`) are a one-liner.
- **`docs/docker.md`**: document log viewing (`docker compose logs -f`) and port overrides.
- Drive-by: fixed the stale `13.0 -> 12.0 -> 3.0` version-order comment in `config-auto-detect.yaml`.

## Test Plan

- [x] `make ci` green (lint 0 issues, `go test -race`, govulncheck); logging package coverage 86.7%
- [x] New `TestPrepareLogsStdout` covers `""`/`stdout`/`-`
- [x] Both compose files pass `docker compose config -q`
- [ ] `docker compose up` end to end on a host (logs via `docker compose logs`, custom ports honored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service ports (exporter, Prometheus, Grafana) are now configurable via environment variables with sensible defaults, enabling easier port conflict resolution.
  * Stdout logging support for containerized deployments.

* **Documentation**
  * Added Docker documentation covering port customization and stdout logging behavior.

* **Improvements**
  * Logging now defaults to stdout for container-friendly operations, removing the need for persistent log directory mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->