### PR TITLE
feat: multi-site support via snapshot collection model (Feature 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-site support**: a single exporter can scrape multiple NetBackup primary servers via
+  a `nbuservers:` list, each with a unique `site`; every metric series carries a `site` label
+  (first label). Collection adopts the family **snapshot model** — a background loop polls
+  every site on `server.collectionInterval` (default 5m) and publishes an immutable snapshot,
+  decoupling backend API load from Prometheus scrape frequency. `/metrics` serves immediately
+  (empty until the first cycle); a down site reports only `nbu_up{site=…}=0` without affecting
+  the others. A legacy single `nbuserver:` block is auto-mapped to a one-entry list (`site`
+  defaults to the host), so existing configs keep working unchanged. Opt-in sub-collectors
+  (alerts/malware/catalog/SLO) are per-site and carry the `site` label too. See
+  [ADR-0004](docs/adr/0004-multisite-snapshot-collection-model.md) and
+  `docs/config-examples/config-multisite.yaml`.
 - **NetBackup 10.x support**: the exporter negotiates API media-type `version=10.0` for
   NetBackup 10.0–10.4 (replacing the never-valid `3.0`); the auto-detect ladder is now
   `14.0 → 13.0 → 12.0 → 10.0`. Includes the NBU 10.3 and 11.2 OpenAPI bundles used for

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A Prometheus exporter that collects backup job statistics and storage metrics fr
 
 - Job metrics collection by type, policy, and status
 - Storage unit capacity monitoring (free/used bytes)
+- Multi-site: scrape several NetBackup primaries from one exporter, labelled by `site`
+  (background snapshot collection loop; see [`config-multisite.yaml`](docs/config-examples/config-multisite.yaml))
 - Automatic NetBackup API version detection (14.0, 13.0, 12.0, 10.0)
 - Optional OpenTelemetry distributed tracing
 - Hot config reload via SIGHUP / file watcher

--- a/docs/adr/0003-api-version-model-and-jobs-cursor-pagination.md
+++ b/docs/adr/0003-api-version-model-and-jobs-cursor-pagination.md
@@ -1,0 +1,67 @@
+# ADR-0003: NetBackup API version model and jobs cursor pagination
+
+- **Status:** Accepted
+- **Date:** 2026-06-17
+- **Deciders:** Frederic Jacquet
+- **Related:** [#34](https://github.com/fjacquet/nbu_exporter/pull/34),
+  `docs/superpowers/specs/2026-06-16-nbu-10x-support-design.md`, ADR-0002,
+  `exporter-standards` (version/generation detection; "absent, never zero" defensive parsing)
+
+## Context
+
+Two latent defects surfaced when validating the exporter against the **real NetBackup
+OpenAPI specs** (the 10.3 / 10.5 / 11.0 / 11.2 bundles under `docs/veritas-*`) rather than
+against assumptions:
+
+1. **Wrong API version for NBU 10.x.** The exporter mapped NetBackup 10.0–10.4 to API
+   media-type `version=3.0`. No NetBackup REST API has ever used `3.0` — the 10.3 bundle
+   declares `version=10.0` for `/admin/jobs` and `/storage/storage-units`. Requesting `3.0`
+   against a 10.x appliance returns a legacy/reduced representation (missing fields), which
+   looked like "NBU 10.x lacks these features" but was really "we asked for the wrong
+   version." (A reporter's "API v3.0" turned out to be the exporter's *Helm* release version,
+   not a NetBackup API version.)
+
+2. **Jobs pagination was offset-based, but the API is cursor-based.** `GET /admin/jobs` has
+   been **cursor-paginated since API version 9.0** (`page[after]`/`page[before]` request
+   params; `meta.pagination.next`/`prev` as opaque **string** cursors; `rangeTruncated`) —
+   confirmed identical across the 10.3, 10.5, 11.0 **and** 11.2 specs. The exporter sent
+   `page[offset]` and declared `Next int`, so the response failed to unmarshal (string cursor
+   into an int) and **every `nbu_jobs_*` metric was silently dropped** on all modern
+   NetBackup — the root cause of issue #13 (storage metrics present, jobs empty on NBU 11.0).
+   `/storage/storage-units` remains **offset**-paginated.
+
+## Decision
+
+- **Version model:** support `10.0` (NBU 10.0–10.4), `12.0` (10.5), `13.0` (11.0), `14.0`
+  (11.2); **drop `3.0`**. Auto-detection probes `models.SupportedAPIVersions` in descending
+  order (`14.0 → 13.0 → 12.0 → 10.0`) and the first to respond wins. A single
+  `Accept: application/vnd.netbackup+json;version=X` header is used for all endpoints — verified
+  that `/admin/jobs` and `/storage/storage-units` answer at the same version per release.
+- **Jobs pagination is cursor-based.** `Jobs.Meta.Pagination` carries
+  `{Limit int, Next string, Prev string, RangeTruncated bool}`; `FetchJobDetails` omits
+  `page[after]` on the first page and then sends `page[after]=<next>`, following
+  `meta.pagination.next` until it is empty. `HandlePagination` is a generic cursor loop.
+- **Storage pagination is left offset-based** — the two endpoints genuinely differ; they are
+  deliberately *not* unified.
+- **Validation is grounded in the checked-in OpenAPI bundles**, not in third-party
+  assumptions; the 10.3 and 11.2 bundles were added to the repo as that source of truth.
+
+## Consequences
+
+**Positive**
+
+- `nbu_jobs_*` metrics work across **all modern NetBackup** (10.x / 10.5 / 11.0 / 11.2),
+  fixing the silent data-loss behind issue #13.
+- NBU 10.x auto-detects with no manual `apiVersion`; the shipped config example for 10.x uses
+  `10.0`.
+- Architectural claims are backed by authoritative vendor specs rather than report wording.
+
+**Negative / trade-offs**
+
+- **Two pagination styles coexist** (jobs = cursor, storage = offset). This is intentional and
+  matches the API; the code and this ADR guard against a well-meaning "unify pagination"
+  refactor that would re-break jobs.
+- The single `Accept`-version header assumes jobs and storage share one version per release
+  (true across 10.0–14.0); revisit if NetBackup ever versions those endpoints independently.
+- The OpenAPI bundles add ~10 MB to the repository, accepted as the validation source of
+  truth (mirrors keeping vendor specs for the other family exporters).

--- a/docs/adr/0004-multisite-snapshot-collection-model.md
+++ b/docs/adr/0004-multisite-snapshot-collection-model.md
@@ -1,0 +1,59 @@
+# ADR-0004: Multi-site support via the snapshot collection model and a `site` identity label
+
+- **Status:** Accepted (implementation pending — tracked by the Feature 1 spec/plan)
+- **Date:** 2026-06-17
+- **Deciders:** Frederic Jacquet
+- **Related:** `docs/superpowers/specs/2026-06-17-feature1-multisite-design.md`,
+  `docs/superpowers/specs/2026-06-16-nbu-feature-deferrals.md`, ADR-0002, `exporter-standards`
+  (`pstore` 0005 identity label; `ppdd` 0001 / `pstore` 0002 snapshot model; `pstore` 0007
+  serve-before-first-collect; `ppdd` 0006 label-key consistency)
+
+## Context
+
+`nbu_exporter` is **fetch-on-scrape**: one `NbuClient`, one `cfg`, one storage cache;
+`NbuCollector.Collect` fetches storage + jobs live on every Prometheus scrape, and a single
+`nbuserver:` block is configured. Operators run **multiple NetBackup primary servers (one per
+site)** and want a single exporter instance that labels metrics by site.
+
+The exporter family's canonical answer for multi-backend is **"one process, many backends +
+an identity label,"** driven by a **background snapshot collection loop** (not fetch-on-scrape)
+— see `exporter-standards`. `nbu` is the only family member still on the fetch-on-scrape
+model. Done naïvely (fetch-on-scrape × N masters), backend API load would scale with scrape
+frequency and a single slow master could stall the whole `/metrics` response.
+
+## Decision
+
+Adopt the family snapshot model and multi-target configuration:
+
+- **Snapshot loop:** a single background loop polls **every** configured master on
+  `collectionInterval` (**default `5m`**, matching today's storage-cache TTL), builds an
+  **immutable snapshot**, and atomic-pointer-swaps it into a `SnapshotStore`. The Prometheus
+  collector's `Collect` reads the latest snapshot — no live fetch on scrape.
+- **Config:** a `nbuservers:` array, each entry with a **required, unique `site`** plus the
+  existing per-server fields. A legacy single `nbuserver:` block is **auto-mapped** to a
+  one-entry list (`site` defaults to the host) with a deprecation warning — existing
+  single-site configs keep working.
+- **Identity label:** every metric series carries a **`site`** label (first in the label set),
+  emitted via the shared label builders and obeying the label-key consistency invariant
+  (`ppdd` 0006).
+- **Per-target isolation:** each target has its own client, version detector, and cache (the
+  snapshot store subsumes the per-scrape storage cache). A failed target emits
+  `nbu_up{site=…}=0` and never aborts the cycle or affects other sites (graceful degradation).
+- **Serve HTTP before the first collection** completes (`pstore` 0007), so `/metrics` is up
+  immediately.
+
+## Consequences
+
+**Positive**
+
+- One exporter instance serves N masters; backend API load is decoupled from scrape
+  frequency; per-site fault isolation; brings `nbu` onto the family architecture.
+- The `site` label makes multi-site dashboards/alerts a single Grafana view (a `site`
+  template variable — see the dashboards spec).
+
+**Negative / trade-offs**
+
+- A **significant refactor** of `NbuCollector` (snapshot reader) and `main.go` (background
+  loop + serve-before-collect), plus threading `site` into every `Desc`/metric key.
+- `site` multiplies series count by the number of sites (bounded and intended).
+- Config shape change, mitigated by the legacy auto-map so it is not a hard break.

--- a/docs/adr/0004-multisite-snapshot-collection-model.md
+++ b/docs/adr/0004-multisite-snapshot-collection-model.md
@@ -1,6 +1,6 @@
 # ADR-0004: Multi-site support via the snapshot collection model and a `site` identity label
 
-- **Status:** Accepted (implementation pending — tracked by the Feature 1 spec/plan)
+- **Status:** Accepted (implemented)
 - **Date:** 2026-06-17
 - **Deciders:** Frederic Jacquet
 - **Related:** `docs/superpowers/specs/2026-06-17-feature1-multisite-design.md`,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,5 @@ superseding decision gets a new ADR that references the old one.
 |-----|-------|--------|------|
 | [0001](0001-tooling-baseline-sync-with-pflex.md) | Sync the tooling/CI/security baseline with pflex_exporter | Accepted | 2026-06-05 |
 | [0002](0002-opt-in-sub-collector-framework.md) | Pluggable opt-in sub-collector framework | Accepted | 2026-06-14 |
+| [0003](0003-api-version-model-and-jobs-cursor-pagination.md) | NetBackup API version model and jobs cursor pagination | Accepted | 2026-06-17 |
+| [0004](0004-multisite-snapshot-collection-model.md) | Multi-site support via the snapshot collection model and a `site` identity label | Accepted | 2026-06-17 |

--- a/docs/config-examples/README.md
+++ b/docs/config-examples/README.md
@@ -77,6 +77,29 @@ This directory contains example configuration files for different NetBackup depl
 
 ---
 
+### 5. Multi-Site (multiple primary servers)
+
+**File:** `config-multisite.yaml`
+
+**Use when:**
+- You run more than one NetBackup primary server (typically one per site)
+- You want a single exporter instance to scrape them all
+- You want every metric labelled with its `site`
+
+**Features:**
+- A `nbuservers:` list with one entry per server, each with a unique `site`
+- A background collection loop polls every site on `collectionInterval`
+  (default 5m); scrapes read the latest snapshot, so backend API load is
+  decoupled from scrape frequency
+- Every metric series carries a `site` label (first label)
+- A down site shows only `nbu_up{site="..."}=0` and never affects the others
+- The legacy single `nbuserver:` block still works (auto-mapped to a one-entry
+  list whose `site` defaults to the host)
+
+**Best for:** Two-or-more-primary deployments; per-site dashboards and alerts
+
+---
+
 ## Quick Start
 
 ### Step 1: Choose Your Configuration
@@ -89,6 +112,7 @@ Select the configuration file that matches your NetBackup version:
 | 10.5              | `config-netbackup-10.5.yaml` | 12.0 |
 | 10.0-10.4         | `config-netbackup-10.0.yaml` | 10.0 |
 | Any/Mixed         | `config-auto-detect.yaml` | Auto |
+| Multiple servers  | `config-multisite.yaml` | Per-site |
 
 ### Step 2: Copy and Customize
 
@@ -127,7 +151,8 @@ nbuserver:
 | `host` | string | Yes | - | Server bind address (e.g., "localhost", "0.0.0.0") |
 | `port` | string | Yes | - | Server port (1-65535, typically "9440") |
 | `uri` | string | Yes | - | Metrics endpoint path (typically "/metrics") |
-| `scrapingInterval` | duration | Yes | - | Time window for job collection (e.g., "30m", "1h", "2h") |
+| `scrapingInterval` | duration | Yes | - | Job lookback window per collection (e.g., "30m", "1h", "2h") |
+| `collectionInterval` | duration | No | "5m" | How often the background loop polls every site. Backend API load is driven by this, not by scrape frequency. The effective job lookback window is `max(scrapingInterval, collectionInterval)`. |
 | `logName` | string | Yes | - | Log file path (e.g., "log/nbu-exporter.log") |
 
 ### NBU Server Section
@@ -144,6 +169,21 @@ nbuserver:
 | `apiKey` | string | Yes | - | NetBackup API key (generate from NetBackup UI) |
 | `contentType` | string | Yes | - | API content type header |
 | `insecureSkipVerify` | bool | No | false | Skip TLS verification (not recommended for production) |
+
+### NBU Servers Section (multi-site)
+
+For multiple primary servers, use a `nbuservers:` list **instead of** the single
+`nbuserver:` block. Each entry takes the same fields as the NBU Server section
+above, plus a required, unique `site`:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `site` | string | Yes | - | Unique site identifier; emitted as the `site` label on every metric from this server |
+| *(all NBU Server fields)* | - | - | - | Same as the single-server section above |
+
+A legacy single `nbuserver:` block is automatically promoted to a one-entry
+`nbuservers:` list whose `site` defaults to the host, so existing single-site
+configurations keep working unchanged. See `config-multisite.yaml`.
 
 ---
 

--- a/docs/config-examples/config-auto-detect.yaml
+++ b/docs/config-examples/config-auto-detect.yaml
@@ -28,7 +28,8 @@ nbuserver:
     # apiVersion: NOT SPECIFIED - Will auto-detect highest supported version
     # Detection order: 14.0 (NBU 11.2) → 13.0 (NBU 11.0) → 12.0 (NBU 10.5) → 10.0 (NBU 10.0-10.4)
     apiKey: "your-api-key-here"  # Generate from NetBackup UI
-    contentType: "application/vnd.netbackup+json; version=14.0"
+    # contentType is intentionally omitted: with auto-detect, the Accept header is
+    # built dynamically from the detected apiVersion (the field is otherwise ignored).
     insecureSkipVerify: false  # Set to true only for testing environments
 
 # Version Detection Behavior:

--- a/docs/config-examples/config-auto-detect.yaml
+++ b/docs/config-examples/config-auto-detect.yaml
@@ -8,7 +8,7 @@
 # - You're upgrading NetBackup and want the exporter to adapt automatically
 #
 # NetBackup Version: 10.0+ (any supported version)
-# API Version: Auto-detected (13.0 → 12.0 → 3.0)
+# API Version: Auto-detected (14.0 → 13.0 → 12.0 → 10.0)
 # Detection: Enabled (no apiVersion specified)
 
 server:
@@ -26,17 +26,18 @@ nbuserver:
     host: "nbu-master.my.domain"  # NetBackup master server (any version 10.0+)
     port: "1556"
     # apiVersion: NOT SPECIFIED - Will auto-detect highest supported version
-    # Detection order: 13.0 (NBU 11.0) → 12.0 (NBU 10.5) → 3.0 (NBU 10.0-10.4)
+    # Detection order: 14.0 (NBU 11.2) → 13.0 (NBU 11.0) → 12.0 (NBU 10.5) → 10.0 (NBU 10.0-10.4)
     apiKey: "your-api-key-here"  # Generate from NetBackup UI
-    contentType: "application/vnd.netbackup+json; version=3.0"
+    contentType: "application/vnd.netbackup+json; version=14.0"
     insecureSkipVerify: false  # Set to true only for testing environments
 
 # Version Detection Behavior:
 # 
 # The exporter will attempt to connect using API versions in this order:
-# 1. API 13.0 (NetBackup 11.0+)
-# 2. API 12.0 (NetBackup 10.5)
-# 3. API 3.0 (NetBackup 10.0-10.4)
+# 1. API 14.0 (NetBackup 11.2+)
+# 2. API 13.0 (NetBackup 11.0+)
+# 3. API 12.0 (NetBackup 10.5)
+# 4. API 10.0 (NetBackup 10.0-10.4)
 #
 # The first version that responds successfully will be used for all subsequent requests.
 #

--- a/docs/config-examples/config-multisite.yaml
+++ b/docs/config-examples/config-multisite.yaml
@@ -1,0 +1,59 @@
+---
+# Configuration Example: Multi-Site (multiple NetBackup primary servers)
+#
+# Use this configuration when:
+# - You run more than one NetBackup primary server (typically one per site)
+# - You want a single exporter instance to scrape them all
+# - You want every metric labelled with its `site`
+#
+# How it works:
+# - A background collection loop polls every site on `collectionInterval`
+#   (default 5m) and publishes an immutable snapshot. Prometheus scrapes read
+#   that snapshot, so backend API load is driven by collectionInterval, not by
+#   scrape frequency.
+# - Every metric series carries a `site` label (its first label).
+# - A site that is down only shows `nbu_up{site="..."} = 0`; the other sites are
+#   unaffected (graceful degradation).
+
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"      # Job lookback window per collection
+    collectionInterval: "5m"    # How often the loop polls every site (default 5m)
+    logName: "log/nbu-exporter.log"
+
+# One entry per NetBackup primary server. `site` is required and must be unique;
+# it becomes the `site` label value on every metric collected from that server.
+nbuservers:
+    - site: "paris"
+      scheme: "https"
+      uri: "/netbackup"
+      host: "nbu-paris.my.domain"
+      port: "1556"
+      apiVersion: "13.0"        # Optional; omit to auto-detect (14.0 -> 13.0 -> 12.0 -> 10.0)
+      apiKey: "paris-api-key-here"  # Generate from the NetBackup UI
+      insecureSkipVerify: false
+
+    - site: "lyon"
+      scheme: "https"
+      uri: "/netbackup"
+      host: "nbu-lyon.my.domain"
+      port: "1556"
+      apiVersion: "13.0"
+      apiKey: "lyon-api-key-here"
+      insecureSkipVerify: false
+
+# Backward compatibility:
+# - A legacy single `nbuserver:` block (with no `nbuservers:` list) still works:
+#   it is auto-mapped to a one-entry list whose `site` defaults to the host.
+#   Migrate to multi-site by replacing the `nbuserver:` block with a
+#   `nbuservers:` list like the one above.
+
+# Notes:
+# - Replace the host / apiKey placeholders with your real values.
+# - For contiguous job coverage, keep scrapingInterval >= collectionInterval.
+#   The exporter uses the larger of the two as the per-poll job lookback window.
+# - Changing `nbuservers:` takes effect on restart (the collection loop builds
+#   its targets at startup).
+# - Keep insecureSkipVerify: false in production.

--- a/docs/superpowers/plans/2026-06-17-feature1-multisite.md
+++ b/docs/superpowers/plans/2026-06-17-feature1-multisite.md
@@ -1,0 +1,288 @@
+# Feature 1 — Multi-Site (Snapshot Collection Model) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. **Dispatch one task per subagent (small), gate each on `make ci`, and commit per task.** Background subagents in this environment stall on a 600s no-progress watchdog for large tasks — if a dispatch stalls, reconcile git state and finish that task inline. Never start the next task before the current one is green + committed.
+
+**Goal:** One exporter instance scrapes multiple NetBackup primary servers (one per site), labelling every metric with `site`, by adopting the family snapshot collection model.
+
+**Architecture:** A background loop polls every configured master on `collectionInterval` (default 5m), builds an immutable `Snapshot`, and atomic-swaps it into a `SnapshotStore`. `NbuCollector.Collect` becomes a snapshot *reader* (no live fetch) and emits each site's metrics with a `site` label. Storage stays offset-paginated, jobs stay cursor-paginated (unchanged from #34).
+
+**Tech Stack:** Go 1.26, prometheus/client_golang, errgroup, testify; `make ci` gate (fmt/vet/lint/test-race/govulncheck + 70% coverage). RTK: use `rtk proxy go test ...` / `rtk proxy make ci`. Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-feature1-multisite-design.md` · **ADR:** `docs/adr/0004-multisite-snapshot-collection-model.md`
+
+---
+
+## File Structure
+
+- `internal/models/Config.go` — add `NbuServers []NbuServerConfig` + `Server.CollectionInterval`; extract `NbuServerConfig` struct (the current inline `NbuServer` fields + `Site`); auto-map legacy `nbuserver:` in `SetDefaults`; validate unique non-empty `site`.
+- `internal/exporter/snapshot.go` *(new)* — `SiteSnapshot`, `Snapshot`, `SnapshotStore` (atomic pointer swap). Pure data + store.
+- `internal/exporter/collector_loop.go` *(new)* — `TargetCollector` (one per site: client + detector + cache) and `CollectionLoop` (errgroup fan-out → build `Snapshot` → `store.Store`).
+- `internal/exporter/prometheus.go` — `site` prepended to every `*prometheus.Desc` label list; `Collect` reads `SnapshotStore` and emits per-site; `expose*` helpers take a `site` arg.
+- `internal/exporter/metrics.go` — unchanged keys; site is prepended at emission (not in `.Labels()`).
+- `main.go` — build targets, start the loop, serve HTTP before first collect.
+- Docs: `docs/config-examples/`, `README.md`, `CHANGELOG.md`.
+
+**Site-threading convention (used throughout):** the `*Key.Labels()` helpers stay site-free; the `expose*` functions receive `site string` and emit with `withSite(site, key.Labels())`, where `withSite` prepends. Every `NewDesc` variable-label list gets `"site"` as its **first** element.
+
+---
+
+## Task 1: Config — `nbuservers[]` array + `collectionInterval` + legacy auto-map
+
+**Files:** Modify `internal/models/Config.go`; Test `internal/models/Config_test.go`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/models/Config_test.go`:
+
+```go
+func TestConfigNbuServersAutoMapLegacy(t *testing.T) {
+	// Legacy single nbuserver: with no nbuservers[] -> one entry, site defaults to host.
+	cfg := createConfigWithAPIVersion("13.0") // existing helper: sets NbuServer.Host=testServerNBUMaster
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("legacy config should validate: %v", err)
+	}
+	if len(cfg.NbuServers) != 1 {
+		t.Fatalf("expected 1 auto-mapped server, got %d", len(cfg.NbuServers))
+	}
+	if cfg.NbuServers[0].Site != cfg.NbuServer.Host {
+		t.Errorf("site = %q, want host %q", cfg.NbuServers[0].Site, cfg.NbuServer.Host)
+	}
+}
+
+func TestConfigNbuServersRequireUniqueSite(t *testing.T) {
+	cfg := createConfigWithAPIVersion("13.0")
+	cfg.NbuServers = []NbuServerConfig{
+		{Site: "paris", Host: "a", Port: "1556", Scheme: "https", APIKey: "k"},
+		{Site: "paris", Host: "b", Port: "1556", Scheme: "https", APIKey: "k"},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Error("duplicate site should fail validation")
+	}
+}
+
+func TestConfigCollectionIntervalDefault(t *testing.T) {
+	cfg := createConfigWithAPIVersion("13.0")
+	cfg.SetDefaults()
+	if cfg.Server.CollectionInterval != "5m" {
+		t.Errorf("CollectionInterval default = %q, want 5m", cfg.Server.CollectionInterval)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `rtk proxy go test ./internal/models/ -run 'NbuServers|CollectionInterval' -v`
+Expected: FAIL (`NbuServers`/`NbuServerConfig`/`CollectionInterval` undefined).
+
+- [ ] **Step 3: Implement the model change**
+
+In `internal/models/Config.go`: add `CollectionInterval string `+"`yaml:\"collectionInterval\"`"+`` to the `Server` struct; define an exported `NbuServerConfig` struct containing the existing `NbuServer` fields **plus** `Site string `+"`yaml:\"site\"`"+``; add `NbuServers []NbuServerConfig `+"`yaml:\"nbuservers\"`"+`` to `Config`. Keep the legacy inline `NbuServer` field for back-compat.
+
+In `SetDefaults()`: after the existing defaults, add:
+
+```go
+	if c.Server.CollectionInterval == "" {
+		c.Server.CollectionInterval = "5m"
+	}
+	// Auto-map a legacy single nbuserver: block to a one-entry nbuservers[] list.
+	if len(c.NbuServers) == 0 && c.NbuServer.Host != "" {
+		legacy := NbuServerConfig{ /* copy all NbuServer fields */ Site: c.NbuServer.Host}
+		c.NbuServers = []NbuServerConfig{legacy}
+		// (logging.LogWarn deprecation notice — import the logging pkg or return a flag the caller logs)
+	}
+```
+
+In `Validate()`: after `SetDefaults()`, validate `len(c.NbuServers) >= 1`, each `Site` non-empty and unique, and run the existing per-server checks (host/port/scheme/apiKey, apiVersion format) over **every** entry (refactor `validateNBUServerConfig` to take an `NbuServerConfig`).
+
+- [ ] **Step 4: Run — expect PASS** (`rtk proxy go test ./internal/models/ -run 'NbuServers|CollectionInterval' -v`).
+
+- [ ] **Step 5: `make ci` checkpoint** — `rtk proxy make ci` green (existing collector code still reads `cfg.NbuServer`; unchanged behaviour).
+
+- [ ] **Step 6: Commit** — `feat(config): add nbuservers[] + collectionInterval; auto-map legacy nbuserver`.
+
+---
+
+## Task 2: `site` label on every metric (single-site value)
+
+**Files:** Modify `internal/exporter/prometheus.go` (Descs + `expose*`); Test `internal/exporter/prometheus_test.go`.
+
+This task adds the label end-to-end while still single-site (site value = `cfg.NbuServers[0].Site`), keeping the tree green before the snapshot model lands.
+
+- [ ] **Step 1: Write failing test** — assert a known metric carries a `site` label:
+
+```go
+func TestExposeMetricsCarriesSiteLabel(t *testing.T) {
+	// Gather from the registry and assert nbu_up has label site="<configured>".
+	// (Mirror the existing gather-based assertions in prometheus_test.go.)
+}
+```
+
+(Use the existing registry-gather test helper in `prometheus_test.go`; assert `site` is present on `nbu_up`.)
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** — add a helper near the `expose*` funcs:
+
+```go
+func withSite(site string, labels []string) []string {
+	return append([]string{site}, labels...)
+}
+```
+
+Prepend `"site"` as the **first** element of every variable-label list in `NewNbuCollector` (e.g. `[]string{"site", "name", "type", "size"}`, `[]string{"site"}` for `nbuUp`, `[]string{"site", "version"}`, etc. — all ~16 Descs). Give `exposeMetrics`/`exposeStorageMetrics`/`exposeStorageUnitMetrics`/`exposeJobAggregateMetrics` a `site string` parameter and wrap every `MustNewConstMetric` label slice with `withSite(site, …)` (and `withSite(site, u.InfoLabels())`, `withSite(site, []string{u.Name, u.Type})`, etc.). In `Collect`, pass `c.cfg.NbuServers[0].Site`.
+
+- [ ] **Step 4: Run** the affected tests; update any existing prometheus_test assertions that build expected label sets to include `site`.
+
+- [ ] **Step 5: `make ci` checkpoint** green.
+
+- [ ] **Step 6: Commit** — `feat(metrics): add site label to every series (single-site)`.
+
+---
+
+## Task 3: `Snapshot` + `SnapshotStore` types
+
+**Files:** Create `internal/exporter/snapshot.go`; Test `internal/exporter/snapshot_test.go`.
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestSnapshotStoreLoadStore(t *testing.T) {
+	var s SnapshotStore
+	if s.Load() != nil { t.Fatal("zero store should Load() nil") }
+	snap := &Snapshot{Sites: map[string]*SiteSnapshot{"paris": {Up: true}}}
+	s.Store(snap)
+	got := s.Load()
+	if got == nil || !got.Sites["paris"].Up { t.Fatal("Load did not return stored snapshot") }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** `internal/exporter/snapshot.go`:
+
+```go
+package exporter
+
+import "sync/atomic"
+
+// SiteSnapshot holds one site's already-aggregated collection results.
+type SiteSnapshot struct {
+	Site          string
+	APIVersion    string
+	Up            bool
+	StorageErr    error
+	JobsErr       error
+	StorageMetrics []StorageMetricValue
+	StorageUnits   []StorageUnitInfo
+	JobAgg         *JobAggregator
+	LastStorageScrape time.Time
+	LastJobsScrape    time.Time
+}
+
+// Snapshot is an immutable point-in-time view across all sites.
+type Snapshot struct {
+	Sites map[string]*SiteSnapshot
+}
+
+// SnapshotStore holds the latest Snapshot behind an atomic pointer swap.
+type SnapshotStore struct{ p atomic.Pointer[Snapshot] }
+
+func (s *SnapshotStore) Store(snap *Snapshot) { s.p.Store(snap) }
+func (s *SnapshotStore) Load() *Snapshot      { return s.p.Load() }
+```
+
+(Add the `time` import.)
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: `make ci`** green.
+- [ ] **Step 6: Commit** — `feat(exporter): add immutable Snapshot + atomic SnapshotStore`.
+
+---
+
+## Task 4: Per-target collector + background collection loop
+
+**Files:** Create `internal/exporter/collector_loop.go`; Test `internal/exporter/collector_loop_test.go`.
+
+- [ ] **Step 1: Write failing test** — two mock targets; one healthy, one failing; assert the built snapshot has both sites and the failing one has `Up=false`:
+
+```go
+func TestCollectionLoopBuildsPerSiteSnapshot(t *testing.T) {
+	// Spin two httptest servers (one returns valid storage/jobs, one returns 500).
+	// Build a CollectionLoop with two TargetCollectors and call collectOnce(ctx).
+	// Assert store.Load().Sites has both sites; healthy Up=true, failing Up=false;
+	// healthy site's JobAgg is non-nil. (Mirror netbackup_test httptest patterns.)
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** `collector_loop.go`:
+  - `TargetCollector` holds `site string`, `client *NbuClient`, `cfg models.Config` (single-server view for that target), `cache *StorageCache`. A `func (tc *TargetCollector) collect(ctx) *SiteSnapshot` runs storage + jobs via the existing `FetchStorageFull` / `FetchAllJobsFull` (reuse `collectAllMetrics`-style errgroup) and sets `Up = storageErr==nil || jobsErr==nil`, capturing errors per source (graceful degradation).
+  - `CollectionLoop` holds `[]*TargetCollector`, `store *SnapshotStore`, `interval time.Duration`. `collectOnce(ctx)` fans out across targets with `errgroup` + `SetLimit(min(len, runtime.NumCPU()))`, assembles `Snapshot{Sites: …}`, and calls `store.Store`. `Run(ctx)` calls `collectOnce` immediately, then on a `time.Ticker(interval)` until `ctx.Done()`.
+
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: `make ci`** green.
+- [ ] **Step 6: Commit** — `feat(exporter): background per-site collection loop building snapshots`.
+
+---
+
+## Task 5: `Collect` reads the snapshot; wire `main.go` (serve-before-collect)
+
+**Files:** Modify `internal/exporter/prometheus.go` (`Collect`, constructor), `main.go`; Tests in both packages.
+
+- [ ] **Step 1: Write failing test** — a snapshot-backed collector emits all sites' metrics:
+
+```go
+func TestCollectorEmitsAllSitesFromSnapshot(t *testing.T) {
+	// Build a SnapshotStore with two SiteSnapshots (paris, lyon), construct the
+	// snapshot-reading NbuCollector over it, gather the registry, and assert
+	// nbu_up appears for site="paris" AND site="lyon".
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** — give `NbuCollector` a `store *SnapshotStore` (drop the live `client`/`storageCache` from the scrape path). `Collect` becomes:
+
+```go
+func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
+	snap := c.store.Load()
+	if snap == nil { return } // first cycle not done yet; /metrics is up, just empty
+	for site, ss := range snap.Sites {
+		c.exposeMetrics(ch, site, ss) // per-site emission using Task 2's site-aware expose*
+	}
+}
+```
+
+Refactor `exposeMetrics` to take `(ch, site string, ss *SiteSnapshot)` and emit `nbu_up{site}` from `ss.Up`, version/last-scrape/storage/jobs from `ss`. In `main.go`: build `[]*TargetCollector` from `cfg.NbuServers`, create `SnapshotStore` + `CollectionLoop`, `go loop.Run(ctx)`, register the snapshot-reading collector, and **start `ListenAndServe` immediately** (do not block on the first collection). Hot-reload rebuilds the loop's targets.
+
+- [ ] **Step 4: Run** the new test + full package; fix call sites.
+- [ ] **Step 5: `make ci`** green (this is the largest task — if a subagent stalls mid-way, reconcile and finish inline).
+- [ ] **Step 6: Commit** — `feat(exporter): snapshot-reading collector + background loop wired in main`.
+
+---
+
+## Task 6: Docs + config examples + CHANGELOG
+
+**Files:** `docs/config-examples/` (new `config-multisite.yaml`), `README.md`, `CHANGELOG.md`, `docs/config-examples/README.md`.
+
+- [ ] **Step 1:** Add `config-multisite.yaml` showing `server.collectionInterval` + a two-entry `nbuservers:` list with `site:`; document legacy auto-map.
+- [ ] **Step 2:** README: note multi-site support + the `site` label. `docs/config-examples/README.md`: add the multi-site example row.
+- [ ] **Step 3:** `CHANGELOG.md` `[Unreleased]` → Added: multi-site support (nbuservers[], `site` label, snapshot collection model) referencing ADR-0004.
+- [ ] **Step 4:** `make ci` green.
+- [ ] **Step 5: Commit** — `docs: multi-site config example + README + changelog`.
+
+---
+
+## Final
+
+- [ ] Whole-implementation review (spec coverage: config array ✓, 5m interval ✓, site label ✓, snapshot model ✓, per-site degradation ✓, serve-before-collect ✓, storage/jobs pagination unchanged ✓).
+- [ ] `make ci` green; manual sanity: `config-multisite.yaml` with two mock servers → `/metrics` shows every series per `site`.
+- [ ] superpowers:finishing-a-development-branch.
+
+## Acceptance criteria (from spec)
+
+- One exporter + two `nbuservers:` entries → `/metrics` shows every series twice (per `site`); a down master shows only `nbu_up{site=…}=0` without affecting the other site.
+- Backend API load driven by `collectionInterval` (5m default), not scrape frequency.
+- Legacy single `nbuserver:` config still works (one site, `site`=host).
+- No metric renamed; only `site` added. Storage offset + jobs cursor pagination unchanged.

--- a/docs/superpowers/specs/2026-06-17-feature1-multisite-design.md
+++ b/docs/superpowers/specs/2026-06-17-feature1-multisite-design.md
@@ -51,7 +51,7 @@ Replace the single `nbuserver:` block with a list, and add a top-level collectio
 
 ```yaml
 server:
-  collectionInterval: "2m"   # how often the loop polls every target (new)
+  collectionInterval: "5m"   # how often the loop polls every target (new; default 5m, matches today's storage-cache TTL)
 nbuservers:
   - site: "paris"            # required identity, unique across the list
     host: "nbu-par.example.com"
@@ -128,11 +128,14 @@ nbuservers:
 - Existing single-site configs keep working (legacy block → one site).
 - No metric renamed; only `site` added.
 
-## Open questions for review
+## Decisions (resolved 2026-06-17)
 
-1. **Back-compat vs clean break:** auto-map legacy `nbuserver:` (recommended), or require
-   `nbuservers:` and document the migration?
-2. **`collectionInterval` default** (proposed `2m`) and whether to keep the existing 5-min
-   storage-cache semantics as the interval default.
-3. **Label name:** `site` (per the NetBackup 1-master-per-site decision) — confirm over a
-   more generic `cluster`/`server`.
+1. **Config back-compat:** **auto-map** the legacy single `nbuserver:` block — when present
+   and `nbuservers:` is absent, treat it as a one-entry list with `site` defaulting to the
+   server `host`, and log a deprecation warning. Existing single-site configs keep working;
+   no forced migration. New configs use `nbuservers:` with an explicit `site`.
+2. **`collectionInterval` default:** **`5m`**, matching today's storage-cache TTL so per-master
+   API load stays close to current behaviour. Operators can tune it; metrics may be up to one
+   interval stale (expected for the snapshot model).
+3. **Identity label:** **`site`** (1 master per site is the NetBackup reality), on every
+   series, first in the label set.

--- a/docs/superpowers/specs/2026-06-17-feature1-multisite-design.md
+++ b/docs/superpowers/specs/2026-06-17-feature1-multisite-design.md
@@ -29,7 +29,7 @@ whole `/metrics` response.
 ## Goals
 
 - `nbuservers:` — a list of primary servers, each with a required `site` identity.
-- A single background collection loop polls **every** server on `collection.interval` and
+- A single background collection loop polls **every** server on `server.collectionInterval` and
   publishes an **immutable snapshot**; `Collect` reads the latest snapshot (no live fetch).
 - Every metric carries a `site` label (constant per target, emitted on every series).
 - Per-target graceful degradation: a failed target emits `nbu_up{site=…}=0` and does not

--- a/internal/exporter/collector_alerts.go
+++ b/internal/exporter/collector_alerts.go
@@ -14,17 +14,19 @@ const alertsPath = "/manage/alerts"
 type alertsCollector struct {
 	client NetBackupClient
 	cfg    models.Config
+	site   string
 	desc   *prometheus.Desc
 }
 
-func newAlertsCollector(client NetBackupClient, cfg models.Config) *alertsCollector {
+func newAlertsCollector(client NetBackupClient, cfg models.Config, site string) *alertsCollector {
 	return &alertsCollector{
 		client: client,
 		cfg:    cfg,
+		site:   site,
 		desc: prometheus.NewDesc(
 			"nbu_alerts_count",
 			"Number of NetBackup alerts by severity and category",
-			[]string{"severity", "category"}, nil,
+			[]string{"site", "severity", "category"}, nil,
 		),
 	}
 }
@@ -45,7 +47,7 @@ func (a *alertsCollector) Collect(ctx context.Context, ch chan<- prometheus.Metr
 		counts[key{d.Attributes.Severity, d.Attributes.Category}]++
 	}
 	for k, v := range counts {
-		ch <- prometheus.MustNewConstMetric(a.desc, prometheus.GaugeValue, v, k.severity, k.category)
+		ch <- prometheus.MustNewConstMetric(a.desc, prometheus.GaugeValue, v, a.site, k.severity, k.category)
 	}
 	return nil
 }

--- a/internal/exporter/collector_alerts_test.go
+++ b/internal/exporter/collector_alerts_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAlertsCollector(t *testing.T) {
 	client := newMockClientFromFixture(t, "../../testdata/api-versions/alerts-response.json")
-	c := newAlertsCollector(client, testConfig())
+	c := newAlertsCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 16)
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
@@ -20,6 +20,7 @@ func TestAlertsCollector(t *testing.T) {
 	for m := range ch {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
 		key := labelValue(&d, "severity") + "/" + labelValue(&d, "category")
 		counts[key] = d.GetGauge().GetValue()
 	}
@@ -29,7 +30,7 @@ func TestAlertsCollector(t *testing.T) {
 
 func TestAlertsCollectorError(t *testing.T) {
 	client := &errClient{}
-	c := newAlertsCollector(client, testConfig())
+	c := newAlertsCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 4)
 	require.Error(t, c.Collect(context.Background(), ch))
 	close(ch)

--- a/internal/exporter/collector_catalog.go
+++ b/internal/exporter/collector_catalog.go
@@ -21,17 +21,19 @@ var catalogAnomalyStatuses = []string{"ANOMALOUS", "NOT_ANOMALOUS", "NOT_PROCESS
 type catalogCollector struct {
 	client NetBackupClient
 	cfg    models.Config
+	site   string
 	desc   *prometheus.Desc
 }
 
-func newCatalogCollector(client NetBackupClient, cfg models.Config) *catalogCollector {
+func newCatalogCollector(client NetBackupClient, cfg models.Config, site string) *catalogCollector {
 	return &catalogCollector{
 		client: client,
 		cfg:    cfg,
+		site:   site,
 		desc: prometheus.NewDesc(
 			"nbu_catalog_images_count",
 			"Number of catalog images by malware and anomaly status",
-			[]string{"malware_status", "anomaly_status"}, nil,
+			[]string{"site", "malware_status", "anomaly_status"}, nil,
 		),
 	}
 }
@@ -57,7 +59,7 @@ func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Met
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.desc, prometheus.GaugeValue,
-				float64(resp.Meta.Pagination.Count), mw, an,
+				float64(resp.Meta.Pagination.Count), c.site, mw, an,
 			)
 		}
 	}

--- a/internal/exporter/collector_catalog.go
+++ b/internal/exporter/collector_catalog.go
@@ -52,6 +52,7 @@ func (c *catalogCollector) Collect(ctx context.Context, ch chan<- prometheus.Met
 				// Per-combination graceful degradation: log and skip this
 				// combination so successful combinations are still emitted.
 				log.WithError(err).
+					WithField("site", c.site).
 					WithField("malware_status", mw).
 					WithField("anomaly_status", an).
 					Warn("catalog count fetch failed; skipping combination")

--- a/internal/exporter/collector_catalog_test.go
+++ b/internal/exporter/collector_catalog_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCatalogCollector(t *testing.T) {
 	client := newMockClientFromFixture(t, "../../testdata/api-versions/catalog-count-response.json")
-	c := newCatalogCollector(client, testConfig())
+	c := newCatalogCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 64)
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
@@ -21,6 +21,7 @@ func TestCatalogCollector(t *testing.T) {
 	for m := range ch {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
 		require.True(t, strings.Contains(m.Desc().String(), "nbu_catalog_images_count"))
 		require.Equal(t, float64(42), d.GetGauge().GetValue())
 		emitted++
@@ -33,7 +34,7 @@ func TestCatalogCollectorError(t *testing.T) {
 	// After per-combination graceful degradation, every sub-call failing leaves
 	// Collect returning nil while emitting no metrics.
 	client := &errClient{}
-	c := newCatalogCollector(client, testConfig())
+	c := newCatalogCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 64)
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -44,16 +44,7 @@ func WithTargetAPITrace(enabled bool) TargetOption {
 // entry supplies this site's NetBackup server fields.
 func NewTargetCollector(base models.Config, entry models.NbuServerConfig, opts ...TargetOption) *TargetCollector {
 	cfg := base
-	cfg.NbuServer.Host = entry.Host
-	cfg.NbuServer.Port = entry.Port
-	cfg.NbuServer.Scheme = entry.Scheme
-	cfg.NbuServer.URI = entry.URI
-	cfg.NbuServer.Domain = entry.Domain
-	cfg.NbuServer.DomainType = entry.DomainType
-	cfg.NbuServer.APIKey = entry.APIKey
-	cfg.NbuServer.APIVersion = entry.APIVersion
-	cfg.NbuServer.ContentType = entry.ContentType
-	cfg.NbuServer.InsecureSkipVerify = entry.InsecureSkipVerify
+	entry.ApplyTo(&cfg) // single-server view of this site (Site tracked separately below)
 	tc := &TargetCollector{
 		site:    entry.Site,
 		cfg:     cfg,

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -77,6 +77,31 @@ func (tc *TargetCollector) clientFor(ctx context.Context) (*NbuClient, error) {
 	return c, nil
 }
 
+// jobWindow returns the job lookback window for one collection: the larger of the
+// configured scrapingInterval and collectionInterval. Because the loop polls every
+// collectionInterval, the window must be at least that long so each poll covers
+// the time since the previous one (no gaps in job coverage).
+func (tc *TargetCollector) jobWindow() string {
+	return maxDurationString(tc.cfg.Server.ScrapingInterval, tc.cfg.Server.CollectionInterval)
+}
+
+// maxDurationString returns whichever of two duration strings parses to the larger
+// duration. If one fails to parse, the other is returned; if both fail, a is returned.
+func maxDurationString(a, b string) string {
+	da, ea := time.ParseDuration(a)
+	db, eb := time.ParseDuration(b)
+	switch {
+	case ea != nil:
+		return b
+	case eb != nil:
+		return a
+	case db > da:
+		return b
+	default:
+		return a
+	}
+}
+
 // close releases this target's client connections, if a client was built.
 func (tc *TargetCollector) close() error {
 	if tc.client != nil {
@@ -104,7 +129,7 @@ func (tc *TargetCollector) collect(ctx context.Context) *SiteSnapshot {
 	var sErr, jErr error
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { sm, su, sErr = FetchStorageFull(gctx, client); return nil })
-	g.Go(func() error { agg, jErr = FetchAllJobsFull(gctx, client, tc.cfg.Server.ScrapingInterval); return nil })
+	g.Go(func() error { agg, jErr = FetchAllJobsFull(gctx, client, tc.jobWindow()); return nil })
 	_ = g.Wait()
 
 	now := time.Now()

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -1,0 +1,135 @@
+package exporter
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"golang.org/x/sync/errgroup"
+)
+
+// TargetCollector collects one site (one NetBackup primary) into a SiteSnapshot.
+type TargetCollector struct {
+	site   string
+	cfg    models.Config // a single-server view: cfg.NbuServer set from this site's entry
+	client *NbuClient    // built lazily with version detection; nil until first success
+}
+
+// NewTargetCollector builds a per-site collector. base supplies Server.* settings;
+// entry supplies this site's NetBackup server fields.
+func NewTargetCollector(base models.Config, entry models.NbuServerConfig) *TargetCollector {
+	cfg := base
+	cfg.NbuServer.Host = entry.Host
+	cfg.NbuServer.Port = entry.Port
+	cfg.NbuServer.Scheme = entry.Scheme
+	cfg.NbuServer.URI = entry.URI
+	cfg.NbuServer.Domain = entry.Domain
+	cfg.NbuServer.DomainType = entry.DomainType
+	cfg.NbuServer.APIKey = entry.APIKey
+	cfg.NbuServer.APIVersion = entry.APIVersion
+	cfg.NbuServer.ContentType = entry.ContentType
+	cfg.NbuServer.InsecureSkipVerify = entry.InsecureSkipVerify
+	return &TargetCollector{site: entry.Site, cfg: cfg}
+}
+
+func (tc *TargetCollector) clientFor(ctx context.Context) (*NbuClient, error) {
+	if tc.client != nil {
+		return tc.client, nil
+	}
+	c, err := NewNbuClientWithVersionDetection(ctx, &tc.cfg)
+	if err != nil {
+		return nil, err
+	}
+	tc.client = c
+	return c, nil
+}
+
+// collect fetches storage + jobs for this site and returns a SiteSnapshot. It never
+// returns an error: failures are captured per-source so other sites are unaffected.
+func (tc *TargetCollector) collect(ctx context.Context) *SiteSnapshot {
+	ss := &SiteSnapshot{Site: tc.site}
+	client, err := tc.clientFor(ctx)
+	if err != nil {
+		ss.Up = false
+		ss.StorageErr = err
+		ss.JobsErr = err
+		return ss
+	}
+	ss.APIVersion = client.cfg.NbuServer.APIVersion
+
+	var sm []StorageMetricValue
+	var su []StorageUnitInfo
+	var agg *JobAggregator
+	var sErr, jErr error
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error { sm, su, sErr = FetchStorageFull(gctx, client); return nil })
+	g.Go(func() error { agg, jErr = FetchAllJobsFull(gctx, client, tc.cfg.Server.ScrapingInterval); return nil })
+	_ = g.Wait()
+
+	now := time.Now()
+	ss.StorageMetrics, ss.StorageUnits, ss.JobAgg = sm, su, agg
+	ss.StorageErr, ss.JobsErr = sErr, jErr
+	if sErr == nil {
+		ss.LastStorageScrape = now
+	}
+	if jErr == nil {
+		ss.LastJobsScrape = now
+	}
+	ss.Up = sErr == nil || jErr == nil
+	return ss
+}
+
+// CollectionLoop polls every target on interval and publishes an immutable Snapshot.
+type CollectionLoop struct {
+	targets  []*TargetCollector
+	store    *SnapshotStore
+	interval time.Duration
+}
+
+// NewCollectionLoop creates a CollectionLoop that collects from all targets on the given
+// interval and publishes each complete sweep as an immutable Snapshot into store.
+func NewCollectionLoop(targets []*TargetCollector, store *SnapshotStore, interval time.Duration) *CollectionLoop {
+	return &CollectionLoop{targets: targets, store: store, interval: interval}
+}
+
+func (l *CollectionLoop) collectOnce(ctx context.Context) {
+	sites := make(map[string]*SiteSnapshot, len(l.targets))
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	limit := runtime.NumCPU()
+	if len(l.targets) < limit {
+		limit = len(l.targets)
+	}
+	if limit > 0 {
+		g.SetLimit(limit)
+	}
+	for _, tc := range l.targets {
+		tc := tc
+		g.Go(func() error {
+			ss := tc.collect(gctx)
+			mu.Lock()
+			sites[tc.site] = ss
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+	l.store.Store(&Snapshot{Sites: sites})
+}
+
+// Run collects immediately, then every interval until ctx is cancelled.
+func (l *CollectionLoop) Run(ctx context.Context) {
+	l.collectOnce(ctx)
+	t := time.NewTicker(l.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			l.collectOnce(ctx)
+		}
+	}
+}

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -7,20 +7,41 @@ import (
 	"time"
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
 
 // TargetCollector collects one site (one NetBackup primary) into a SiteSnapshot.
 type TargetCollector struct {
-	site    string
-	cfg     models.Config  // a single-server view: cfg.NbuServer set from this site's entry
-	client  *NbuClient     // built lazily with version detection; nil until first success
-	tracing *TracerWrapper // noop unless a TracerProvider is wired
+	site           string
+	cfg            models.Config // a single-server view: cfg.NbuServer set from this site's entry
+	client         *NbuClient    // built lazily with version detection; nil until first success
+	tracing        *TracerWrapper
+	tracerProvider trace.TracerProvider // threaded into the lazily-built client
+	apiTrace       bool                 // --trace: log API response bodies on this site's client
+}
+
+// TargetOption configures optional per-target settings (tracing, API trace).
+type TargetOption func(*TargetCollector)
+
+// WithTargetTracerProvider wires an OpenTelemetry TracerProvider into the target's
+// client and sub-collector spans. Without it, tracing is a noop.
+func WithTargetTracerProvider(tp trace.TracerProvider) TargetOption {
+	return func(tc *TargetCollector) {
+		tc.tracerProvider = tp
+		tc.tracing = NewTracerWrapper(tp, "nbu-exporter/target")
+	}
+}
+
+// WithTargetAPITrace enables NetBackup API response-body trace logging on the
+// target's client (the --trace flag).
+func WithTargetAPITrace(enabled bool) TargetOption {
+	return func(tc *TargetCollector) { tc.apiTrace = enabled }
 }
 
 // NewTargetCollector builds a per-site collector. base supplies Server.* settings;
 // entry supplies this site's NetBackup server fields.
-func NewTargetCollector(base models.Config, entry models.NbuServerConfig) *TargetCollector {
+func NewTargetCollector(base models.Config, entry models.NbuServerConfig, opts ...TargetOption) *TargetCollector {
 	cfg := base
 	cfg.NbuServer.Host = entry.Host
 	cfg.NbuServer.Port = entry.Port
@@ -32,23 +53,36 @@ func NewTargetCollector(base models.Config, entry models.NbuServerConfig) *Targe
 	cfg.NbuServer.APIVersion = entry.APIVersion
 	cfg.NbuServer.ContentType = entry.ContentType
 	cfg.NbuServer.InsecureSkipVerify = entry.InsecureSkipVerify
-	return &TargetCollector{
+	tc := &TargetCollector{
 		site:    entry.Site,
 		cfg:     cfg,
 		tracing: NewTracerWrapper(nil, "nbu-exporter/target"),
 	}
+	for _, opt := range opts {
+		opt(tc)
+	}
+	return tc
 }
 
 func (tc *TargetCollector) clientFor(ctx context.Context) (*NbuClient, error) {
 	if tc.client != nil {
 		return tc.client, nil
 	}
-	c, err := NewNbuClientWithVersionDetection(ctx, &tc.cfg)
+	c, err := NewNbuClientWithVersionDetection(ctx, &tc.cfg,
+		WithTracerProvider(tc.tracerProvider), WithAPITrace(tc.apiTrace))
 	if err != nil {
 		return nil, err
 	}
 	tc.client = c
 	return c, nil
+}
+
+// close releases this target's client connections, if a client was built.
+func (tc *TargetCollector) close() error {
+	if tc.client != nil {
+		return tc.client.Close()
+	}
+	return nil
 }
 
 // collect fetches storage + jobs for this site and returns a SiteSnapshot. It never
@@ -129,6 +163,18 @@ func (l *CollectionLoop) collectOnce(ctx context.Context) {
 	}
 	_ = g.Wait()
 	l.store.Store(&Snapshot{Sites: sites})
+}
+
+// Close releases every target's client connections. Call it only after Run has
+// returned (the loop goroutine has stopped), so no collection is in flight.
+func (l *CollectionLoop) Close() error {
+	var firstErr error
+	for _, tc := range l.targets {
+		if err := tc.close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // Run collects immediately, then every interval until ctx is cancelled.

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -210,9 +210,12 @@ func (l *CollectionLoop) Close() error {
 
 // Run collects immediately, then every interval until ctx is cancelled.
 func (l *CollectionLoop) Run(ctx context.Context) {
-	l.collectOnce(ctx)
+	// Start the ticker before the first sweep so its cadence is anchored at t0:
+	// the next sweep fires at `interval`, not `first_sweep_duration + interval`,
+	// avoiding a startup coverage gap.
 	t := time.NewTicker(l.interval)
 	defer t.Stop()
+	l.collectOnce(ctx)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -15,6 +15,7 @@ import (
 type TargetCollector struct {
 	site           string
 	cfg            models.Config // a single-server view: cfg.NbuServer set from this site's entry
+	clientMu       sync.Mutex    // guards client (lazy build vs. close)
 	client         *NbuClient    // built lazily with version detection; nil until first success
 	tracing        *TracerWrapper
 	tracerProvider trace.TracerProvider // threaded into the lazily-built client
@@ -65,6 +66,8 @@ func NewTargetCollector(base models.Config, entry models.NbuServerConfig, opts .
 }
 
 func (tc *TargetCollector) clientFor(ctx context.Context) (*NbuClient, error) {
+	tc.clientMu.Lock()
+	defer tc.clientMu.Unlock()
 	if tc.client != nil {
 		return tc.client, nil
 	}
@@ -86,7 +89,8 @@ func (tc *TargetCollector) jobWindow() string {
 }
 
 // maxDurationString returns whichever of two duration strings parses to the larger
-// duration. If one fails to parse, the other is returned; if both fail, a is returned.
+// duration. If exactly one fails to parse, the other is returned. (Both inputs are
+// validated/defaulted upstream, so the both-unparseable case is unreachable.)
 func maxDurationString(a, b string) string {
 	da, ea := time.ParseDuration(a)
 	db, eb := time.ParseDuration(b)
@@ -104,6 +108,8 @@ func maxDurationString(a, b string) string {
 
 // close releases this target's client connections, if a client was built.
 func (tc *TargetCollector) close() error {
+	tc.clientMu.Lock()
+	defer tc.clientMu.Unlock()
 	if tc.client != nil {
 		return tc.client.Close()
 	}

--- a/internal/exporter/collector_loop.go
+++ b/internal/exporter/collector_loop.go
@@ -12,9 +12,10 @@ import (
 
 // TargetCollector collects one site (one NetBackup primary) into a SiteSnapshot.
 type TargetCollector struct {
-	site   string
-	cfg    models.Config // a single-server view: cfg.NbuServer set from this site's entry
-	client *NbuClient    // built lazily with version detection; nil until first success
+	site    string
+	cfg     models.Config  // a single-server view: cfg.NbuServer set from this site's entry
+	client  *NbuClient     // built lazily with version detection; nil until first success
+	tracing *TracerWrapper // noop unless a TracerProvider is wired
 }
 
 // NewTargetCollector builds a per-site collector. base supplies Server.* settings;
@@ -31,7 +32,11 @@ func NewTargetCollector(base models.Config, entry models.NbuServerConfig) *Targe
 	cfg.NbuServer.APIVersion = entry.APIVersion
 	cfg.NbuServer.ContentType = entry.ContentType
 	cfg.NbuServer.InsecureSkipVerify = entry.InsecureSkipVerify
-	return &TargetCollector{site: entry.Site, cfg: cfg}
+	return &TargetCollector{
+		site:    entry.Site,
+		cfg:     cfg,
+		tracing: NewTracerWrapper(nil, "nbu-exporter/target"),
+	}
 }
 
 func (tc *TargetCollector) clientFor(ctx context.Context) (*NbuClient, error) {
@@ -78,6 +83,13 @@ func (tc *TargetCollector) collect(ctx context.Context) *SiteSnapshot {
 		ss.LastJobsScrape = now
 	}
 	ss.Up = sErr == nil || jErr == nil
+
+	// Run enabled opt-in sub-collectors for this site and buffer their metrics
+	// into the snapshot, to be re-emitted on each scrape (graceful degradation:
+	// a failing sub-collector is logged and skipped, never aborting the cycle).
+	subs := buildSubCollectorsFor(client, tc.cfg, tc.site)
+	ss.SubMetrics = collectSubMetrics(ctx, subs, tc.tracing)
+
 	return ss
 }
 

--- a/internal/exporter/collector_loop_test.go
+++ b/internal/exporter/collector_loop_test.go
@@ -1,0 +1,124 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+)
+
+// nbuOKHandler returns HTTP 200 with valid empty NBU JSON for all requests.
+// It handles both version-detection probes (/admin/jobs?page[limit]=1) and
+// the actual jobs + storage fetches that FetchAllJobsFull / FetchStorageFull make.
+func nbuOKHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract the requested API version from the Accept header so the
+	// Content-Type response matches (mirrors writeVersionResponse in
+	// version_detection_integration_test.go).
+	accept := r.Header.Get("Accept")
+	version := "14.0"
+	for _, v := range []string{"14.0", "13.0", "12.0", "10.0"} {
+		if strings.Contains(accept, v) {
+			version = v
+			break
+		}
+	}
+	ct := fmt.Sprintf(contentTypeNetBackupJSONFormat, version)
+
+	switch {
+	case strings.Contains(r.URL.Path, "/storage/storage-units"):
+		// Encode an empty but valid storage response as raw JSON.
+		w.Header().Set(contentTypeHeader, ct)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[],"meta":{"pagination":{}},"links":{}}`))
+	default:
+		// Handles /admin/jobs (version probe + actual job fetch)
+		resp := &models.Jobs{}
+		resp.Data = []models.JobData{}
+		resp.Meta.Pagination.Next = ""
+		w.Header().Set(contentTypeHeader, ct)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// nbuErrorHandler returns HTTP 500 for every request.
+func nbuErrorHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+// newNbuServerConfig builds a NbuServerConfig for a plain-http httptest.Server.
+func newNbuServerConfig(site, serverURL, apiVersion string) models.NbuServerConfig {
+	// serverURL is "http://127.0.0.1:<port>" — strip scheme to get host:port.
+	hostPort := strings.TrimPrefix(serverURL, "http://")
+	parts := strings.SplitN(hostPort, ":", 2)
+	host := parts[0]
+	port := ""
+	if len(parts) == 2 {
+		port = parts[1]
+	}
+	return models.NbuServerConfig{
+		Site:               site,
+		Host:               host,
+		Port:               port,
+		Scheme:             "http",
+		URI:                "/netbackup",
+		APIKey:             testAPIKey,
+		APIVersion:         apiVersion,
+		ContentType:        contentTypeJSON,
+		InsecureSkipVerify: true,
+	}
+}
+
+// TestCollectionLoop_collectOnce verifies that collectOnce produces a Snapshot
+// with Up=true for a healthy server and Up=false for an unhealthy one.
+func TestCollectionLoop_collectOnce(t *testing.T) {
+	serverA := httptest.NewServer(http.HandlerFunc(nbuOKHandler))
+	defer serverA.Close()
+
+	serverB := httptest.NewServer(http.HandlerFunc(nbuErrorHandler))
+	defer serverB.Close()
+
+	// Use createTestConfig for the shared Server.* block (host, port, scraping interval).
+	base := createTestConfig(serverA.URL, "14.0")
+
+	entryA := newNbuServerConfig("a", serverA.URL, "14.0")
+	entryB := newNbuServerConfig("b", serverB.URL, "14.0")
+
+	tcA := NewTargetCollector(base, entryA)
+	tcB := NewTargetCollector(base, entryB)
+
+	store := &SnapshotStore{}
+	loop := NewCollectionLoop([]*TargetCollector{tcA, tcB}, store, time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	loop.collectOnce(ctx)
+
+	snap := store.Load()
+	if snap == nil {
+		t.Fatal("store.Load() returned nil after collectOnce")
+	}
+
+	siteA, ok := snap.Sites["a"]
+	if !ok {
+		t.Fatal("Snapshot missing site 'a'")
+	}
+	if !siteA.Up {
+		t.Errorf("site 'a' Up = false, want true (storageErr=%v, jobsErr=%v)", siteA.StorageErr, siteA.JobsErr)
+	}
+
+	siteB, ok := snap.Sites["b"]
+	if !ok {
+		t.Fatal("Snapshot missing site 'b'")
+	}
+	if siteB.Up {
+		t.Errorf("site 'b' Up = true, want false")
+	}
+}

--- a/internal/exporter/collector_loop_test.go
+++ b/internal/exporter/collector_loop_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // nbuOKHandler returns HTTP 200 with valid empty NBU JSON for all requests.
@@ -120,5 +121,39 @@ func TestCollectionLoop_collectOnce(t *testing.T) {
 	}
 	if siteB.Up {
 		t.Errorf("site 'b' Up = true, want false")
+	}
+}
+
+// TestTargetCollector_BuffersSubMetrics verifies that an enabled opt-in
+// sub-collector is run per-target and its metrics are buffered into the
+// SiteSnapshot, carrying the target's site label. The SLO collector always
+// emits exactly one series, so it is the simplest probe.
+func TestTargetCollector_BuffersSubMetrics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(nbuOKHandler))
+	defer server.Close()
+
+	base := createTestConfig(server.URL, "14.0")
+	base.Collectors.SLO.Enabled = true
+
+	entry := newNbuServerConfig("paris", server.URL, "14.0")
+	tc := NewTargetCollector(base, entry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ss := tc.collect(ctx)
+	if !ss.Up {
+		t.Fatalf("site Up = false, want true (storageErr=%v jobsErr=%v)", ss.StorageErr, ss.JobsErr)
+	}
+	if len(ss.SubMetrics) != 1 {
+		t.Fatalf("SubMetrics len = %d, want 1 (nbu_slo_count)", len(ss.SubMetrics))
+	}
+
+	var d dto.Metric
+	if err := ss.SubMetrics[0].Write(&d); err != nil {
+		t.Fatalf("metric write: %v", err)
+	}
+	if got := labelValue(&d, "site"); got != "paris" {
+		t.Errorf("buffered sub-metric site label = %q, want paris", got)
 	}
 }

--- a/internal/exporter/collector_loop_test.go
+++ b/internal/exporter/collector_loop_test.go
@@ -55,14 +55,7 @@ func nbuErrorHandler(w http.ResponseWriter, _ *http.Request) {
 
 // newNbuServerConfig builds a NbuServerConfig for a plain-http httptest.Server.
 func newNbuServerConfig(site, serverURL, apiVersion string) models.NbuServerConfig {
-	// serverURL is "http://127.0.0.1:<port>" — strip scheme to get host:port.
-	hostPort := strings.TrimPrefix(serverURL, "http://")
-	parts := strings.SplitN(hostPort, ":", 2)
-	host := parts[0]
-	port := ""
-	if len(parts) == 2 {
-		port = parts[1]
-	}
+	host, port := splitTestServerURL(serverURL)
 	return models.NbuServerConfig{
 		Site:               site,
 		Host:               host,

--- a/internal/exporter/collector_loop_test.go
+++ b/internal/exporter/collector_loop_test.go
@@ -124,6 +124,23 @@ func TestCollectionLoop_collectOnce(t *testing.T) {
 	}
 }
 
+// TestMaxDurationString verifies the job-window coupling: the larger of the two
+// durations wins, with sane fallback when one is unparseable.
+func TestMaxDurationString(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"1h", "5m", "1h"},   // scraping window already larger
+		{"1m", "10m", "10m"}, // poll interval larger -> widen window to avoid gaps
+		{"5m", "5m", "5m"},   // equal
+		{"5m", "", "5m"},     // unparseable b -> a
+		{"", "5m", "5m"},     // unparseable a -> b
+	}
+	for _, c := range cases {
+		if got := maxDurationString(c.a, c.b); got != c.want {
+			t.Errorf("maxDurationString(%q,%q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
 // TestTargetCollector_BuffersSubMetrics verifies that an enabled opt-in
 // sub-collector is run per-target and its metrics are buffered into the
 // SiteSnapshot, carrying the target's site label. The SLO collector always

--- a/internal/exporter/collector_malware.go
+++ b/internal/exporter/collector_malware.go
@@ -14,18 +14,20 @@ const malwarePath = "/malware/latest-scan-results"
 type malwareCollector struct {
 	client       NetBackupClient
 	cfg          models.Config
+	site         string
 	scannedDesc  *prometheus.Desc
 	infectedDesc *prometheus.Desc
 	scanDesc     *prometheus.Desc
 }
 
-func newMalwareCollector(client NetBackupClient, cfg models.Config) *malwareCollector {
+func newMalwareCollector(client NetBackupClient, cfg models.Config, site string) *malwareCollector {
 	return &malwareCollector{
 		client:       client,
 		cfg:          cfg,
-		scannedDesc:  prometheus.NewDesc("nbu_malware_files_scanned", "Total files scanned by malware scans", nil, nil),
-		infectedDesc: prometheus.NewDesc("nbu_malware_files_infected", "Total infected files found by malware scans", nil, nil),
-		scanDesc:     prometheus.NewDesc("nbu_malware_scan_count", "Number of malware scan results by status", []string{"status"}, nil),
+		site:         site,
+		scannedDesc:  prometheus.NewDesc("nbu_malware_files_scanned", "Total files scanned by malware scans", []string{"site"}, nil),
+		infectedDesc: prometheus.NewDesc("nbu_malware_files_infected", "Total infected files found by malware scans", []string{"site"}, nil),
+		scanDesc:     prometheus.NewDesc("nbu_malware_scan_count", "Number of malware scan results by status", []string{"site", "status"}, nil),
 	}
 }
 
@@ -44,10 +46,10 @@ func (m *malwareCollector) Collect(ctx context.Context, ch chan<- prometheus.Met
 		infected += float64(d.Attributes.NumberOfFilesImpacted)
 		statusCounts[d.Attributes.ScanState]++
 	}
-	ch <- prometheus.MustNewConstMetric(m.scannedDesc, prometheus.GaugeValue, scanned)
-	ch <- prometheus.MustNewConstMetric(m.infectedDesc, prometheus.GaugeValue, infected)
+	ch <- prometheus.MustNewConstMetric(m.scannedDesc, prometheus.GaugeValue, scanned, m.site)
+	ch <- prometheus.MustNewConstMetric(m.infectedDesc, prometheus.GaugeValue, infected, m.site)
 	for status, v := range statusCounts {
-		ch <- prometheus.MustNewConstMetric(m.scanDesc, prometheus.GaugeValue, v, status)
+		ch <- prometheus.MustNewConstMetric(m.scanDesc, prometheus.GaugeValue, v, m.site, status)
 	}
 	return nil
 }

--- a/internal/exporter/collector_malware_test.go
+++ b/internal/exporter/collector_malware_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMalwareCollector(t *testing.T) {
 	client := newMockClientFromFixture(t, "../../testdata/api-versions/malware-response.json")
-	c := newMalwareCollector(client, testConfig())
+	c := newMalwareCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 16)
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
@@ -22,6 +22,7 @@ func TestMalwareCollector(t *testing.T) {
 	for m := range ch {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
 		desc := m.Desc().String()
 		switch {
 		case strings.Contains(desc, "nbu_malware_files_scanned"):
@@ -43,7 +44,7 @@ func TestMalwareCollector(t *testing.T) {
 
 func TestMalwareCollectorError(t *testing.T) {
 	client := &errClient{}
-	c := newMalwareCollector(client, testConfig())
+	c := newMalwareCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 4)
 	require.Error(t, c.Collect(context.Background(), ch))
 	close(ch)

--- a/internal/exporter/collector_slo.go
+++ b/internal/exporter/collector_slo.go
@@ -19,17 +19,19 @@ const sloPath = "/servicecatalog/slos"
 type sloCollector struct {
 	client NetBackupClient
 	cfg    models.Config
+	site   string
 	desc   *prometheus.Desc
 }
 
-func newSLOCollector(client NetBackupClient, cfg models.Config) *sloCollector {
+func newSLOCollector(client NetBackupClient, cfg models.Config, site string) *sloCollector {
 	return &sloCollector{
 		client: client,
 		cfg:    cfg,
+		site:   site,
 		desc: prometheus.NewDesc(
 			"nbu_slo_count",
 			"Number of configured NetBackup SLOs",
-			nil, nil,
+			[]string{"site"}, nil,
 		),
 	}
 }
@@ -42,6 +44,6 @@ func (s *sloCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric)
 	if err := s.client.FetchData(ctx, url, &resp); err != nil {
 		return err
 	}
-	ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, float64(len(resp.Data)))
+	ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, float64(len(resp.Data)), s.site)
 	return nil
 }

--- a/internal/exporter/collector_slo_test.go
+++ b/internal/exporter/collector_slo_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSLOCollector(t *testing.T) {
 	client := newMockClientFromFixture(t, "../../testdata/api-versions/slo-response.json")
-	c := newSLOCollector(client, testConfig())
+	c := newSLOCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 16)
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
@@ -21,7 +21,8 @@ func TestSLOCollector(t *testing.T) {
 	for m := range ch {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
-		require.Empty(t, d.GetLabel(), "nbu_slo_count must be unlabeled")
+		require.Len(t, d.GetLabel(), 1, "nbu_slo_count carries only the site label")
+		require.Equal(t, "site1", labelValue(&d, "site"))
 		total = d.GetGauge().GetValue()
 		emitted++
 	}
@@ -31,7 +32,7 @@ func TestSLOCollector(t *testing.T) {
 
 func TestSLOCollectorError(t *testing.T) {
 	client := &errClient{}
-	c := newSLOCollector(client, testConfig())
+	c := newSLOCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 4)
 	require.Error(t, c.Collect(context.Background(), ch))
 	close(ch)

--- a/internal/exporter/collector_test_helpers_test.go
+++ b/internal/exporter/collector_test_helpers_test.go
@@ -5,12 +5,24 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
+
+// splitTestServerURL splits an "http://host:port" httptest server URL into its
+// host and port. Shared by the test config builders.
+func splitTestServerURL(serverURL string) (host, port string) {
+	parts := strings.SplitN(strings.TrimPrefix(serverURL, "http://"), ":", 2)
+	host = parts[0]
+	if len(parts) == 2 {
+		port = parts[1]
+	}
+	return host, port
+}
 
 // fixtureClient is a minimal NetBackupClient mock whose FetchData reads a JSON
 // fixture from disk and unmarshals it into the supplied target. It is shared by

--- a/internal/exporter/health.go
+++ b/internal/exporter/health.go
@@ -27,6 +27,12 @@ const healthCheckTimeout = 5 * time.Second
 //	    log.Warnf("NBU connectivity failed: %v", err)
 //	}
 func (c *NbuCollector) TestConnectivity(ctx context.Context) error {
+	// Multi-site mode: health is derived from the latest snapshot — at least one
+	// site reachable — without an extra live API call.
+	if c.store != nil {
+		return c.snapshotHealth()
+	}
+
 	// Use provided context or create one with timeout
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -40,6 +46,21 @@ func (c *NbuCollector) TestConnectivity(ctx context.Context) error {
 		return fmt.Errorf("NetBackup connectivity test failed: %w", err)
 	}
 	return nil
+}
+
+// snapshotHealth reports health from the latest published snapshot: healthy if no
+// snapshot exists yet (still starting up) or if at least one site is reachable.
+func (c *NbuCollector) snapshotHealth() error {
+	snap := c.store.Load()
+	if snap == nil {
+		return nil // first collection in flight; treat as starting, not unhealthy
+	}
+	for _, ss := range snap.Sites {
+		if ss.Up {
+			return nil
+		}
+	}
+	return fmt.Errorf("no NetBackup site reachable")
 }
 
 // IsHealthy returns true if the last collection was successful.

--- a/internal/exporter/health.go
+++ b/internal/exporter/health.go
@@ -70,6 +70,11 @@ func (c *NbuCollector) snapshotHealth() error {
 // This method is useful for lightweight health checks that don't need to
 // verify current connectivity, only whether recent scrapes succeeded.
 func (c *NbuCollector) IsHealthy() bool {
+	// Multi-site mode: derive health from the latest snapshot (mirrors
+	// TestConnectivity), since the live scrape-time fields are never written.
+	if c.store != nil {
+		return c.snapshotHealth() == nil
+	}
 	c.scrapeMu.RLock()
 	defer c.scrapeMu.RUnlock()
 	// Healthy if we've had at least one successful scrape

--- a/internal/exporter/integration_test.go
+++ b/internal/exporter/integration_test.go
@@ -412,14 +412,8 @@ func loadJobsTestData(t *testing.T) *models.Jobs {
 }
 
 func createTestConfig(serverURL, apiVersion string) models.Config {
-	// Parse the test server URL to extract host and port
-	// serverURL format: http://127.0.0.1:12345
-	parts := strings.Split(strings.TrimPrefix(serverURL, "http://"), ":")
-	host := parts[0]
-	port := ""
-	if len(parts) > 1 {
-		port = parts[1]
-	}
+	// Parse the test server URL ("http://127.0.0.1:12345") into host and port.
+	host, port := splitTestServerURL(serverURL)
 
 	cfg := models.Config{}
 	cfg.Server.Host = "localhost"

--- a/internal/exporter/metrics_consistency_test.go
+++ b/internal/exporter/metrics_consistency_test.go
@@ -69,7 +69,7 @@ func TestMetricsConsistencyJobMetrics(t *testing.T) {
 			require.NotNil(t, apiVersionMetric, "API version metric should exist")
 			assert.Equal(t, 1, len(apiVersionMetric.GetMetric()),
 				"API version metric should have one value")
-			assert.Equal(t, version, apiVersionMetric.GetMetric()[0].GetLabel()[1].GetValue(),
+			assert.Equal(t, version, labelValue(apiVersionMetric.GetMetric()[0], "version"),
 				"API version label should match configured version")
 		})
 	}

--- a/internal/exporter/metrics_consistency_test.go
+++ b/internal/exporter/metrics_consistency_test.go
@@ -69,7 +69,7 @@ func TestMetricsConsistencyJobMetrics(t *testing.T) {
 			require.NotNil(t, apiVersionMetric, "API version metric should exist")
 			assert.Equal(t, 1, len(apiVersionMetric.GetMetric()),
 				"API version metric should have one value")
-			assert.Equal(t, version, apiVersionMetric.GetMetric()[0].GetLabel()[0].GetValue(),
+			assert.Equal(t, version, apiVersionMetric.GetMetric()[0].GetLabel()[1].GetValue(),
 				"API version label should match configured version")
 		})
 	}
@@ -115,7 +115,7 @@ func TestMetricsConsistencyStorageMetrics(t *testing.T) {
 				}
 
 				// Expected labels for storage metrics
-				expectedLabels := []string{"name", "type", "size"}
+				expectedLabels := []string{"site", "name", "type", "size"}
 				for _, expected := range expectedLabels {
 					assert.Contains(t, labelNames, expected,
 						"Storage metric should have label %s for version %s", expected, version)

--- a/internal/exporter/otel_integration_test.go
+++ b/internal/exporter/otel_integration_test.go
@@ -50,12 +50,13 @@ func TestIntegrationEndToEndTracing(t *testing.T) {
 	// Create client and verify it gets a tracer
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			ScrapingInterval: "5m",
 		},
@@ -110,12 +111,13 @@ func TestIntegrationBackwardCompatibility(t *testing.T) {
 	// Create config without OpenTelemetry
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -205,12 +207,13 @@ func TestIntegrationGracefulDegradation(t *testing.T) {
 	// Create client
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			ScrapingInterval: "5m",
 		},

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -433,6 +433,12 @@ func (c *NbuCollector) exposeSnapshot(ch chan<- prometheus.Metric, site string, 
 	}
 	ch <- prometheus.MustNewConstMetric(c.nbuUp, prometheus.GaugeValue, upValue, site)
 
+	// Per-site degradation contract: a fully-down site exposes ONLY nbu_up=0, so
+	// no stale/misleading series (e.g. nbu_api_version) are published for it.
+	if !ss.Up {
+		return
+	}
+
 	if !ss.LastStorageScrape.IsZero() {
 		ch <- prometheus.MustNewConstMetric(c.nbuLastScrapeTime, prometheus.GaugeValue,
 			float64(ss.LastStorageScrape.Unix()), site, "storage")

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -100,6 +100,13 @@ type NbuCollector struct {
 	lastJobsScrapeTime    time.Time    // Last successful jobs metric collection
 }
 
+// withSite prepends the site label value to a slice of additional label values.
+// Used at emission time so every metric series carries the site dimension.
+func withSite(site string, labels []string) []string {
+	result := make([]string, 0, 1+len(labels))
+	return append(append(result, site), labels...)
+}
+
 // NewNbuCollector creates a new NetBackup collector with the provided configuration.
 // It initializes the HTTP client, performs automatic API version detection if needed,
 // and registers Prometheus metric descriptors.
@@ -157,87 +164,87 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 		nbuResponseTime: prometheus.NewDesc(
 			"nbu_response_time_ms",
 			"The server response time in milliseconds",
-			nil, nil,
+			[]string{"site"}, nil,
 		),
 		nbuDiskSize: prometheus.NewDesc(
 			"nbu_disk_bytes",
 			fmt.Sprintf("The quantity of storage bytes (cached: %s TTL)", cfg.GetCacheTTL()),
-			[]string{"name", "type", "size"}, nil,
+			[]string{"site", "name", "type", "size"}, nil,
 		),
 		nbuJobsSize: prometheus.NewDesc(
 			"nbu_jobs_bytes",
 			"The quantity of processed bytes",
-			[]string{"action", "policy_type", "status"}, nil,
+			[]string{"site", "action", "policy_type", "status"}, nil,
 		),
 		nbuJobsCount: prometheus.NewDesc(
 			"nbu_jobs_count",
 			"The quantity of jobs",
-			[]string{"action", "policy_type", "status"}, nil,
+			[]string{"site", "action", "policy_type", "status"}, nil,
 		),
 		nbuJobsStatusCount: prometheus.NewDesc(
 			"nbu_status_count",
 			"The quantity per status",
-			[]string{"action", "status"}, nil,
+			[]string{"site", "action", "status"}, nil,
 		),
 		nbuAPIVersion: prometheus.NewDesc(
 			"nbu_api_version",
 			"The NetBackup API version currently in use",
-			[]string{"version"}, nil,
+			[]string{"site", "version"}, nil,
 		),
 		nbuUp: prometheus.NewDesc(
 			"nbu_up",
 			"1 if NetBackup API is reachable, 0 if all collections failed",
-			nil, nil,
+			[]string{"site"}, nil,
 		),
 		nbuLastScrapeTime: prometheus.NewDesc(
 			"nbu_last_scrape_timestamp_seconds",
 			"Unix timestamp of the last successful metric collection",
-			[]string{"source"}, nil, // source: "storage" or "jobs"
+			[]string{"site", "source"}, nil, // source: "storage" or "jobs"
 		),
 		nbuDiskCapacity: prometheus.NewDesc(
 			"nbu_disk_capacity_bytes",
 			"Authoritative total capacity of the storage unit in bytes",
-			[]string{"name", "type"}, nil,
+			[]string{"site", "name", "type"}, nil,
 		),
 		nbuStorageMaxJobs: prometheus.NewDesc(
 			"nbu_storage_max_concurrent_jobs",
 			"Maximum number of concurrent jobs the storage unit accepts",
-			[]string{"name", "type"}, nil,
+			[]string{"site", "name", "type"}, nil,
 		),
 		nbuStorageMaxFragment: prometheus.NewDesc(
 			"nbu_storage_max_fragment_size_bytes",
 			"Maximum fragment size the storage unit accepts, in bytes",
-			[]string{"name", "type"}, nil,
+			[]string{"site", "name", "type"}, nil,
 		),
 		nbuStorageInfo: prometheus.NewDesc(
 			"nbu_storage_info",
 			"Storage unit capabilities (always 1; metadata carried in labels)",
-			[]string{"name", "type", "subtype", "is_cloud", "worm_capable", "use_worm", "replication_capable", "instant_access"}, nil,
+			[]string{"site", "name", "type", "subtype", "is_cloud", "worm_capable", "use_worm", "replication_capable", "instant_access"}, nil,
 		),
 		nbuJobsStateCount: prometheus.NewDesc(
 			"nbu_jobs_state_count",
 			"The quantity of jobs per lifecycle state",
-			[]string{"action", "state"}, nil,
+			[]string{"site", "action", "state"}, nil,
 		),
 		nbuJobsFilesCount: prometheus.NewDesc(
 			"nbu_jobs_files_count",
 			"The total number of files processed by jobs",
-			[]string{"action", "policy_type"}, nil,
+			[]string{"site", "action", "policy_type"}, nil,
 		),
 		nbuJobsDedupRatio: prometheus.NewDesc(
 			"nbu_jobs_dedup_ratio",
 			"The mean deduplication ratio across jobs",
-			[]string{"action", "policy_type"}, nil,
+			[]string{"site", "action", "policy_type"}, nil,
 		),
 		nbuJobsQueuedCount: prometheus.NewDesc(
 			"nbu_jobs_queued_count",
 			"The quantity of queued jobs per queue reason code",
-			[]string{"action", "reason"}, nil,
+			[]string{"site", "action", "reason"}, nil,
 		),
 		nbuJobDuration: prometheus.NewDesc(
 			"nbu_job_duration_seconds",
 			"Histogram of completed job durations in seconds",
-			[]string{"action", "policy_type"}, nil,
+			[]string{"site", "action", "policy_type"}, nil,
 		),
 	}
 
@@ -349,8 +356,14 @@ func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
 	// Update span with scrape results
 	c.updateScrapeSpan(span, scrapeStart, storageMetrics, jobMetricCount, storageErr, jobsErr)
 
+	// Determine site label value (fallback to NbuServer.Host for tests that bypass SetDefaults)
+	site := c.cfg.NbuServer.Host
+	if len(c.cfg.NbuServers) > 0 {
+		site = c.cfg.NbuServers[0].Site
+	}
+
 	// Expose all collected metrics (pass errors for nbu_up calculation)
-	c.exposeMetrics(ch, storageMetrics, storageUnits, jobAgg, storageErr, jobsErr)
+	c.exposeMetrics(ch, site, storageMetrics, storageUnits, jobAgg, storageErr, jobsErr)
 
 	// Run enabled opt-in sub-collectors (graceful degradation: errors logged, never propagated).
 	runSubCollectors(ctx, c.subCollectors, ch, c.tracing)
@@ -517,14 +530,14 @@ func (c *NbuCollector) recordScrapeAttributes(span trace.Span, scrapeStart time.
 // exposeMetrics sends all collected metrics to the Prometheus channel.
 // It calculates nbu_up based on collection errors: 1 if any collection succeeded, 0 if all failed.
 // It also exposes nbu_last_scrape_timestamp_seconds for staleness detection.
-func (c *NbuCollector) exposeMetrics(ch chan<- prometheus.Metric, storageMetrics []StorageMetricValue, storageUnits []StorageUnitInfo, jobAgg *JobAggregator, storageErr, jobsErr error) {
+func (c *NbuCollector) exposeMetrics(ch chan<- prometheus.Metric, site string, storageMetrics []StorageMetricValue, storageUnits []StorageUnitInfo, jobAgg *JobAggregator, storageErr, jobsErr error) {
 	// Expose nbu_up metric first (Prometheus convention)
 	// up=1 if ANY collection succeeded, up=0 if ALL failed
 	upValue := 0.0
 	if storageErr == nil || jobsErr == nil {
 		upValue = 1.0
 	}
-	ch <- prometheus.MustNewConstMetric(c.nbuUp, prometheus.GaugeValue, upValue)
+	ch <- prometheus.MustNewConstMetric(c.nbuUp, prometheus.GaugeValue, upValue, site)
 
 	// Expose last scrape timestamps for staleness detection
 	c.scrapeMu.RLock()
@@ -533,7 +546,7 @@ func (c *NbuCollector) exposeMetrics(ch chan<- prometheus.Metric, storageMetrics
 			c.nbuLastScrapeTime,
 			prometheus.GaugeValue,
 			float64(c.lastStorageScrapeTime.Unix()),
-			"storage",
+			site, "storage",
 		)
 	}
 	if !c.lastJobsScrapeTime.IsZero() {
@@ -541,27 +554,27 @@ func (c *NbuCollector) exposeMetrics(ch chan<- prometheus.Metric, storageMetrics
 			c.nbuLastScrapeTime,
 			prometheus.GaugeValue,
 			float64(c.lastJobsScrapeTime.Unix()),
-			"jobs",
+			site, "jobs",
 		)
 	}
 	c.scrapeMu.RUnlock()
 
 	// Expose existing storage + job metrics
-	c.exposeStorageMetrics(ch, storageMetrics)
-	c.exposeStorageUnitMetrics(ch, storageUnits)
-	c.exposeJobAggregateMetrics(ch, jobAgg)
-	c.exposeAPIVersionMetric(ch)
+	c.exposeStorageMetrics(ch, site, storageMetrics)
+	c.exposeStorageUnitMetrics(ch, site, storageUnits)
+	c.exposeJobAggregateMetrics(ch, site, jobAgg)
+	c.exposeAPIVersionMetric(ch, site)
 }
 
 // exposeStorageUnitMetrics emits the per-unit storage attribute metrics:
 // capacity, max concurrent jobs, max fragment size, and the info metric.
-func (c *NbuCollector) exposeStorageUnitMetrics(ch chan<- prometheus.Metric, units []StorageUnitInfo) {
+func (c *NbuCollector) exposeStorageUnitMetrics(ch chan<- prometheus.Metric, site string, units []StorageUnitInfo) {
 	for _, u := range units {
-		labels := []string{u.Name, u.Type}
+		labels := withSite(site, []string{u.Name, u.Type})
 		ch <- prometheus.MustNewConstMetric(c.nbuDiskCapacity, prometheus.GaugeValue, u.TotalCapacityBytes, labels...)
 		ch <- prometheus.MustNewConstMetric(c.nbuStorageMaxJobs, prometheus.GaugeValue, u.MaxConcurrentJobs, labels...)
 		ch <- prometheus.MustNewConstMetric(c.nbuStorageMaxFragment, prometheus.GaugeValue, u.MaxFragmentBytes, labels...)
-		ch <- prometheus.MustNewConstMetric(c.nbuStorageInfo, prometheus.GaugeValue, 1, u.InfoLabels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuStorageInfo, prometheus.GaugeValue, 1, withSite(site, u.InfoLabels())...)
 	}
 }
 
@@ -569,59 +582,59 @@ func (c *NbuCollector) exposeStorageUnitMetrics(ch chan<- prometheus.Metric, uni
 // A nil aggregator (jobs fetch failed) yields no job metrics, preserving the
 // graceful-degradation contract. Dedup ratio is emitted only when at least one
 // job contributed (absent, never a fake zero).
-func (c *NbuCollector) exposeJobAggregateMetrics(ch chan<- prometheus.Metric, agg *JobAggregator) {
+func (c *NbuCollector) exposeJobAggregateMetrics(ch chan<- prometheus.Metric, site string, agg *JobAggregator) {
 	if agg == nil {
 		return
 	}
 
 	for key, value := range agg.Size {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsSize, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsSize, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, value := range agg.Count {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsCount, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsCount, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, value := range agg.StatusCount {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsStatusCount, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsStatusCount, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, value := range agg.StateCount {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsStateCount, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsStateCount, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, value := range agg.FilesCount {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsFilesCount, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsFilesCount, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, value := range agg.QueuedCount {
-		ch <- prometheus.MustNewConstMetric(c.nbuJobsQueuedCount, prometheus.GaugeValue, value, key.Labels()...)
+		ch <- prometheus.MustNewConstMetric(c.nbuJobsQueuedCount, prometheus.GaugeValue, value, withSite(site, key.Labels())...)
 	}
 	for key, sum := range agg.DedupSum {
 		if n := agg.DedupCount[key]; n > 0 {
-			ch <- prometheus.MustNewConstMetric(c.nbuJobsDedupRatio, prometheus.GaugeValue, sum/n, key.Labels()...)
+			ch <- prometheus.MustNewConstMetric(c.nbuJobsDedupRatio, prometheus.GaugeValue, sum/n, withSite(site, key.Labels())...)
 		}
 	}
 	for key, acc := range agg.Duration {
-		ch <- prometheus.MustNewConstHistogram(c.nbuJobDuration, acc.Count, acc.Sum, acc.Buckets(), key.Labels()...)
+		ch <- prometheus.MustNewConstHistogram(c.nbuJobDuration, acc.Count, acc.Sum, acc.Buckets(), withSite(site, key.Labels())...)
 	}
 }
 
 // exposeStorageMetrics sends storage metrics to the Prometheus channel.
 // Uses Labels() method directly - no string parsing needed.
-func (c *NbuCollector) exposeStorageMetrics(ch chan<- prometheus.Metric, storageMetrics []StorageMetricValue) {
+func (c *NbuCollector) exposeStorageMetrics(ch chan<- prometheus.Metric, site string, storageMetrics []StorageMetricValue) {
 	for _, m := range storageMetrics {
 		ch <- prometheus.MustNewConstMetric(
 			c.nbuDiskSize,
 			prometheus.GaugeValue,
 			m.Value,
-			m.Key.Labels()...,
+			withSite(site, m.Key.Labels())...,
 		)
 	}
 }
 
 // exposeAPIVersionMetric sends the API version metric to the Prometheus channel.
-func (c *NbuCollector) exposeAPIVersionMetric(ch chan<- prometheus.Metric) {
+func (c *NbuCollector) exposeAPIVersionMetric(ch chan<- prometheus.Metric, site string) {
 	ch <- prometheus.MustNewConstMetric(
 		c.nbuAPIVersion,
 		prometheus.GaugeValue,
 		1,
-		c.cfg.NbuServer.APIVersion,
+		site, c.cfg.NbuServer.APIVersion,
 	)
 }
 

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -256,18 +256,22 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 
 // buildSubCollectors returns the enabled optional collectors based on config.
 func buildSubCollectors(c *NbuCollector) []subCollector {
+	site := c.cfg.NbuServer.Host
+	if len(c.cfg.NbuServers) > 0 {
+		site = c.cfg.NbuServers[0].Site
+	}
 	var subs []subCollector
 	if c.cfg.Collectors.Alerts.Enabled {
-		subs = append(subs, newAlertsCollector(c.client, c.cfg))
+		subs = append(subs, newAlertsCollector(c.client, c.cfg, site))
 	}
 	if c.cfg.Collectors.Malware.Enabled {
-		subs = append(subs, newMalwareCollector(c.client, c.cfg))
+		subs = append(subs, newMalwareCollector(c.client, c.cfg, site))
 	}
 	if c.cfg.Collectors.Catalog.Enabled {
-		subs = append(subs, newCatalogCollector(c.client, c.cfg))
+		subs = append(subs, newCatalogCollector(c.client, c.cfg, site))
 	}
 	if c.cfg.Collectors.SLO.Enabled {
-		subs = append(subs, newSLOCollector(c.client, c.cfg))
+		subs = append(subs, newSLOCollector(c.client, c.cfg, site))
 	}
 	return subs
 }

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -67,11 +67,18 @@ func WithCollectorAPITrace(enabled bool) CollectorOption {
 // Storage metrics are cached to reduce NetBackup API load. The cache TTL is
 // configurable via Config.Server.CacheTTL (default 5m).
 type NbuCollector struct {
-	cfg                models.Config
+	cfg     models.Config
+	tracing *TracerWrapper
+
+	// store is set for the multi-site snapshot-reading collector (the registered
+	// collector). When non-nil, Collect reads the latest Snapshot and emits each
+	// site's metrics, performing no live fetch on scrape. When nil, the collector
+	// is in the legacy single-target live-fetch mode (used by tests).
+	store *SnapshotStore
+
 	client             *NbuClient
-	tracing            *TracerWrapper
-	storageCache       *StorageCache  // TTL cache for storage metrics
-	subCollectors      []subCollector // Enabled opt-in metric collectors
+	storageCache       *StorageCache  // TTL cache for storage metrics (live mode only)
+	subCollectors      []subCollector // Enabled opt-in metric collectors (live mode only)
 	nbuDiskSize        *prometheus.Desc
 	nbuResponseTime    *prometheus.Desc
 	nbuJobsSize        *prometheus.Desc
@@ -153,14 +160,41 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 	// Create TracerWrapper for collector
 	tracing := NewTracerWrapper(options.tracerProvider, "nbu-exporter/collector")
 
-	// Create storage cache with configured TTL
-	storageCache := NewStorageCache(cfg.GetCacheTTL())
+	c := newBaseCollector(cfg, tracing)
+	c.client = client
+	c.storageCache = NewStorageCache(cfg.GetCacheTTL())
 
-	c := &NbuCollector{
-		cfg:          cfg,
-		client:       client,
-		tracing:      tracing,
-		storageCache: storageCache,
+	// Populate enabled opt-in collectors from config (empty unless configured).
+	c.subCollectors = buildSubCollectors(c)
+
+	return c, nil
+}
+
+// NewSnapshotCollector creates the multi-site collector that exposes metrics from
+// the latest Snapshot published by the background collection loop. It performs no
+// live fetching on scrape: Collect reads the SnapshotStore and emits each site's
+// metrics. This is the collector registered with Prometheus in production.
+//
+// cfg supplies only descriptor metadata (e.g. help strings); all metric values
+// come from the snapshot, so per-site connection details live in the targets.
+func NewSnapshotCollector(cfg models.Config, store *SnapshotStore, opts ...CollectorOption) *NbuCollector {
+	options := defaultCollectorOptions()
+	for _, opt := range opts {
+		opt(&options)
+	}
+	tracing := NewTracerWrapper(options.tracerProvider, "nbu-exporter/collector")
+	c := newBaseCollector(cfg, tracing)
+	c.store = store
+	return c
+}
+
+// newBaseCollector builds an NbuCollector with its configuration, tracer, and all
+// Prometheus metric descriptors set, but without a client, cache, store, or
+// sub-collectors. Both constructors share it so the descriptor set stays identical.
+func newBaseCollector(cfg models.Config, tracing *TracerWrapper) *NbuCollector {
+	return &NbuCollector{
+		cfg:     cfg,
+		tracing: tracing,
 		nbuResponseTime: prometheus.NewDesc(
 			"nbu_response_time_ms",
 			"The server response time in milliseconds",
@@ -247,11 +281,6 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 			[]string{"site", "action", "policy_type"}, nil,
 		),
 	}
-
-	// Populate enabled opt-in collectors from config (empty until Phase 4).
-	c.subCollectors = buildSubCollectors(c)
-
-	return c, nil
 }
 
 // buildSubCollectors returns the enabled optional collectors based on config.
@@ -329,6 +358,12 @@ func (c *NbuCollector) createScrapeSpan(ctx context.Context) (context.Context, t
 // Parameters:
 //   - ch: Channel to send Prometheus metrics to (provided by Prometheus registry)
 func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
+	// Multi-site mode: read the latest snapshot and emit per-site (no live fetch).
+	if c.store != nil {
+		c.collectFromSnapshot(ch)
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), collectionTimeout)
 	defer cancel()
 
@@ -361,6 +396,62 @@ func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
 
 	log.Debugf("Collected %d storage, %d storage units, %d job metric keys",
 		len(storageMetrics), len(storageUnits), jobMetricCount)
+}
+
+// collectFromSnapshot emits metrics for every site in the latest snapshot
+// published by the background collection loop. If no snapshot exists yet (first
+// collection still in flight), it emits nothing: /metrics is up but empty until
+// the first cycle completes (serve-before-first-collect).
+func (c *NbuCollector) collectFromSnapshot(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), collectionTimeout)
+	defer cancel()
+	_, span := c.createScrapeSpan(ctx)
+	defer span.End()
+
+	snap := c.store.Load()
+	if snap == nil {
+		span.SetStatus(codes.Ok, "no snapshot yet")
+		return
+	}
+	for site, ss := range snap.Sites {
+		c.exposeSnapshot(ch, site, ss)
+	}
+	span.SetStatus(codes.Ok, "")
+}
+
+// exposeSnapshot emits one site's metrics from its already-aggregated SiteSnapshot.
+// Every series carries the site label (first), and a failed site still emits
+// nbu_up{site}=0 without affecting the others (graceful degradation).
+func (c *NbuCollector) exposeSnapshot(ch chan<- prometheus.Metric, site string, ss *SiteSnapshot) {
+	if ss == nil {
+		return
+	}
+
+	upValue := 0.0
+	if ss.Up {
+		upValue = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(c.nbuUp, prometheus.GaugeValue, upValue, site)
+
+	if !ss.LastStorageScrape.IsZero() {
+		ch <- prometheus.MustNewConstMetric(c.nbuLastScrapeTime, prometheus.GaugeValue,
+			float64(ss.LastStorageScrape.Unix()), site, "storage")
+	}
+	if !ss.LastJobsScrape.IsZero() {
+		ch <- prometheus.MustNewConstMetric(c.nbuLastScrapeTime, prometheus.GaugeValue,
+			float64(ss.LastJobsScrape.Unix()), site, "jobs")
+	}
+
+	c.exposeStorageMetrics(ch, site, ss.StorageMetrics)
+	c.exposeStorageUnitMetrics(ch, site, ss.StorageUnits)
+	c.exposeJobAggregateMetrics(ch, site, ss.JobAgg)
+
+	ch <- prometheus.MustNewConstMetric(c.nbuAPIVersion, prometheus.GaugeValue, 1, site, ss.APIVersion)
+
+	// Re-emit the buffered opt-in sub-collector metrics (already site-labelled).
+	for _, m := range ss.SubMetrics {
+		ch <- m
+	}
 }
 
 // collectAllMetrics fetches storage and job metrics from NetBackup API in parallel.

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -69,6 +69,7 @@ func WithCollectorAPITrace(enabled bool) CollectorOption {
 type NbuCollector struct {
 	cfg     models.Config
 	tracing *TracerWrapper
+	site    string // identity label value for live mode (snapshot mode uses per-site snapshot keys)
 
 	// store is set for the multi-site snapshot-reading collector (the registered
 	// collector). When non-nil, Collect reads the latest Snapshot and emits each
@@ -163,11 +164,22 @@ func NewNbuCollector(cfg models.Config, opts ...CollectorOption) (*NbuCollector,
 	c := newBaseCollector(cfg, tracing)
 	c.client = client
 	c.storageCache = NewStorageCache(cfg.GetCacheTTL())
+	c.site = primarySite(cfg)
 
 	// Populate enabled opt-in collectors from config (empty unless configured).
 	c.subCollectors = buildSubCollectors(c)
 
 	return c, nil
+}
+
+// primarySite returns the identity label value for a single-target (live-mode)
+// collector: the configured primary site, falling back to the legacy host for
+// configs/tests that bypass SetDefaults.
+func primarySite(cfg models.Config) string {
+	if len(cfg.NbuServers) > 0 {
+		return cfg.NbuServers[0].Site
+	}
+	return cfg.NbuServer.Host
 }
 
 // NewSnapshotCollector creates the multi-site collector that exposes metrics from
@@ -285,11 +297,7 @@ func newBaseCollector(cfg models.Config, tracing *TracerWrapper) *NbuCollector {
 
 // buildSubCollectors returns the enabled optional collectors based on config.
 func buildSubCollectors(c *NbuCollector) []subCollector {
-	site := c.cfg.NbuServer.Host
-	if len(c.cfg.NbuServers) > 0 {
-		site = c.cfg.NbuServers[0].Site
-	}
-	return buildSubCollectorsFor(c.client, c.cfg, site)
+	return buildSubCollectorsFor(c.client, c.cfg, c.site)
 }
 
 // Describe sends the descriptors of each metric to the provided channel.
@@ -382,14 +390,8 @@ func (c *NbuCollector) Collect(ch chan<- prometheus.Metric) {
 	// Update span with scrape results
 	c.updateScrapeSpan(span, scrapeStart, storageMetrics, jobMetricCount, storageErr, jobsErr)
 
-	// Determine site label value (fallback to NbuServer.Host for tests that bypass SetDefaults)
-	site := c.cfg.NbuServer.Host
-	if len(c.cfg.NbuServers) > 0 {
-		site = c.cfg.NbuServers[0].Site
-	}
-
 	// Expose all collected metrics (pass errors for nbu_up calculation)
-	c.exposeMetrics(ch, site, storageMetrics, storageUnits, jobAgg, storageErr, jobsErr)
+	c.exposeMetrics(ch, c.site, storageMetrics, storageUnits, jobAgg, storageErr, jobsErr)
 
 	// Run enabled opt-in sub-collectors (graceful degradation: errors logged, never propagated).
 	runSubCollectors(ctx, c.subCollectors, ch, c.tracing)

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -260,20 +260,7 @@ func buildSubCollectors(c *NbuCollector) []subCollector {
 	if len(c.cfg.NbuServers) > 0 {
 		site = c.cfg.NbuServers[0].Site
 	}
-	var subs []subCollector
-	if c.cfg.Collectors.Alerts.Enabled {
-		subs = append(subs, newAlertsCollector(c.client, c.cfg, site))
-	}
-	if c.cfg.Collectors.Malware.Enabled {
-		subs = append(subs, newMalwareCollector(c.client, c.cfg, site))
-	}
-	if c.cfg.Collectors.Catalog.Enabled {
-		subs = append(subs, newCatalogCollector(c.client, c.cfg, site))
-	}
-	if c.cfg.Collectors.SLO.Enabled {
-		subs = append(subs, newSLOCollector(c.client, c.cfg, site))
-	}
-	return subs
+	return buildSubCollectorsFor(c.client, c.cfg, site)
 }
 
 // Describe sends the descriptors of each metric to the provided channel.

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -380,12 +380,13 @@ func TestNbuCollectorDescribe(t *testing.T) {
 func TestNbuCollectorCreateScrapeSpanNilSafe(t *testing.T) {
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -442,12 +443,13 @@ func TestNbuCollectorCreateScrapeSpanNilSafe(t *testing.T) {
 func TestNbuCollectorCreateScrapeSpanWithTracer(t *testing.T) {
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -510,12 +512,13 @@ func TestNbuCollectorCollectWithoutTracing(t *testing.T) {
 
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -627,12 +630,13 @@ func TestNbuCollectorCollectWithoutTracing(t *testing.T) {
 func TestNbuCollectorTracingDisabled(t *testing.T) {
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -702,12 +706,13 @@ func TestNbuCollectorStorageCacheIntegration(t *testing.T) {
 
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -773,12 +778,13 @@ func TestNbuCollectorHelpStringIncludesTTL(t *testing.T) {
 
 	cfg := models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -900,3 +900,48 @@ func TestNbuCollectorNbuUpHasSiteLabel(t *testing.T) {
 	assert.Equal(t, "site", labels[0].GetName(), "first label must be named 'site'")
 	assert.Equal(t, serverHost, labels[0].GetValue(), "site label value must equal NbuServers[0].Site")
 }
+
+// TestSnapshotCollectorEmitsAllSites verifies the snapshot-reading collector emits
+// metrics for every site in the latest snapshot, with the right nbu_up values,
+// and emits nothing (no panic) before the first snapshot is published.
+func TestSnapshotCollectorEmitsAllSites(t *testing.T) {
+	store := &SnapshotStore{}
+	collector := NewSnapshotCollector(models.Config{}, store)
+
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(collector))
+
+	// Before any snapshot: gather succeeds and yields no nbu_up series.
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+	require.Empty(t, upValuesBySite(mfs), "no series expected before first snapshot")
+
+	// Publish a two-site snapshot: paris up, lyon down.
+	store.Store(&Snapshot{Sites: map[string]*SiteSnapshot{
+		"paris": {Site: "paris", APIVersion: models.APIVersion130, Up: true},
+		"lyon":  {Site: "lyon", APIVersion: models.APIVersion130, Up: false},
+	}})
+
+	mfs, err = registry.Gather()
+	require.NoError(t, err)
+
+	ups := upValuesBySite(mfs)
+	require.Contains(t, ups, "paris")
+	require.Contains(t, ups, "lyon")
+	assert.Equal(t, float64(1), ups["paris"], "nbu_up{site=paris} should be 1")
+	assert.Equal(t, float64(0), ups["lyon"], "nbu_up{site=lyon} should be 0")
+}
+
+// upValuesBySite extracts nbu_up gauge values keyed by their site label.
+func upValuesBySite(mfs []*dto.MetricFamily) map[string]float64 {
+	out := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "nbu_up" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			out[labelValue(m, "site")] = m.GetGauge().GetValue()
+		}
+	}
+	return out
+}

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -930,6 +930,20 @@ func TestSnapshotCollectorEmitsAllSites(t *testing.T) {
 	require.Contains(t, ups, "lyon")
 	assert.Equal(t, float64(1), ups["paris"], "nbu_up{site=paris} should be 1")
 	assert.Equal(t, float64(0), ups["lyon"], "nbu_up{site=lyon} should be 0")
+
+	// Degradation contract: the up site emits nbu_api_version; the down site does
+	// NOT (a fully-down site exposes only nbu_up=0).
+	apiVersionSites := map[string]bool{}
+	for _, mf := range mfs {
+		if mf.GetName() != "nbu_api_version" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			apiVersionSites[labelValue(m, "site")] = true
+		}
+	}
+	assert.True(t, apiVersionSites["paris"], "up site should emit nbu_api_version")
+	assert.False(t, apiVersionSites["lyon"], "down site must not emit nbu_api_version")
 }
 
 // upValuesBySite extracts nbu_up gauge values keyed by their site label.

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -560,42 +561,42 @@ func TestNbuCollectorCollectWithoutTracing(t *testing.T) {
 		nbuDiskSize: prometheus.NewDesc(
 			"nbu_disk_bytes",
 			"The quantity of storage bytes",
-			[]string{"name", "type", "size"}, nil,
+			[]string{"site", "name", "type", "size"}, nil,
 		),
 		nbuResponseTime: prometheus.NewDesc(
 			"nbu_response_time_ms",
 			"The server response time in milliseconds",
-			nil, nil,
+			[]string{"site"}, nil,
 		),
 		nbuJobsSize: prometheus.NewDesc(
 			"nbu_jobs_bytes",
 			"The quantity of processed bytes",
-			[]string{"action", "policy_type", "status"}, nil,
+			[]string{"site", "action", "policy_type", "status"}, nil,
 		),
 		nbuJobsCount: prometheus.NewDesc(
 			"nbu_jobs_count",
 			"The quantity of jobs",
-			[]string{"action", "policy_type", "status"}, nil,
+			[]string{"site", "action", "policy_type", "status"}, nil,
 		),
 		nbuJobsStatusCount: prometheus.NewDesc(
 			"nbu_status_count",
 			"The quantity per status",
-			[]string{"action", "status"}, nil,
+			[]string{"site", "action", "status"}, nil,
 		),
 		nbuAPIVersion: prometheus.NewDesc(
 			"nbu_api_version",
 			"The NetBackup API version currently in use",
-			[]string{"version"}, nil,
+			[]string{"site", "version"}, nil,
 		),
 		nbuUp: prometheus.NewDesc(
 			"nbu_up",
 			"1 if NetBackup API is reachable, 0 if all collections failed",
-			nil, nil,
+			[]string{"site"}, nil,
 		),
 		nbuLastScrapeTime: prometheus.NewDesc(
 			"nbu_last_scrape_timestamp_seconds",
 			"Unix timestamp of the last successful metric collection",
-			[]string{"source"}, nil,
+			[]string{"site", "source"}, nil,
 		),
 	}
 
@@ -846,4 +847,56 @@ func TestNbuCollectorHelpStringIncludesTTL(t *testing.T) {
 	if !foundDiskBytes {
 		t.Error("nbu_disk_bytes descriptor not found")
 	}
+}
+
+// TestNbuCollectorNbuUpHasSiteLabel verifies that nbu_up carries a "site" label
+// equal to the configured site name (NbuServers[0].Site after SetDefaults promotion).
+func TestNbuCollectorNbuUpHasSiteLabel(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": []}`))
+	}))
+	defer server.Close()
+
+	serverHost, serverPort, _ := net.SplitHostPort(server.Listener.Addr().String())
+
+	cfg := models.Config{}
+	cfg.Server.Host = "localhost"
+	cfg.Server.Port = "9440"
+	cfg.Server.URI = "/metrics"
+	cfg.Server.ScrapingInterval = "5m"
+	cfg.NbuServer.Scheme = "https"
+	cfg.NbuServer.Host = serverHost
+	cfg.NbuServer.Port = serverPort
+	cfg.NbuServer.APIKey = testAPIKey
+	cfg.NbuServer.APIVersion = models.APIVersion130
+	cfg.NbuServer.InsecureSkipVerify = true
+	// SetDefaults (called inside NewNbuCollector via performVersionDetectionIfNeeded)
+	// promotes NbuServer -> NbuServers[0].Site = serverHost
+
+	collector, err := NewNbuCollector(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	defer func() { _ = collector.Close() }()
+
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(collector))
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	var upFamily *dto.MetricFamily
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "nbu_up" {
+			upFamily = mf
+			break
+		}
+	}
+	require.NotNil(t, upFamily, "nbu_up metric family must be present")
+	require.Len(t, upFamily.GetMetric(), 1, "nbu_up must have exactly one series")
+
+	labels := upFamily.GetMetric()[0].GetLabel()
+	require.Len(t, labels, 1, "nbu_up must carry exactly one label (site)")
+	assert.Equal(t, "site", labels[0].GetName(), "first label must be named 'site'")
+	assert.Equal(t, serverHost, labels[0].GetValue(), "site label value must equal NbuServers[0].Site")
 }

--- a/internal/exporter/snapshot.go
+++ b/internal/exporter/snapshot.go
@@ -3,6 +3,8 @@ package exporter
 import (
 	"sync/atomic"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // SiteSnapshot holds one site's already-aggregated collection results.
@@ -17,6 +19,10 @@ type SiteSnapshot struct {
 	JobAgg            *JobAggregator
 	LastStorageScrape time.Time
 	LastJobsScrape    time.Time
+	// SubMetrics holds the already-built metrics emitted by enabled opt-in
+	// sub-collectors (alerts/malware/catalog/SLO) for this site. They are
+	// buffered at collection time and re-emitted verbatim on each scrape.
+	SubMetrics []prometheus.Metric
 }
 
 // Snapshot is an immutable, point-in-time view across all configured sites.

--- a/internal/exporter/snapshot.go
+++ b/internal/exporter/snapshot.go
@@ -1,0 +1,38 @@
+package exporter
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// SiteSnapshot holds one site's already-aggregated collection results.
+type SiteSnapshot struct {
+	Site              string
+	APIVersion        string
+	Up                bool
+	StorageErr        error
+	JobsErr           error
+	StorageMetrics    []StorageMetricValue
+	StorageUnits      []StorageUnitInfo
+	JobAgg            *JobAggregator
+	LastStorageScrape time.Time
+	LastJobsScrape    time.Time
+}
+
+// Snapshot is an immutable, point-in-time view across all configured sites.
+type Snapshot struct {
+	Sites map[string]*SiteSnapshot
+}
+
+// SnapshotStore holds the latest Snapshot behind an atomic pointer swap, so the
+// background collection loop can publish a new snapshot while scrapes read the
+// previous one without locking.
+type SnapshotStore struct {
+	p atomic.Pointer[Snapshot]
+}
+
+// Store publishes a new snapshot.
+func (s *SnapshotStore) Store(snap *Snapshot) { s.p.Store(snap) }
+
+// Load returns the latest snapshot, or nil if none has been published yet.
+func (s *SnapshotStore) Load() *Snapshot { return s.p.Load() }

--- a/internal/exporter/snapshot_test.go
+++ b/internal/exporter/snapshot_test.go
@@ -1,0 +1,16 @@
+package exporter
+
+import "testing"
+
+func TestSnapshotStoreLoadStore(t *testing.T) {
+	var s SnapshotStore
+	if s.Load() != nil {
+		t.Fatal("zero-value store should Load() nil")
+	}
+	snap := &Snapshot{Sites: map[string]*SiteSnapshot{"paris": {Site: "paris", Up: true}}}
+	s.Store(snap)
+	got := s.Load()
+	if got == nil || got.Sites["paris"] == nil || !got.Sites["paris"].Up {
+		t.Fatal("Load did not return the stored snapshot")
+	}
+}

--- a/internal/exporter/subcollector.go
+++ b/internal/exporter/subcollector.go
@@ -3,11 +3,54 @@ package exporter
 import (
 	"context"
 
+	"github.com/fjacquet/nbu_exporter/internal/models"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
+
+// buildSubCollectorsFor returns the enabled opt-in collectors for one target,
+// each labelled with the given site. Shared by the per-target collection loop
+// and the (single-site) live collector.
+func buildSubCollectorsFor(client NetBackupClient, cfg models.Config, site string) []subCollector {
+	var subs []subCollector
+	if cfg.Collectors.Alerts.Enabled {
+		subs = append(subs, newAlertsCollector(client, cfg, site))
+	}
+	if cfg.Collectors.Malware.Enabled {
+		subs = append(subs, newMalwareCollector(client, cfg, site))
+	}
+	if cfg.Collectors.Catalog.Enabled {
+		subs = append(subs, newCatalogCollector(client, cfg, site))
+	}
+	if cfg.Collectors.SLO.Enabled {
+		subs = append(subs, newSLOCollector(client, cfg, site))
+	}
+	return subs
+}
+
+// collectSubMetrics runs every sub-collector and returns the metrics they emit
+// as a buffered slice, so they can be stored in a snapshot and re-emitted on
+// each scrape. Errors are handled inside runSubCollectors (logged, never fatal).
+func collectSubMetrics(ctx context.Context, collectors []subCollector, tracing *TracerWrapper) []prometheus.Metric {
+	if len(collectors) == 0 {
+		return nil
+	}
+	ch := make(chan prometheus.Metric, 256)
+	done := make(chan struct{})
+	var out []prometheus.Metric
+	go func() {
+		for m := range ch {
+			out = append(out, m)
+		}
+		close(done)
+	}()
+	runSubCollectors(ctx, collectors, ch, tracing)
+	close(ch)
+	<-done
+	return out
+}
 
 // subCollector is an optional, opt-in metric source (alerts, malware, catalog, SLO).
 // Each runs independently; a failure is logged and skipped so other collectors and

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -147,6 +147,16 @@ func (c *Config) SetDefaults() {
 		}
 	}
 
+	// Default each multi-site entry's URI so an omitted uri inherits "/netbackup",
+	// matching the legacy single-server default. This ensures both the per-site
+	// clients and the reverse-map below build a correct base URL (without it,
+	// API calls would drop the /netbackup base path and 404).
+	for i := range c.NbuServers {
+		if c.NbuServers[i].URI == "" {
+			c.NbuServers[i].URI = "/netbackup"
+		}
+	}
+
 	// Reverse-map: when only nbuservers[] is provided (no legacy nbuserver: block),
 	// mirror the primary entry into the legacy NbuServer fields so legacy
 	// single-server code paths (validation, GetNBUBaseURL, telemetry, MaskAPIKey)

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -28,18 +28,40 @@ const (
 // This list is used for version detection fallback (newest to oldest).
 var SupportedAPIVersions = []string{APIVersion140, APIVersion130, APIVersion120, APIVersion100}
 
+// NbuServerConfig holds connection settings for a single NetBackup master server.
+// It mirrors the legacy inline NbuServer struct but adds a Site identifier used
+// by the multi-site feature. The Site field defaults to the Host value when the
+// legacy single nbuserver: block is auto-mapped.
+type NbuServerConfig struct {
+	Site               string `yaml:"site"`
+	Port               string `yaml:"port"`
+	Scheme             string `yaml:"scheme"`
+	URI                string `yaml:"uri"`
+	Domain             string `yaml:"domain"`
+	DomainType         string `yaml:"domainType"`
+	Host               string `yaml:"host"`
+	APIKey             string `yaml:"apiKey"`
+	APIVersion         string `yaml:"apiVersion"`
+	ContentType        string `yaml:"contentType"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+}
+
 // Config represents the complete application configuration for the NBU exporter.
 // It includes settings for the server and the NBU server.
 type Config struct {
 	Server struct {
-		Port             string `yaml:"port"`
-		Host             string `yaml:"host"`
-		URI              string `yaml:"uri"`
-		ScrapingInterval string `yaml:"scrapingInterval"`
-		LogName          string `yaml:"logName"`
-		CacheTTL         string `yaml:"cacheTTL"` // TTL for storage metrics cache (e.g., "5m")
+		Port               string `yaml:"port"`
+		Host               string `yaml:"host"`
+		URI                string `yaml:"uri"`
+		ScrapingInterval   string `yaml:"scrapingInterval"`
+		LogName            string `yaml:"logName"`
+		CacheTTL           string `yaml:"cacheTTL"`           // TTL for storage metrics cache (e.g., "5m")
+		CollectionInterval string `yaml:"collectionInterval"` // How far back to collect job data (e.g., "5m")
 	} `yaml:"server"`
 
+	// NbuServer is the legacy single-server configuration block. It is kept for
+	// backward compatibility and is automatically promoted into NbuServers[0]
+	// during Validate()/SetDefaults() if NbuServers is empty.
 	NbuServer struct {
 		Port               string `yaml:"port"`
 		Scheme             string `yaml:"scheme"`
@@ -52,6 +74,10 @@ type Config struct {
 		ContentType        string `yaml:"contentType"`
 		InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
 	} `yaml:"nbuserver"`
+
+	// NbuServers is the multi-site server list. When empty and NbuServer.Host is
+	// set, SetDefaults() auto-maps the legacy block into this slice.
+	NbuServers []NbuServerConfig `yaml:"nbuservers"`
 
 	OpenTelemetry struct {
 		Enabled      bool    `yaml:"enabled"`
@@ -95,6 +121,31 @@ func (c *Config) SetDefaults() {
 	if c.Server.CacheTTL == "" {
 		c.Server.CacheTTL = "5m"
 	}
+
+	// Set default collection interval (5 minutes)
+	if c.Server.CollectionInterval == "" {
+		c.Server.CollectionInterval = "5m"
+	}
+
+	// Auto-map legacy single nbuserver: block into NbuServers when the list is empty.
+	// deprecated single nbuserver auto-mapped
+	if len(c.NbuServers) == 0 && c.NbuServer.Host != "" {
+		c.NbuServers = []NbuServerConfig{
+			{
+				Site:               c.NbuServer.Host,
+				Port:               c.NbuServer.Port,
+				Scheme:             c.NbuServer.Scheme,
+				URI:                c.NbuServer.URI,
+				Domain:             c.NbuServer.Domain,
+				DomainType:         c.NbuServer.DomainType,
+				Host:               c.NbuServer.Host,
+				APIKey:             c.NbuServer.APIKey,
+				APIVersion:         c.NbuServer.APIVersion,
+				ContentType:        c.NbuServer.ContentType,
+				InsecureSkipVerify: c.NbuServer.InsecureSkipVerify,
+			},
+		}
+	}
 }
 
 // Validate checks if the configuration is valid and returns an error if not.
@@ -120,6 +171,10 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.validateNBUServerConfig(); err != nil {
+		return err
+	}
+
+	if err := c.validateNbuServers(); err != nil {
 		return err
 	}
 
@@ -188,6 +243,43 @@ func (c *Config) validateNBUServerConfig() error {
 	}
 	if c.NbuServer.APIKey == "" {
 		return errors.New("NBU server API key is required")
+	}
+	return nil
+}
+
+// validateNbuServers validates the NbuServers slice: requires at least one entry,
+// each entry must have a non-empty Site and unique Site across the slice, and each
+// entry's connection fields (host/port/scheme/apiKey) must be present and valid.
+func (c *Config) validateNbuServers() error {
+	if len(c.NbuServers) == 0 {
+		return errors.New("at least one entry in nbuservers is required")
+	}
+
+	seen := make(map[string]bool, len(c.NbuServers))
+	for i, s := range c.NbuServers {
+		if s.Site == "" {
+			return fmt.Errorf("nbuservers[%d]: site is required", i)
+		}
+		if seen[s.Site] {
+			return fmt.Errorf("nbuservers: duplicate site name %q", s.Site)
+		}
+		seen[s.Site] = true
+
+		if s.Host == "" {
+			return fmt.Errorf("nbuservers[%d] (%s): host is required", i, s.Site)
+		}
+		if s.Port == "" {
+			return fmt.Errorf("nbuservers[%d] (%s): port is required", i, s.Site)
+		}
+		if err := validatePort(s.Port); err != nil {
+			return fmt.Errorf("nbuservers[%d] (%s): invalid port %s", i, s.Site, s.Port)
+		}
+		if s.Scheme != "http" && s.Scheme != "https" {
+			return fmt.Errorf("nbuservers[%d] (%s): invalid scheme %q (must be http or https)", i, s.Site, s.Scheme)
+		}
+		if s.APIKey == "" {
+			return fmt.Errorf("nbuservers[%d] (%s): apiKey is required", i, s.Site)
+		}
 	}
 	return nil
 }

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -46,6 +46,40 @@ type NbuServerConfig struct {
 	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
 }
 
+// ApplyTo copies this server's connection settings into cfg's legacy NbuServer
+// block. Site is the multi-site identity, tracked separately, so it is not copied.
+// Shared by the reverse-map (Config.SetDefaults) and the per-site collector view.
+func (s NbuServerConfig) ApplyTo(cfg *Config) {
+	cfg.NbuServer.Port = s.Port
+	cfg.NbuServer.Scheme = s.Scheme
+	cfg.NbuServer.URI = s.URI
+	cfg.NbuServer.Domain = s.Domain
+	cfg.NbuServer.DomainType = s.DomainType
+	cfg.NbuServer.Host = s.Host
+	cfg.NbuServer.APIKey = s.APIKey
+	cfg.NbuServer.APIVersion = s.APIVersion
+	cfg.NbuServer.ContentType = s.ContentType
+	cfg.NbuServer.InsecureSkipVerify = s.InsecureSkipVerify
+}
+
+// legacyServerConfig returns the legacy NbuServer block as an NbuServerConfig,
+// defaulting Site to the host. Used when auto-mapping the deprecated single block.
+func (c *Config) legacyServerConfig() NbuServerConfig {
+	return NbuServerConfig{
+		Site:               c.NbuServer.Host,
+		Port:               c.NbuServer.Port,
+		Scheme:             c.NbuServer.Scheme,
+		URI:                c.NbuServer.URI,
+		Domain:             c.NbuServer.Domain,
+		DomainType:         c.NbuServer.DomainType,
+		Host:               c.NbuServer.Host,
+		APIKey:             c.NbuServer.APIKey,
+		APIVersion:         c.NbuServer.APIVersion,
+		ContentType:        c.NbuServer.ContentType,
+		InsecureSkipVerify: c.NbuServer.InsecureSkipVerify,
+	}
+}
+
 // Config represents the complete application configuration for the NBU exporter.
 // It includes settings for the server and the NBU server.
 type Config struct {
@@ -127,24 +161,10 @@ func (c *Config) SetDefaults() {
 		c.Server.CollectionInterval = "5m"
 	}
 
-	// Auto-map legacy single nbuserver: block into NbuServers when the list is empty.
-	// deprecated single nbuserver auto-mapped
+	// Auto-map a deprecated single nbuserver: block into NbuServers when the list
+	// is empty (site defaults to the host).
 	if len(c.NbuServers) == 0 && c.NbuServer.Host != "" {
-		c.NbuServers = []NbuServerConfig{
-			{
-				Site:               c.NbuServer.Host,
-				Port:               c.NbuServer.Port,
-				Scheme:             c.NbuServer.Scheme,
-				URI:                c.NbuServer.URI,
-				Domain:             c.NbuServer.Domain,
-				DomainType:         c.NbuServer.DomainType,
-				Host:               c.NbuServer.Host,
-				APIKey:             c.NbuServer.APIKey,
-				APIVersion:         c.NbuServer.APIVersion,
-				ContentType:        c.NbuServer.ContentType,
-				InsecureSkipVerify: c.NbuServer.InsecureSkipVerify,
-			},
-		}
+		c.NbuServers = []NbuServerConfig{c.legacyServerConfig()}
 	}
 
 	// Default each multi-site entry's URI so an omitted uri inherits "/netbackup",
@@ -162,17 +182,7 @@ func (c *Config) SetDefaults() {
 	// single-server code paths (validation, GetNBUBaseURL, telemetry, MaskAPIKey)
 	// operate on the primary site.
 	if c.NbuServer.Host == "" && len(c.NbuServers) > 0 {
-		first := c.NbuServers[0]
-		c.NbuServer.Port = first.Port
-		c.NbuServer.Scheme = first.Scheme
-		c.NbuServer.URI = first.URI
-		c.NbuServer.Domain = first.Domain
-		c.NbuServer.DomainType = first.DomainType
-		c.NbuServer.Host = first.Host
-		c.NbuServer.APIKey = first.APIKey
-		c.NbuServer.APIVersion = first.APIVersion
-		c.NbuServer.ContentType = first.ContentType
-		c.NbuServer.InsecureSkipVerify = first.InsecureSkipVerify
+		c.NbuServers[0].ApplyTo(c)
 	}
 }
 

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -56,7 +56,7 @@ type Config struct {
 		ScrapingInterval   string `yaml:"scrapingInterval"`
 		LogName            string `yaml:"logName"`
 		CacheTTL           string `yaml:"cacheTTL"`           // TTL for storage metrics cache (e.g., "5m")
-		CollectionInterval string `yaml:"collectionInterval"` // How far back to collect job data (e.g., "5m")
+		CollectionInterval string `yaml:"collectionInterval"` // Background collection loop poll interval (e.g., "5m")
 	} `yaml:"server"`
 
 	// NbuServer is the legacy single-server configuration block. It is kept for
@@ -145,6 +145,24 @@ func (c *Config) SetDefaults() {
 				InsecureSkipVerify: c.NbuServer.InsecureSkipVerify,
 			},
 		}
+	}
+
+	// Reverse-map: when only nbuservers[] is provided (no legacy nbuserver: block),
+	// mirror the primary entry into the legacy NbuServer fields so legacy
+	// single-server code paths (validation, GetNBUBaseURL, telemetry, MaskAPIKey)
+	// operate on the primary site.
+	if c.NbuServer.Host == "" && len(c.NbuServers) > 0 {
+		first := c.NbuServers[0]
+		c.NbuServer.Port = first.Port
+		c.NbuServer.Scheme = first.Scheme
+		c.NbuServer.URI = first.URI
+		c.NbuServer.Domain = first.Domain
+		c.NbuServer.DomainType = first.DomainType
+		c.NbuServer.Host = first.Host
+		c.NbuServer.APIKey = first.APIKey
+		c.NbuServer.APIVersion = first.APIVersion
+		c.NbuServer.ContentType = first.ContentType
+		c.NbuServer.InsecureSkipVerify = first.InsecureSkipVerify
 	}
 }
 
@@ -471,6 +489,24 @@ func (c *Config) GetCacheTTL() time.Duration {
 		return 5 * time.Minute
 	}
 	duration, err := time.ParseDuration(c.Server.CacheTTL)
+	if err != nil {
+		return 5 * time.Minute
+	}
+	return duration
+}
+
+// GetCollectionInterval parses and returns the background collection loop poll
+// interval as a time.Duration. Returns 5 minutes if unset or unparseable.
+//
+// This is how often the snapshot collection loop polls every configured site;
+// it decouples backend API load from Prometheus scrape frequency.
+//
+// Example: "5m" -> 5 * time.Minute
+func (c *Config) GetCollectionInterval() time.Duration {
+	if c.Server.CollectionInterval == "" {
+		return 5 * time.Minute
+	}
+	duration, err := time.ParseDuration(c.Server.CollectionInterval)
 	if err != nil {
 		return 5 * time.Minute
 	}

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -1935,6 +1935,31 @@ func TestConfigPureMultiSiteValidates(t *testing.T) {
 	}
 }
 
+// TestConfigMultiSiteDefaultsURI verifies that a multi-site entry omitting `uri`
+// inherits the default "/netbackup" (so per-site clients build correct URLs and
+// the reverse-map does not clobber it).
+func TestConfigMultiSiteDefaultsURI(t *testing.T) {
+	cfg := &Config{}
+	cfg.Server.Port = "9440"
+	cfg.Server.Host = "localhost"
+	cfg.Server.URI = testPathMetrics
+	cfg.Server.ScrapingInterval = "5m"
+	cfg.NbuServers = []NbuServerConfig{
+		// no uri specified -> must default to /netbackup
+		{Site: "paris", Host: "nbu-paris", Port: "1556", Scheme: "https", APIKey: "k1", APIVersion: "13.0"},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config should validate: %v", err)
+	}
+	if cfg.NbuServers[0].URI != "/netbackup" {
+		t.Errorf("NbuServers[0].URI = %q, want /netbackup (default)", cfg.NbuServers[0].URI)
+	}
+	if cfg.NbuServer.URI != "/netbackup" {
+		t.Errorf("NbuServer.URI = %q, want /netbackup (reverse-mapped default)", cfg.NbuServer.URI)
+	}
+}
+
 // TestGetCollectionInterval verifies parsing, default, and fallback behaviour.
 func TestGetCollectionInterval(t *testing.T) {
 	cfg := &Config{}

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -91,12 +91,13 @@ func TestSetDefaults_PreservesEmptyAPIVersionForAutoDetection(t *testing.T) {
 func createConfigWithAPIVersion(apiVersion string) *Config {
 	return &Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -510,12 +511,13 @@ func TestConfigGetServerAddress(t *testing.T) {
 			name: "standard server address",
 			config: Config{
 				Server: struct {
-					Port             string `yaml:"port"`
-					Host             string `yaml:"host"`
-					URI              string `yaml:"uri"`
-					ScrapingInterval string `yaml:"scrapingInterval"`
-					LogName          string `yaml:"logName"`
-					CacheTTL         string `yaml:"cacheTTL"`
+					Port               string `yaml:"port"`
+					Host               string `yaml:"host"`
+					URI                string `yaml:"uri"`
+					ScrapingInterval   string `yaml:"scrapingInterval"`
+					LogName            string `yaml:"logName"`
+					CacheTTL           string `yaml:"cacheTTL"`
+					CollectionInterval string `yaml:"collectionInterval"`
 				}{
 					Host: "0.0.0.0",
 					Port: "9440",
@@ -527,12 +529,13 @@ func TestConfigGetServerAddress(t *testing.T) {
 			name: "localhost with custom port",
 			config: Config{
 				Server: struct {
-					Port             string `yaml:"port"`
-					Host             string `yaml:"host"`
-					URI              string `yaml:"uri"`
-					ScrapingInterval string `yaml:"scrapingInterval"`
-					LogName          string `yaml:"logName"`
-					CacheTTL         string `yaml:"cacheTTL"`
+					Port               string `yaml:"port"`
+					Host               string `yaml:"host"`
+					URI                string `yaml:"uri"`
+					ScrapingInterval   string `yaml:"scrapingInterval"`
+					LogName            string `yaml:"logName"`
+					CacheTTL           string `yaml:"cacheTTL"`
+					CollectionInterval string `yaml:"collectionInterval"`
 				}{
 					Host: "localhost",
 					Port: "9090",
@@ -556,12 +559,13 @@ func TestConfigGetServerAddress(t *testing.T) {
 func createConfigWithInterval(interval string) Config {
 	return Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			ScrapingInterval: interval,
 		},
@@ -788,12 +792,13 @@ func TestConfigValidateServerFields(t *testing.T) {
 	baseConfig := func() Config {
 		return Config{
 			Server: struct {
-				Port             string `yaml:"port"`
-				Host             string `yaml:"host"`
-				URI              string `yaml:"uri"`
-				ScrapingInterval string `yaml:"scrapingInterval"`
-				LogName          string `yaml:"logName"`
-				CacheTTL         string `yaml:"cacheTTL"`
+				Port               string `yaml:"port"`
+				Host               string `yaml:"host"`
+				URI                string `yaml:"uri"`
+				ScrapingInterval   string `yaml:"scrapingInterval"`
+				LogName            string `yaml:"logName"`
+				CacheTTL           string `yaml:"cacheTTL"`
+				CollectionInterval string `yaml:"collectionInterval"`
 			}{
 				Port:             "9440",
 				Host:             "localhost",
@@ -1026,12 +1031,13 @@ func TestConfigValidateSupportedVersions(t *testing.T) {
 func createBaseTestConfig() Config {
 	return Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Port:             "9440",
 			Host:             "localhost",
@@ -1267,12 +1273,13 @@ func TestConfigValidateOTelEndpoint(t *testing.T) {
 	baseConfig := func() Config {
 		return Config{
 			Server: struct {
-				Port             string `yaml:"port"`
-				Host             string `yaml:"host"`
-				URI              string `yaml:"uri"`
-				ScrapingInterval string `yaml:"scrapingInterval"`
-				LogName          string `yaml:"logName"`
-				CacheTTL         string `yaml:"cacheTTL"`
+				Port               string `yaml:"port"`
+				Host               string `yaml:"host"`
+				URI                string `yaml:"uri"`
+				ScrapingInterval   string `yaml:"scrapingInterval"`
+				LogName            string `yaml:"logName"`
+				CacheTTL           string `yaml:"cacheTTL"`
+				CollectionInterval string `yaml:"collectionInterval"`
 			}{
 				Port:             "9440",
 				Host:             "localhost",
@@ -1837,5 +1844,68 @@ func TestCollectorsConfigDefaults(t *testing.T) {
 	if c.Collectors.Alerts.Enabled || c.Collectors.Malware.Enabled ||
 		c.Collectors.Catalog.Enabled || c.Collectors.SLO.Enabled {
 		t.Errorf("new collectors must default to disabled, got %+v", c.Collectors)
+	}
+}
+
+// TestConfigNbuServersAutoMapLegacy verifies that a single legacy nbuserver block is
+// automatically promoted into NbuServers[0] with Site set to the host name.
+func TestConfigNbuServersAutoMapLegacy(t *testing.T) {
+	cfg := createConfigWithAPIVersion("13.0")
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+
+	if len(cfg.NbuServers) != 1 {
+		t.Fatalf("expected len(NbuServers)==1, got %d", len(cfg.NbuServers))
+	}
+
+	if cfg.NbuServers[0].Site != cfg.NbuServer.Host {
+		t.Errorf("NbuServers[0].Site = %q, want %q (NbuServer.Host)", cfg.NbuServers[0].Site, cfg.NbuServer.Host)
+	}
+}
+
+// TestConfigNbuServersRequireUniqueSite verifies that duplicate Site values in
+// NbuServers produce a validation error.
+func TestConfigNbuServersRequireUniqueSite(t *testing.T) {
+	cfg := createConfigWithAPIVersion("13.0")
+	cfg.NbuServers = []NbuServerConfig{
+		{
+			Site:       "paris",
+			Host:       testServerNBUMaster,
+			Port:       "1556",
+			Scheme:     "https",
+			URI:        testPathNetBackup,
+			APIKey:     testKeyName,
+			APIVersion: "13.0",
+		},
+		{
+			Site:       "paris", // duplicate
+			Host:       testServerNBUMaster,
+			Port:       "1556",
+			Scheme:     "https",
+			URI:        testPathNetBackup,
+			APIKey:     testKeyName,
+			APIVersion: "13.0",
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("Validate() expected error for duplicate Site names, got nil")
+	} else if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("Validate() error = %q, want error containing 'duplicate'", err.Error())
+	}
+}
+
+// TestConfigCollectionIntervalDefault verifies that SetDefaults populates
+// Server.CollectionInterval with "5m" when not set.
+func TestConfigCollectionIntervalDefault(t *testing.T) {
+	cfg := &Config{}
+
+	cfg.SetDefaults()
+
+	if cfg.Server.CollectionInterval != "5m" {
+		t.Errorf("SetDefaults() CollectionInterval = %q, want %q", cfg.Server.CollectionInterval, "5m")
 	}
 }

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -1909,3 +1909,46 @@ func TestConfigCollectionIntervalDefault(t *testing.T) {
 		t.Errorf("SetDefaults() CollectionInterval = %q, want %q", cfg.Server.CollectionInterval, "5m")
 	}
 }
+
+// TestConfigPureMultiSiteValidates verifies that a config providing only the
+// nbuservers[] list (no legacy nbuserver: block) validates, and that the legacy
+// NbuServer fields are mirrored from the primary entry for legacy code paths.
+func TestConfigPureMultiSiteValidates(t *testing.T) {
+	cfg := &Config{}
+	cfg.Server.Port = "9440"
+	cfg.Server.Host = "localhost"
+	cfg.Server.URI = testPathMetrics
+	cfg.Server.ScrapingInterval = "5m"
+	cfg.NbuServers = []NbuServerConfig{
+		{Site: "paris", Host: "nbu-paris", Port: "1556", Scheme: "https", URI: testPathNetBackup, APIKey: "k1", APIVersion: "13.0"},
+		{Site: "lyon", Host: "nbu-lyon", Port: "1556", Scheme: "https", URI: testPathNetBackup, APIKey: "k2", APIVersion: "13.0"},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("pure multi-site config should validate, got: %v", err)
+	}
+	if cfg.NbuServer.Host != "nbu-paris" {
+		t.Errorf("NbuServer.Host = %q, want nbu-paris (mirrored from NbuServers[0])", cfg.NbuServer.Host)
+	}
+	if len(cfg.NbuServers) != 2 {
+		t.Errorf("len(NbuServers) = %d, want 2 (list preserved)", len(cfg.NbuServers))
+	}
+}
+
+// TestGetCollectionInterval verifies parsing, default, and fallback behaviour.
+func TestGetCollectionInterval(t *testing.T) {
+	cfg := &Config{}
+	if got := cfg.GetCollectionInterval(); got != 5*time.Minute {
+		t.Errorf("default GetCollectionInterval() = %v, want 5m", got)
+	}
+
+	cfg.Server.CollectionInterval = "10m"
+	if got := cfg.GetCollectionInterval(); got != 10*time.Minute {
+		t.Errorf("GetCollectionInterval() = %v, want 10m", got)
+	}
+
+	cfg.Server.CollectionInterval = "not-a-duration"
+	if got := cfg.GetCollectionInterval(); got != 5*time.Minute {
+		t.Errorf("invalid GetCollectionInterval() = %v, want 5m fallback", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -83,18 +83,18 @@ var (
 //
 //	server.Shutdown()
 type Server struct {
-	cfg              *models.SafeConfig     // Thread-safe config wrapper
-	configPath       string                 // Path to config file (for reload)
-	apiTrace         bool                   // Log NetBackup API response bodies (--trace flag)
-	httpSrv          *http.Server           // HTTP server instance
-	registry         *prometheus.Registry   // Prometheus metrics registry
-	telemetryManager *telemetry.Manager     // OpenTelemetry telemetry manager (nil if disabled)
-	collector        *exporter.NbuCollector // Snapshot-reading collector (for cleanup)
+	cfg              *models.SafeConfig       // Thread-safe config wrapper
+	configPath       string                   // Path to config file (for reload)
+	apiTrace         bool                     // Log NetBackup API response bodies (--trace flag)
+	httpSrv          *http.Server             // HTTP server instance
+	registry         *prometheus.Registry     // Prometheus metrics registry
+	telemetryManager *telemetry.Manager       // OpenTelemetry telemetry manager (nil if disabled)
+	collector        *exporter.NbuCollector   // Snapshot-reading collector (for cleanup)
 	store            *exporter.SnapshotStore  // Latest per-site snapshot, published by the loop
 	loop             *exporter.CollectionLoop // Background per-site collection loop
 	loopCancel       context.CancelFunc       // Cancels the collection loop on shutdown
 	loopDone         chan struct{}            // Closed when the loop goroutine returns
-	configWatcher    *fsnotify.Watcher      // File watcher for config reload (for cleanup)
+	configWatcher    *fsnotify.Watcher        // File watcher for config reload (for cleanup)
 	// serverErrChan receives HTTP server errors. It is buffered (capacity 1)
 	// to ensure the goroutine can send an error even if the main select
 	// hasn't started listening yet (race between Start() return and select).

--- a/main.go
+++ b/main.go
@@ -225,6 +225,13 @@ func (s *Server) Start() error {
 
 	// Register collector with Prometheus
 	if err := s.registry.Register(collector); err != nil {
+		// Registration failed after the loop goroutine started: stop and drain it
+		// (and close per-site clients) so we don't leak background work. main()
+		// returns on Start() error without calling Shutdown(), so do it here.
+		s.loopCancel()
+		<-s.loopDone
+		_ = s.loop.Close()
+		_ = collector.Close()
 		return fmt.Errorf("failed to register collector: %w", err)
 	}
 
@@ -473,6 +480,12 @@ func validateConfig(configPath string) (*models.Config, error) {
 	var cfg models.Config
 	if err := utils.ReadFile(&cfg, configPath); err != nil {
 		return nil, err
+	}
+
+	// Detect legacy single-server usage before Validate() promotes it into
+	// NbuServers[0], and warn the operator to migrate to the nbuservers[] list.
+	if cfg.NbuServer.Host != "" && len(cfg.NbuServers) == 0 {
+		log.Warn("config: the single 'nbuserver:' block is deprecated and auto-mapped to a one-site 'nbuservers:' list; migrate to 'nbuservers:' (see docs/config-examples/config-multisite.yaml)")
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/main.go
+++ b/main.go
@@ -89,7 +89,11 @@ type Server struct {
 	httpSrv          *http.Server           // HTTP server instance
 	registry         *prometheus.Registry   // Prometheus metrics registry
 	telemetryManager *telemetry.Manager     // OpenTelemetry telemetry manager (nil if disabled)
-	collector        *exporter.NbuCollector // NetBackup collector (for cleanup)
+	collector        *exporter.NbuCollector // Snapshot-reading collector (for cleanup)
+	store            *exporter.SnapshotStore  // Latest per-site snapshot, published by the loop
+	loop             *exporter.CollectionLoop // Background per-site collection loop
+	loopCancel       context.CancelFunc       // Cancels the collection loop on shutdown
+	loopDone         chan struct{}            // Closed when the loop goroutine returns
 	configWatcher    *fsnotify.Watcher      // File watcher for config reload (for cleanup)
 	// serverErrChan receives HTTP server errors. It is buffered (capacity 1)
 	// to ensure the goroutine can send an error even if the main select
@@ -183,10 +187,38 @@ func (s *Server) Start() error {
 		log.Info("API trace enabled: logging every NetBackup API response body (bodies only, never headers)")
 	}
 
-	collector, err := exporter.NewNbuCollector(*cfg, collectorOpts...)
-	if err != nil {
-		return fmt.Errorf("failed to create collector: %w", err)
+	// Build one collection target per configured site (nbuservers[]). Each target
+	// owns its own client + version detection, built lazily so a single
+	// unreachable site never blocks startup.
+	var targetOpts []exporter.TargetOption
+	if tracerProvider != nil {
+		targetOpts = append(targetOpts, exporter.WithTargetTracerProvider(tracerProvider))
 	}
+	if s.apiTrace {
+		targetOpts = append(targetOpts, exporter.WithTargetAPITrace(true))
+	}
+	targets := make([]*exporter.TargetCollector, 0, len(cfg.NbuServers))
+	for _, entry := range cfg.NbuServers {
+		targets = append(targets, exporter.NewTargetCollector(*cfg, entry, targetOpts...))
+	}
+
+	// Start the background collection loop: it polls every site on
+	// collectionInterval and publishes an immutable snapshot into the store.
+	s.store = &exporter.SnapshotStore{}
+	s.loop = exporter.NewCollectionLoop(targets, s.store, cfg.GetCollectionInterval())
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	s.loopCancel = loopCancel
+	s.loopDone = make(chan struct{})
+	go func() {
+		defer close(s.loopDone)
+		s.loop.Run(loopCtx)
+	}()
+	log.Infof("Collecting %d NetBackup site(s) every %s", len(targets), cfg.GetCollectionInterval())
+
+	// The registered collector reads the latest snapshot; it never fetches on
+	// scrape, so /metrics serves immediately (empty until the first cycle).
+	collector := exporter.NewSnapshotCollector(*cfg, s.store, collectorOpts...)
 
 	// Store collector reference for shutdown cleanup
 	s.collector = collector
@@ -252,11 +284,16 @@ func (s *Server) ReloadConfig(configPath string) error {
 		return err
 	}
 
-	// Flush cache if NBU server address changed
-	if serverChanged && s.collector != nil {
-		if cache := s.collector.GetStorageCache(); cache != nil {
-			cache.Flush()
-			log.Info("Storage cache flushed due to server address change")
+	// The background collection loop's targets are built once at startup, so a
+	// changed NBU server configuration needs a restart to take effect. Surface
+	// that instead of silently ignoring the change.
+	if serverChanged {
+		log.Warn("NBU server configuration changed; restart the exporter to apply it to the collection loop (live target rebuild is not yet supported)")
+		if s.collector != nil {
+			if cache := s.collector.GetStorageCache(); cache != nil {
+				cache.Flush()
+				log.Info("Storage cache flushed due to server address change")
+			}
 		}
 	}
 
@@ -314,6 +351,16 @@ func (s *Server) Shutdown() error {
 		}
 	}
 
+	// Step 1b: Stop the background collection loop and wait for it to finish, so
+	// no collection is in flight before telemetry flush and client close.
+	if s.loopCancel != nil {
+		log.Info("Stopping collection loop...")
+		s.loopCancel()
+		if s.loopDone != nil {
+			<-s.loopDone
+		}
+	}
+
 	// Step 2: Shutdown OpenTelemetry (flush pending spans)
 	if s.telemetryManager != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
@@ -326,9 +373,16 @@ func (s *Server) Shutdown() error {
 		}
 	}
 
-	// Step 3: Close collector (drains API connections)
+	// Step 3: Close per-site collection clients (drains API connections)
+	if s.loop != nil {
+		log.Info("Closing collection clients...")
+		if err := s.loop.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("collection loop close: %w", err))
+		}
+	}
+
+	// Step 4: Close collector (snapshot reader holds no client; symmetry/safety)
 	if s.collector != nil {
-		log.Info("Closing collector connections...")
 		if err := s.collector.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("collector close: %w", err))
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -34,12 +34,13 @@ func testdataPath(t *testing.T, filename string) string {
 func createTestConfig() models.Config {
 	return models.Config{
 		Server: struct {
-			Port             string `yaml:"port"`
-			Host             string `yaml:"host"`
-			URI              string `yaml:"uri"`
-			ScrapingInterval string `yaml:"scrapingInterval"`
-			LogName          string `yaml:"logName"`
-			CacheTTL         string `yaml:"cacheTTL"`
+			Port               string `yaml:"port"`
+			Host               string `yaml:"host"`
+			URI                string `yaml:"uri"`
+			ScrapingInterval   string `yaml:"scrapingInterval"`
+			LogName            string `yaml:"logName"`
+			CacheTTL           string `yaml:"cacheTTL"`
+			CollectionInterval string `yaml:"collectionInterval"`
 		}{
 			Host:             "127.0.0.1",
 			Port:             "0", // Let OS assign port


### PR DESCRIPTION
## Summary

Adds **multi-site** support: a single exporter scrapes multiple NetBackup primary servers (one per site) via a `nbuservers:` list, labelling every metric with `site`. Collection adopts the exporter family's canonical **snapshot model** ([ADR-0004](docs/adr/0004-multisite-snapshot-collection-model.md)): a background loop polls every site on `server.collectionInterval` (default 5m) and atomic-swaps an immutable snapshot; Prometheus scrapes read the snapshot, so backend API load is decoupled from scrape frequency.

- `nbuservers:` array with a unique `site` per entry + `server.collectionInterval`. A legacy single `nbuserver:` block auto-maps to a one-entry list (`site` defaults to host) — existing configs keep working unchanged.
- `site` is the **first** label on every series (core metrics **and** opt-in alerts/malware/catalog/SLO sub-collectors, which now run per-site).
- Per-site graceful degradation: a down site emits only `nbu_up{site=…}=0` and never aborts the cycle or affects other sites.
- Serve `/metrics` before the first collection completes (empty until then); job lookback window = `max(scrapingInterval, collectionInterval)` so polls leave no coverage gaps.
- OpenTelemetry + `--trace` threaded into per-site clients; shutdown stops the loop, waits for it, then drains clients.
- Docs: `docs/config-examples/config-multisite.yaml`, config-examples README, root README, CHANGELOG, ADR-0004 (→ Accepted/implemented).

## Test plan
- [x] `make ci` green: `go vet`, `golangci-lint` (0 issues), `go test -race`, `govulncheck` (no vulns), **84.7%** total coverage (≥ 70% gate)
- [x] New tests: snapshot collector emits all sites; per-target sub-metric buffering; pure multi-site config + per-entry URI default; job-window coupling
- [x] Live smoke test: two-site config against unreachable hosts → `/metrics` + `/health` served *before* first snapshot, then `nbu_up{site=…}=0` and `nbu_api_version{site=…}` per site
- [x] Fresh-eyes code review; findings addressed (per-entry URI default bug; target-client mutex)
- No metric renamed; only `site` added. Storage offset + jobs cursor pagination unchanged.

## Follow-up (not in this PR)
The legacy single-target live-fetch `NbuCollector` path is now production-dead (main uses only the snapshot path) but retained so existing tests stay green. Retiring it — migrating those tests onto `TargetCollector` + the snapshot reader — is a sizable, separable change best done as a focused follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-site support: Run a single exporter instance to monitor multiple NetBackup primary servers with per-site metric labeling.
  * Background snapshot collection: Configurable polling interval (default 5 minutes) with immutable data snapshots.
  * Graceful degradation: When one site is unavailable, others continue reporting; individual site health shown via `nbu_up{site=...}`.

* **Bug Fixes**
  * Corrected NetBackup API version detection to support versions 10.0, 12.0, 13.0, and 14.0.
  * Fixed jobs endpoint pagination to use cursor-based model.

* **Documentation**
  * Added multi-site configuration examples and architecture decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->