### PR TITLE
docs: fix broken MkDocs links + stale 3.0 API-version refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the others. A legacy single `nbuserver:` block is auto-mapped to a one-entry list (`site`
   defaults to the host), so existing configs keep working unchanged. Opt-in sub-collectors
   (alerts/malware/catalog/SLO) are per-site and carry the `site` label too. See
-  [ADR-0004](docs/adr/0004-multisite-snapshot-collection-model.md) and
+  [ADR-0004](https://github.com/fjacquet/nbu_exporter/blob/main/docs/adr/0004-multisite-snapshot-collection-model.md) and
   `docs/config-examples/config-multisite.yaml`.
 - **NetBackup 10.x support**: the exporter negotiates API media-type `version=10.0` for
   NetBackup 10.0–10.4 (replacing the never-valid `3.0`); the auto-detect ladder is now
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **NetBackup 11.2 (API version 14.0) support**: auto-detection probes `14.0` first
   (`14.0 → 13.0 → 12.0 → 3.0`), with v14 response fixtures.
-- **Opt-in sub-collector framework** ([ADR-0002](docs/adr/0002-opt-in-sub-collector-framework.md))
+- **Opt-in sub-collector framework** ([ADR-0002](https://github.com/fjacquet/nbu_exporter/blob/main/docs/adr/0002-opt-in-sub-collector-framework.md))
   with four collectors, all **default-off** via a new `collectors:` config section: alerts
   (`nbu_alerts_count`), malware scan results, catalog posture, and SLO compliance
   (`nbu_slo_count`). Each degrades gracefully and never affects `nbu_up`.
@@ -162,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.5.0] - 2026-06-05
 
 Tooling/CI/security baseline sync with the sibling `pflex_exporter` (see
-[ADR-0001](docs/adr/0001-tooling-baseline-sync-with-pflex.md), [#19](https://github.com/fjacquet/nbu_exporter/pull/19)).
+[ADR-0001](https://github.com/fjacquet/nbu_exporter/blob/main/docs/adr/0001-tooling-baseline-sync-with-pflex.md), [#19](https://github.com/fjacquet/nbu_exporter/pull/19)).
 
 ### Added
 
@@ -402,11 +402,11 @@ opentelemetry:
 - Correlate logs with traces for troubleshooting
 - Monitor API version detection performance
 
-See [docs/opentelemetry-example.md](docs/opentelemetry-example.md) for complete setup guide and [docs/trace-analysis-guide.md](docs/trace-analysis-guide.md) for trace analysis examples.
+See [docs/opentelemetry-example.md](https://github.com/fjacquet/nbu_exporter/blob/main/docs/opentelemetry-example.md) for complete setup guide and [docs/trace-analysis-guide.md](https://github.com/fjacquet/nbu_exporter/blob/main/docs/trace-analysis-guide.md) for trace analysis examples.
 
 ### Multi-Version API Support
 
-**Important**: This version adds support for NetBackup 10.0, 10.5, and 11.0 with automatic version detection. See [docs/netbackup-11-migration.md](docs/netbackup-11-migration.md) for complete migration guide.
+**Important**: This version adds support for NetBackup 10.0, 10.5, and 11.0 with automatic version detection. See [docs/netbackup-11-migration.md](https://github.com/fjacquet/nbu_exporter/blob/main/docs/netbackup-11-migration.md) for complete migration guide.
 
 **Quick Start:**
 

--- a/docs/api-10.5-migration.md
+++ b/docs/api-10.5-migration.md
@@ -174,7 +174,7 @@ nbuserver:
     port: "1556"
     apiVersion: "12.0"  # ADD THIS LINE
     apiKey: "your-api-key-here"
-    contentType: "application/vnd.netbackup+json; version=3.0"
+    contentType: "application/vnd.netbackup+json; version=12.0"
     insecureSkipVerify: false
 ```
 
@@ -255,7 +255,7 @@ nbuserver:
     port: "1556"
     apiVersion: "12.0"  # NetBackup 10.5 API version
     apiKey: "your-api-key-here"
-    contentType: "application/vnd.netbackup+json; version=3.0"
+    contentType: "application/vnd.netbackup+json; version=12.0"
     insecureSkipVerify: false
 ```
 
@@ -609,4 +609,4 @@ If you encounter issues not covered in this guide:
 
 ## Changelog
 
-See [CHANGELOG.md](../CHANGELOG.md) for detailed version history and all changes.
+See [Changelog](changelog.md) for detailed version history and all changes.

--- a/docs/config-examples/README.md
+++ b/docs/config-examples/README.md
@@ -390,7 +390,7 @@ ERROR: Failed to detect compatible NetBackup API version
 
 ## Additional Resources
 
-- [Main README](../../README.md) - Complete documentation
+- [Home](../index.md) - Complete documentation
 - [Migration Guide](../netbackup-11-migration.md) - Upgrade instructions
 - [API 10.5 Migration](../api-10.5-migration.md) - Previous migration guide
 - [NetBackup API Documentation](https://sort.veritas.com/public/documents/nbu/)

--- a/docs/deployment-verification.md
+++ b/docs/deployment-verification.md
@@ -1049,5 +1049,5 @@ For issues during deployment:
 ## Related Documentation
 
 - [API 10.5 Migration Guide](api-10.5-migration.md) - Detailed upgrade instructions
-- [README.md](../README.md) - General usage and configuration
-- [CHANGELOG.md](../CHANGELOG.md) - Version history and changes
+- [Home](index.md) - General usage and configuration
+- [Changelog](changelog.md) - Version history and changes

--- a/docs/netbackup-11-migration.md
+++ b/docs/netbackup-11-migration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide provides step-by-step instructions for upgrading the NBU Exporter to support NetBackup 11.0 (API version 13.0) while maintaining backward compatibility with NetBackup 10.5 (API 12.0) and NetBackup 10.0-10.4 (API 3.0).
+This guide provides step-by-step instructions for upgrading the NBU Exporter to support NetBackup 11.0 (API version 13.0) while maintaining backward compatibility with NetBackup 10.5 (API 12.0) and NetBackup 10.0-10.4 (API 10.0).
 
 ## What's New
 
@@ -14,7 +14,7 @@ The exporter now supports three NetBackup API versions:
 |-------------------|-------------|----------------|
 | 11.0+             | 13.0        | ✅ Fully Supported |
 | 10.5              | 12.0        | ✅ Fully Supported |
-| 10.0 - 10.4       | 3.0         | ✅ Legacy Support |
+| 10.0 - 10.4       | 10.0        | ✅ Fully Supported |
 
 ### Automatic Version Detection
 
@@ -23,7 +23,7 @@ The exporter can automatically detect the highest supported API version availabl
 **Detection Process:**
 1. Attempts API version 13.0 (NetBackup 11.0+)
 2. Falls back to API version 12.0 (NetBackup 10.5)
-3. Falls back to API version 3.0 (NetBackup 10.0-10.4)
+3. Falls back to API version 10.0 (NetBackup 10.0-10.4)
 4. Uses the first version that responds successfully
 
 ### Key Benefits
@@ -67,7 +67,7 @@ The exporter can automatically detect the highest supported API version availabl
        port: "1556"
        # apiVersion not specified - will auto-detect 13.0
        apiKey: "your-api-key-here"
-       contentType: "application/vnd.netbackup+json; version=3.0"
+       contentType: "application/vnd.netbackup+json; version=13.0"
        insecureSkipVerify: false
    ```
 
@@ -207,7 +207,7 @@ nbuserver:
    # config-nbu10-legacy.yaml
    nbuserver:
        host: "nbu10-legacy.my.domain"
-       # apiVersion omitted - will detect 3.0
+       # apiVersion omitted - will detect 10.0
    ```
 
 3. **Each exporter automatically detects the correct version**
@@ -304,7 +304,7 @@ nbuserver:
          port: "1556"
          # apiVersion omitted for auto-detection
          apiKey: "${NBU_API_KEY}"
-         contentType: "application/vnd.netbackup+json; version=3.0"
+         contentType: "application/vnd.netbackup+json; version=13.0"
          insecureSkipVerify: false
    ```
 
@@ -453,7 +453,7 @@ nbuserver:
 **Symptoms:**
 ```
 ERROR: Failed to detect compatible NetBackup API version.
-Attempted versions: 13.0, 12.0, 3.0
+Attempted versions: 13.0, 12.0, 10.0
 ```
 
 **Diagnosis:**
@@ -675,9 +675,9 @@ Always have a rollback plan:
 
 ### Documentation
 
-- [README.md](../README.md) - Main documentation
+- [Home](index.md) - Main documentation
 - [API 10.5 Migration Guide](api-10.5-migration.md) - Previous migration guide
-- [CHANGELOG.md](../CHANGELOG.md) - Version history
+- [Changelog](changelog.md) - Version history
 
 ### NetBackup API Documentation
 
@@ -712,7 +712,7 @@ Always have a rollback plan:
 
 **Backward Compatibility:**
 - NetBackup 11.0 supports API 12.0
-- NetBackup 11.0 supports API 3.0
+- NetBackup 11.0 supports API 10.0
 - Smooth upgrade path
 
 ---


### PR DESCRIPTION
## Summary

Doc-hygiene follow-up (no code change). Two things:

**1. Broken links — `mkdocs build --strict` now passes (was: aborted with 12 warnings).**
- `CHANGELOG.md` is snippet-included into `docs/changelog.md` (`--8<--`), so its relative `docs/...` links doubled up (`docs/docs/...`). Converted the ADR-000x / opentelemetry / trace-analysis / migration-guide links to **absolute GitHub URLs** (work in both the GitHub root view and the site).
- `../README.md` / `../CHANGELOG.md` / `../../README.md` links in `deployment-verification.md`, `netbackup-11-migration.md`, `api-10.5-migration.md`, and `config-examples/README.md` pointed outside the docs tree → repointed to the in-site `index.md` / `changelog.md`.

**2. Stale `3.0` API version → real `10.0`.** The never-valid `3.0` (ADR-0003) still mapped NBU 10.0–10.4 in the two nav-visible migration guides. Corrected the version matrices, detection ladders, "supported versions" statements, and example `contentType` (13.0/12.0 left untouched).

## Test plan
- [x] `mkdocs build --strict` → `Documentation built`, **0 warnings** (matches/strengthens `static.yml`'s `gh-deploy`).
- [x] Re-audited the two migration guides — no stray `3.0` remains (only `13.0/12.0/10.0`).
- [x] Docs-only; no code touched.

## Left intentionally
- The historical `3.0` in a **past** CHANGELOG release entry (immutable record; the correction is already in `[Unreleased]`).
- Orphaned, dated `*_SUMMARY.md` docs (not in nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)