### PR TITLE
docs: document multi-site in the published MkDocs site

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -33,6 +33,45 @@ nbuserver:
 !!! warning
     Never commit API keys to version control. Use environment variables or secure secret management.
 
+## Multiple Sites
+
+To monitor more than one NetBackup primary server from a single exporter, replace the single
+`nbuserver:` block with a `nbuservers:` list — one entry per site, each with a **required, unique
+`site`**. Every metric is then labelled with its `site`, and a background loop collects all sites
+on `server.collectionInterval` (default `5m`), so backend API load is decoupled from Prometheus
+scrape frequency.
+
+```yaml
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    collectionInterval: "5m"   # how often every site is polled (default 5m)
+    logName: "log/nbu-exporter.log"
+
+nbuservers:
+    - site: "paris"
+      scheme: "https"
+      uri: "/netbackup"
+      host: "nbu-paris.my.domain"
+      port: "1556"
+      apiVersion: "13.0"        # optional; omit to auto-detect
+      apiKey: "your-paris-api-key"
+      insecureSkipVerify: false
+    - site: "lyon"
+      scheme: "https"
+      uri: "/netbackup"
+      host: "nbu-lyon.my.domain"
+      port: "1556"
+      apiKey: "your-lyon-api-key"
+```
+
+An unreachable site reports only `nbu_up{site="..."}=0` and never affects the others. A legacy
+single `nbuserver:` block is automatically mapped to a one-entry list (with `site` defaulting to
+the host), so existing single-site configurations keep working unchanged. See
+[`config-multisite.yaml`](../config-examples/config-multisite.yaml).
+
 ## Environment Variables / .env loading
 
 The `host` and `apiKey` fields in the `nbuserver` section support `${VAR}` interpolation.
@@ -60,19 +99,19 @@ nbuserver:
 The `NBU1_*` variables are passed into the container by `docker-compose.yml` from the `.env`
 file automatically.
 
