### PR TITLE
feat(helm): add Helm chart + lockstep publishing

### DIFF
--- a/.github/workflows/helm-charts.yml
+++ b/.github/workflows/helm-charts.yml
@@ -1,0 +1,58 @@
+name: Release Helm Chart
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Lint chart
+        run: helm lint charts/nbu-exporter
+
+      - name: Render templates
+        run: helm template release-test charts/nbu-exporter > /dev/null
+
+  publish-chart:
+    needs: lint
+    # Publish on release tags only, so the chart version + appVersion always
+    # match the app release (lockstep). No manual Chart.yaml bump required.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Log in to GHCR
+        run: helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Package and push chart (version from release tag)
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "Publishing chart + appVersion ${version} from tag ${GITHUB_REF_NAME}"
+          helm package charts/nbu-exporter \
+            --version "${version}" --app-version "${version}" \
+            --destination dist-charts
+          helm push dist-charts/*.tgz "oci://ghcr.io/${{ github.repository_owner }}/charts"

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ coverage.out
 coverage.html
 *.coverprofile
 /nbu_exporter
-nbu-exporter
+/nbu-exporter
 
 # Logs
 log/

--- a/charts/nbu-exporter/.helmignore
+++ b/charts/nbu-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nbu-exporter/Chart.yaml
+++ b/charts/nbu-exporter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: nbu-exporter
+description: Chart for NBU Exporter (Prometheus exporter for Veritas NetBackup)
+type: application
+
+# Baseline version for local installs from source. On a release, CI overrides
+# both `version` and `appVersion` from the git tag (.github/workflows/helm-charts.yml),
+# so the published OCI chart always matches the app release — no manual bump needed.
+version: "3.0.0"
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.0"

--- a/charts/nbu-exporter/templates/_helpers.tpl
+++ b/charts/nbu-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nbu-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nbu-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nbu-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nbu-exporter.labels" -}}
+helm.sh/chart: {{ include "nbu-exporter.chart" . }}
+{{ include "nbu-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nbu-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nbu-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nbu-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nbu-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/nbu-exporter/templates/config.yaml
+++ b/charts/nbu-exporter/templates/config.yaml
@@ -1,0 +1,10 @@
+{{- if and (not .Values.existingSecret) .Values.config }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nbu-exporter.fullname" . }}-config
+  labels:
+    {{- include "nbu-exporter.labels" . | nindent 4 }}
+stringData:
+  config.yaml: {{ tpl .Values.config . | quote }}
+{{- end }}

--- a/charts/nbu-exporter/templates/deployment.yaml
+++ b/charts/nbu-exporter/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nbu-exporter.fullname" . }}
+  labels:
+    {{- include "nbu-exporter.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nbu-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "nbu-exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "nbu-exporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --config
+            - /etc/nbu_exporter/config.yaml
+          {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or (.Values.config) (.Values.existingSecret) (.Values.volumeMounts) }}
+          volumeMounts:
+          {{- end }}
+            {{- if or .Values.config .Values.existingSecret }}
+            - mountPath: "/etc/nbu_exporter"
+              name: config
+              readOnly: true
+            {{- end }}
+          {{- range .Values.volumeMounts }}
+            - {{ toYaml . | indent 14 | trim }}
+          {{- end -}}
+      {{- if or (.Values.config) (.Values.existingSecret) (.Values.volumes) }}
+      volumes:
+      {{- end }}
+      {{- if or .Values.config .Values.existingSecret }}
+        - name: config
+          secret:
+            secretName: {{ .Values.existingSecret | default (printf "%s-config" (include "nbu-exporter.fullname" .)) }}
+      {{- end }}
+      {{- range .Values.volumes }}
+        - {{ toYaml . | indent 10 | trim }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nbu-exporter/templates/prometheusrule.yaml
+++ b/charts/nbu-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+# Source https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-rabbitmq-exporter/templates/prometheusrule.yaml
+{{- if .Values.prometheus.rules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "nbu-exporter.fullname" . }}
+{{- with .Values.prometheus.rules.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "nbu-exporter.name" . }}
+    chart: {{ template "nbu-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.prometheus.rules.additionalLabels }}
+{{ toYaml .Values.prometheus.rules.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+{{- with .Values.prometheus.rules.additionalRules }}
+  groups:
+    - name: {{ template "nbu-exporter.fullname" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/nbu-exporter/templates/scrapeconfig.yaml
+++ b/charts/nbu-exporter/templates/scrapeconfig.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.prometheus.scrapeConfig.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: {{ template "nbu-exporter.fullname" . }}
+{{- with .Values.prometheus.scrapeConfig.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "nbu-exporter.name" . }}
+    chart: {{ template "nbu-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.prometheus.scrapeConfig.additionalLabels }}
+{{ toYaml .Values.prometheus.scrapeConfig.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  staticConfigs:
+    - targets:
+        - {{ include "nbu-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+{{- with .Values.prometheus.scrapeConfig.interval }}
+  scrapeInterval: {{ . }}
+{{- end }}
+{{- with .Values.prometheus.scrapeConfig.scrapeTimeout }}
+  scrapeTimeout: {{ . }}
+{{- end }}
+{{- with .Values.prometheus.scrapeConfig.metricRelabelings }}
+  metricRelabelings:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.prometheus.scrapeConfig.relabelings }}
+  relabelings:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/nbu-exporter/templates/service.yaml
+++ b/charts/nbu-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nbu-exporter.fullname" . }}
+  labels:
+    {{- include "nbu-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nbu-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/nbu-exporter/templates/serviceaccount.yaml
+++ b/charts/nbu-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nbu-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "nbu-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/nbu-exporter/templates/servicemonitor.yaml
+++ b/charts/nbu-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+# Source https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-rabbitmq-exporter/templates/servicemonitor.yaml
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nbu-exporter.fullname" . }}
+  labels:
+    app: {{ template "nbu-exporter.name" . }}
+    chart: {{ template "nbu-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.prometheus.monitor.additionalLabels }}
+{{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "nbu-exporter.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: http
+  {{- if .Values.prometheus.monitor.interval }}
+      interval: {{ .Values.prometheus.monitor.interval }}
+  {{- end }}
+  {{- with .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.prometheus.monitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- if .Values.prometheus.monitor.namespace }}
+  namespaceSelector:
+    matchNames:
+    {{- range .Values.prometheus.monitor.namespace }}
+    - {{ . }}
+    {{- end }}
+  {{- with .Values.prometheus.monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/nbu-exporter/values.yaml
+++ b/charts/nbu-exporter/values.yaml
@@ -1,0 +1,142 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/fjacquet/nbu_exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9440
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+volumes: []
+volumeMounts: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraArgs: []
+
+existingSecret: ""
+
+# Inline exporter config, rendered into a Secret and mounted at /etc/nbu_exporter/config.yaml.
+# Secrets replaced by placeholders — set real values via env vars or an external Secret.
+config: |
+  server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    logName: "stdout"
+  nbuserver:
+    scheme: "https"
+    uri: "/netbackup"
+    domain: "my.domain"
+    domainType: "NT"
+    host: "master.my.domain"
+    port: "1556"
+    apiVersion: "13.0"
+    apiKey: "REPLACE_WITH_API_KEY"
+    contentType: "application/vnd.netbackup+json; version=13.0"
+    insecureSkipVerify: false
+  opentelemetry:
+    enabled: false
+    endpoint: "localhost:4317"
+    insecure: true
+    samplingRate: 0.1
+  collectors:
+    alerts:  { enabled: false }
+    malware: { enabled: false }
+    catalog: { enabled: false }
+    slo:     { enabled: false }
+
+env: []
+# - name: NBU1_HOSTNAME
+#   value: master.my.domain
+# - name: NBU1_APIKEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-external-nbu-secret
+#       key: nbu-api-key
+
+deploymentAnnotations: {}
+
+podAnnotations:
+  prometheus.io/scrape: "false"
+  prometheus.io/path: "/metrics"
+  prometheus.io/port: "9440"
+
+prometheus:
+  monitor:
+    enabled: false
+    additionalLabels: {}
+    interval: 15s
+    namespace: []
+    metricRelabelings: []
+    relabelings: []
+    targetLabels: []
+
+  rules:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+    additionalRules: []
+
+  scrapeConfig:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+    interval: 60s
+    scrapeTimeout: 55s
+    metricRelabelings: []
+    relabelings: []


### PR DESCRIPTION
## Summary

Adds a Helm chart for the nbu-exporter, modeled on the exporter-standards family pattern (idrac-exporter).

### Adaptation choices

| Point | Value | Source |
|-------|-------|--------|
| **Port** | `9440` | `Dockerfile` EXPOSE + `config.yaml` server.port |
| **Config path** | `/etc/nbu_exporter/config.yaml` | `Dockerfile` CMD `--config /etc/nbu_exporter/config.yaml` + COPY |
| **Config flag** | `--config` | `Dockerfile` CMD, confirmed in `main.go` cobra flag |
| **Health probe** | `httpGet /health` | `main.go:209` `mux.HandleFunc("/health", s.healthHandler)` |
| **Image** | `ghcr.io/fjacquet/nbu_exporter` | `.goreleaser.yml` + release workflow |
| **Baseline version** | `3.0.0` | `gh release view` → `v3.0.0` |

### Files added

- `charts/nbu-exporter/Chart.yaml` — name `nbu-exporter`, version/appVersion `3.0.0` (CI overrides from git tag)
- `charts/nbu-exporter/values.yaml` — port 9440, `/health` probes, `config:` passthrough with placeholder secrets
- `charts/nbu-exporter/templates/_helpers.tpl` — all helpers renamed to `nbu-exporter.*`
- `charts/nbu-exporter/templates/deployment.yaml` — mounts config Secret at `/etc/nbu_exporter`, passes `--config` flag
- `charts/nbu-exporter/templates/config.yaml` — Secret rendering `values.config` as `config.yaml`
- `charts/nbu-exporter/templates/service.yaml`
- `charts/nbu-exporter/templates/serviceaccount.yaml`
- `charts/nbu-exporter/templates/servicemonitor.yaml` — gated on `prometheus.monitor.enabled`
- `charts/nbu-exporter/templates/prometheusrule.yaml` — gated on `prometheus.rules.enabled`
- `charts/nbu-exporter/templates/scrapeconfig.yaml` — gated on `prometheus.scrapeConfig.enabled`
- `.github/workflows/helm-charts.yml` — lint on `charts/**` PRs; publish OCI to `ghcr.io/$owner/charts` on `v*` tags; SHA-pinned actions
- `.gitignore` — scoped `nbu-exporter` → `/nbu-exporter` (was blocking `charts/nbu-exporter/` from being tracked)

### Validation

```
helm lint charts/nbu-exporter   → 1 chart(s) linted, 0 chart(s) failed
helm template nbu-exporter ...  → clean render
```

### Assumptions / risks

- The `scrapeConfig` template uses `staticConfigs` (not `httpSDConfigs` with a `/discover` endpoint) since nbu-exporter is not a multi-target proxy — it scrapes a fixed set of NBU hosts from its config.
- Prometheus CRD templates (ServiceMonitor, PrometheusRule, ScrapeConfig) are all disabled by default; opt in via values.
- The `.gitignore` fix (`/nbu-exporter` instead of `nbu-exporter`) prevents the chart directory from being silently ignored in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)