-**Multi-server** — `config.yaml` is the source of truth. Add one `nbuserver` entry per cluster
-and supply literal values or your own env references:
+**Multi-site** — use the `nbuservers:` list (see [Multiple Sites](#multiple-sites) above). Each
+entry's `host` and `apiKey` support the same `${VAR}` interpolation:
 
 ```yaml
-# Cluster A
-nbuserver:
-  host: "nbu-a.example.com"
-  apiKey: "literal-key-a"
-
-# Cluster B (env-interpolated)
-nbuserver:
-  host: "${NBU_B_HOST}"
-  apiKey: "${NBU_B_KEY}"
+nbuservers:
+  - site: "paris"
+    host: "${NBU_PARIS_HOST}"
+    apiKey: "${NBU_PARIS_KEY}"
+    # ...
+  - site: "lyon"
+    host: "${NBU_LYON_HOST}"
+    apiKey: "${NBU_LYON_KEY}"
+    # ...
 ```
 
 The `.env` / `NBU1_*` naming is a single-server convenience; there is no limit on variable names.
@@ -84,10 +123,14 @@ The `.env` / `NBU1_*` naming is a single-server convenience; there is no limit o
 | `host` | string | Yes | Server bind address |
 | `port` | string | Yes | Server port (1-65535) |
 | `uri` | string | Yes | Metrics endpoint path |
-| `scrapingInterval` | duration | Yes | Time window for job collection (e.g., "1h", "30m") |
+| `scrapingInterval` | duration | Yes | Job lookback window per collection (e.g., "1h", "30m") |
+| `collectionInterval` | duration | No | Background poll interval for every site (default "5m"). Effective job window = max(scrapingInterval, collectionInterval). |
 | `logName` | string | Yes | Log file path |
 
 ## NBU Server Section
+
+For multiple servers, use a `nbuservers:` list instead of this single block — each entry takes
+the same fields plus a required, unique `site` (see [Multiple Sites](#multiple-sites)).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -97,7 +140,7 @@ The `.env` / `NBU1_*` naming is a single-server convenience; there is no limit o
 | `domainType` | string | Yes | Domain type (NT, vx, etc.) |
 | `host` | string | Yes | NetBackup master server hostname |
 | `port` | string | Yes | API port (typically 1556) |
-| `apiVersion` | string | No | API version (13.0, 12.0, or 3.0). Auto-detects if omitted. |
+| `apiVersion` | string | No | API version (14.0, 13.0, 12.0, or 10.0). Auto-detects if omitted. |
 | `apiKey` | string | Yes | NetBackup API key |
 | `contentType` | string | Yes | API content type header |
 | `insecureSkipVerify` | bool | No | Skip TLS certificate verification |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,10 @@ A production-ready Prometheus exporter that collects backup job statistics and s
 
 - **Job Metrics Collection** - Aggregates backup job statistics by type, policy, and status
 - **Storage Monitoring** - Tracks storage unit capacity (free/used bytes) for disk-based storage
+- **Multi-Site** - Scrape multiple NetBackup primary servers from one exporter, with every metric labelled by `site` (background snapshot collection)
 - **Prometheus Integration** - Native Prometheus metrics exposition via HTTP endpoint
 - **OpenTelemetry Tracing** - Optional distributed tracing for performance analysis and troubleshooting
-- **Multi-Version API Support** - Automatic detection of NetBackup API versions (3.0, 12.0, 13.0)
+- **Multi-Version API Support** - Automatic detection of NetBackup API versions (14.0, 13.0, 12.0, 10.0)
 - **Health Checks** - Built-in `/health` endpoint for monitoring exporter status
 - **Graceful Shutdown** - Proper signal handling with configurable shutdown timeout
 - **Security** - Configurable TLS verification, API key masking in logs
@@ -35,11 +36,12 @@ See the [Installation guide](getting-started/installation.md) for full details.
 
 | NetBackup Version | API Version | Support Status |
 |-------------------|-------------|----------------|
-| 11.0+             | 13.0        | Fully Supported |
+| 11.2              | 14.0        | Fully Supported |
+| 11.0 - 11.1       | 13.0        | Fully Supported |
 | 10.5              | 12.0        | Fully Supported |
-| 10.0 - 10.4       | 3.0         | Legacy Support |
+| 10.0 - 10.4       | 10.0        | Fully Supported |
 
-The exporter automatically detects the highest supported API version (13.0 -> 12.0 -> 3.0).
+The exporter automatically detects the highest supported API version (14.0 -> 13.0 -> 12.0 -> 10.0).
 
 ## Metrics at a Glance
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,5 +1,11 @@
 # Metrics Reference
 
+!!! info "The `site` label"
+    **Every metric below also carries a `site` label** — its first label — identifying the
+    NetBackup primary it came from. Single-site deployments have one `site` value; a
+    `nbuservers:` list produces one per configured site. The per-metric tables list only the
+    *additional* labels, so a `—` in the Labels column means the series carries `site` only.
+
 ## Job Metrics
 
 | Metric | Labels | Description |
@@ -90,7 +96,7 @@ collectors:
 | Metric | Labels | Description |
 |--------|--------|-------------|
 | `nbu_up` | — | `1` if any collection succeeded, `0` if all collections failed |
-| `nbu_api_version` | `version` | Currently active NetBackup API version (14.0, 13.0, 12.0, or 3.0) |
+| `nbu_api_version` | `version` | Currently active NetBackup API version (14.0, 13.0, 12.0, or 10.0) |
 | `nbu_response_time_ms` | — | NetBackup API response time in milliseconds |
 | `nbu_last_scrape_timestamp_seconds` | `source` | Unix timestamp of the last successful collection (`source`: `storage` or `jobs`) |
 
@@ -100,6 +106,9 @@ Metrics use pipe-delimited keys internally, split into labels:
 
 - **Storage**: `name|type|size` (e.g., "pool1|AdvancedDisk|free")
 - **Jobs**: `action|policy_type|status` (e.g., "BACKUP|Standard|0")
+
+The `site` label is prepended at emission time (it is not part of these internal keys), so every
+emitted series is `site` followed by the labels above.
 
 ## Prometheus Configuration
 


### PR DESCRIPTION
## Summary

Feature 1 (multi-site, #36) updated the repo-side docs (config examples, README, CHANGELOG, ADR-0004) but the **published MkDocs site** still described single-server only. This brings the published pages current.

- **`getting-started/configuration.md`**: new **Multiple Sites** section (`nbuservers:` list, required unique `site`, `collectionInterval`, legacy auto-map, down-site behavior); added `collectionInterval` to the Server table; **replaced the old "Multi-server" block that showed invalid duplicate `nbuserver:` keys** with correct `nbuservers:` guidance.
- **`metrics.md`**: prominent note that **every series carries a `site` label** (first); clarified internal pipe-key vs. emitted labels.
- **`index.md`**: added **Multi-Site** to Features.
- Fixed stale **`3.0`** API-version references → the real `14.0 / 13.0 / 12.0 / 10.0` ladder (ADR-0003) across all three pages, including the version-support matrix.

## Test plan
- [x] `mkdocs build` (non-strict, matching `static.yml`'s `gh-deploy`) — the three edited pages add **no** warnings; new links (`config-multisite.yaml`, `#multiple-sites` anchor) resolve.
- [x] Docs-only change; no code touched.

Note: the strict build surfaces ~12 **pre-existing** broken-link warnings in other pages (`changelog.md`, `api-10.5-migration.md`, `deployment-verification.md`, …) — unrelated to this PR; left for a separate doc-hygiene pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added multi-site configuration guidance with automatic legacy config mapping
  * Updated API version compatibility matrix with supported versions 14.0, 13.0, 12.0, and 10.0
  * Clarified collection and scraping interval configuration parameters
  * Enhanced metrics documentation to clarify site labeling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->