### PR TITLE
feat: per-client lifecycle metrics + opt-in tape & disk-pool collector (API v12.0+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NBU Exporter - Prometheus Exporter for Veritas NetBackup
+# NBU Exporter — Prometheus Exporter for Veritas NetBackup
 
-A Prometheus exporter that collects backup job statistics and storage metrics from Veritas NetBackup REST API.
+A Prometheus exporter that collects backup job statistics, storage metrics, tape health, and per-client lifecycle data from the Veritas NetBackup REST API.
 
 [![CI](https://github.com/fjacquet/nbu_exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/nbu_exporter/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/fjacquet/nbu_exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/fjacquet/nbu_exporter/actions/workflows/codeql.yml)
@@ -12,86 +12,138 @@ A Prometheus exporter that collects backup job statistics and storage metrics fr
 
 ## Features
 
-- Job metrics collection by type, policy, and status
-- Storage unit capacity monitoring (free/used bytes)
-- Multi-site: scrape several NetBackup primaries from one exporter, labelled by `site`
-  (background snapshot collection loop; see [`config-multisite.yaml`](docs/config-examples/config-multisite.yaml))
-- Automatic NetBackup API version detection (14.0, 13.0, 12.0, 10.0)
-- Optional OpenTelemetry distributed tracing
-- Hot config reload via SIGHUP / file watcher
-- Health check endpoint
-- Docker support
+- **Job metrics** — count, volume, duration, dedup ratio, queued jobs; by action, policy type, and status
+- **Storage metrics** — free/used bytes per storage unit, capacity, concurrent job limits
+- **Tape & disk-pool metrics** — drive status per robot, media inventory per pool, disk pool volume states (NBU 10.5+, opt-in)
+- **Per-client lifecycle** — last successful job timestamp and job counts per client, for BACKUP / DUPLICATION / IMPORT phases (opt-in, allowlist or all clients)
+- **Multi-site** — scrape several NetBackup primaries from one exporter, every metric labelled by `site`
+- **Automatic API version detection** — probes 14.0 → 13.0 → 12.0 → 10.0 at startup; or pin explicitly
+- **7 Grafana dashboards** — Overview, Jobs, Storage, Data Protection, Tape & Disks, Lifecycle, Multi-site
+- **Prometheus alerting rules** — per-client compliance, tape health, inter-site divergence
+- **Hot config reload** via SIGHUP / fsnotify file watcher
+- **Optional OpenTelemetry** distributed tracing (OTLP gRPC)
+- **Health check** endpoint at `/health`
 
-## Quick Start
+## Full observability stack (recommended)
 
-On macOS, install via Homebrew:
+Deploy the exporter, Prometheus, and Grafana with one command:
 
 ```bash
-brew install fjacquet/tap/nbu_exporter
+git clone https://github.com/cbijon/nbu_exporter.git
+cd nbu_exporter
+
+# Fill in your NBU master hostname and API key
+cp .env.example .env
+# Edit config.yaml with your nbuserver details (see Configuration below)
+
+docker compose up -d
 ```
 
-Or build from source (macOS/Linux):
+Then open:
+- **Grafana** — `http://localhost:3000` (admin / admin) → Dashboards → NetBackup
+- **Prometheus** — `http://localhost:9090`
+- **Metrics** — `http://localhost:9440/metrics`
 
-```bash
-make cli
+See [docs/deploy-stack.md](docs/deploy-stack.md) for the full step-by-step guide (API key generation, multi-site setup, alerting, production hardening).
+
+## Configuration
+
+```yaml
+# config.yaml — minimal single-site example
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    logName: "log/nbu-exporter.log"
+
+nbuserver:
+    scheme: "https"
+    uri: "/netbackup"
+    host: "nbu-master.my.domain"   # NBU primary server FQDN
+    port: "1556"
+    apiKey: "your-api-key-here"    # generated from NBU Admin Console → API Keys
+    insecureSkipVerify: false
+
+collectors:
+    tape:
+        enabled: true    # NBU 10.5+ required; set false if older
+    perClient:
+        enabled: false   # opt-in; set true to track per-client compliance
 ```
 
-Then configure and run:
+For multi-site, replace `nbuserver:` with an `nbuservers:` list — see [`docs/config-examples/config-multisite.yaml`](docs/config-examples/config-multisite.yaml).
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `NBU1_HOSTNAME` | NetBackup master hostname (single-site quickstart) |
+| `NBU1_APIKEY` | NetBackup API key |
+
+`config.yaml` supports `${VAR}` interpolation for secrets — never commit API keys.
+
+## Dashboards
+
+| Dashboard | What it shows |
+|---|---|
+| **Overview** | Site health tiles, backup success rate, storage usage, alert summary |
+| **Jobs** | Success rate, volume, duration p50/p95, dedup ratio, queued jobs |
+| **Storage** | Capacity gauges per storage unit |
+| **Data Protection** | Alerts, malware scans, catalog SLOs |
+| **Tape & Disks** | Drive status by robot, media inventory by pool, disk pool volumes |
+| **Lifecycle** | Per-client compliance timeline, BACKUP/DUPLICATION/IMPORT success rates, overdue clients |
+| **Multi-site** | Cross-site volume, replication rate, divergence ratio, per-site comparison |
+
+All dashboards have a `$site` variable to filter by site or view all at once.
+
+## Binary / CLI usage
 
 ```bash
-# Configure — supply credentials via environment variables (never commit secrets)
-cp .env.example .env        # fill in NBU1_HOSTNAME and NBU1_APIKEY
-cp config.yaml config.local.yaml  # optional: edit server settings
+# Build
+make cli                    # outputs bin/nbu_exporter
 
 # Run
-NBU1_HOSTNAME=nbu.example.com NBU1_APIKEY=mykey nbu_exporter --config config.yaml
-# or with a .env file sourced into your shell, simply:
-nbu_exporter --config config.yaml
+./bin/nbu_exporter --config config.yaml
+./bin/nbu_exporter --config config.yaml --debug   # verbose logging
+./bin/nbu_exporter --config config.yaml --trace   # log every API response body
+
+# macOS (Homebrew)
+brew install fjacquet/tap/nbu_exporter
 ```
-
-`host` and `apiKey` in `config.yaml` support `${VAR}` interpolation — see
-[Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) for details.
-
-Metrics are exposed at `http://localhost:9440/metrics`.
-
-### Environment Variables / .env
-
-| Variable | Description | Default in compose |
-|----------|-------------|-------------------|
-| `NBU1_HOSTNAME` | NetBackup master server hostname | `master.my.domain` |
-| `NBU1_APIKEY` | NetBackup API key | _(empty)_ |
-
-`NBU1_*` is a single-server quickstart convenience — `config.yaml` is always the source of truth.
-For multiple servers add more entries directly in `config.yaml` (literal values or additional env refs).
-
-## Documentation
-
-Full documentation is available at **[fjacquet.github.io/nbu_exporter](https://fjacquet.github.io/nbu_exporter/)**.
-
-| Topic | Link |
-|-------|------|
-| Installation | [Getting Started](https://fjacquet.github.io/nbu_exporter/getting-started/installation/) |
-| Configuration | [Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) |
-| Metrics Reference | [Metrics](https://fjacquet.github.io/nbu_exporter/metrics/) |
-| Docker Deployment | [Docker](https://fjacquet.github.io/nbu_exporter/docker/) |
-| OpenTelemetry | [Tracing Setup](https://fjacquet.github.io/nbu_exporter/opentelemetry-example/) |
-| Migration Guides | [NetBackup 11.0](https://fjacquet.github.io/nbu_exporter/netbackup-11-migration/) |
-| Changelog | [Changelog](https://fjacquet.github.io/nbu_exporter/changelog/) |
 
 ## Development
 
 ```bash
-make sure          # fmt, test, build, lint
-make test          # run tests
+make tools         # install golangci-lint, govulncheck, cyclonedx-gomod (one-time)
+make sure          # fmt + vet + test + build + lint
+make ci            # full CI gate (fmt-check, vet, lint, test-race, govulncheck, coverage)
 make test-coverage # tests with HTML coverage report
 make docker        # build Docker image
+
+# Regenerate Grafana dashboard JSONs after editing grafana/gen/*.py
+PYTHONPATH=. python3 grafana/build_dashboards.py
 ```
+
+## Documentation
+
+Full docs at **[fjacquet.github.io/nbu_exporter](https://fjacquet.github.io/nbu_exporter/)**.
+
+| Topic | Link |
+|---|---|
+| **Full stack deployment** | [docs/deploy-stack.md](docs/deploy-stack.md) |
+| Installation | [Getting Started](https://fjacquet.github.io/nbu_exporter/getting-started/installation/) |
+| Configuration | [Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) |
+| Metrics reference | [Metrics](https://fjacquet.github.io/nbu_exporter/metrics/) |
+| Docker | [Docker](https://fjacquet.github.io/nbu_exporter/docker/) |
+| OpenTelemetry | [Tracing Setup](https://fjacquet.github.io/nbu_exporter/opentelemetry-example/) |
+| Changelog | [Changelog](https://fjacquet.github.io/nbu_exporter/changelog/) |
 
 ## Contributing
 
 1. Fork the repository
 2. Create a feature branch
-3. Run `make sure` before submitting
+3. Run `make ci` before submitting
 4. Submit a pull request
 
 ## License

--- a/deploy/prometheus/nbu-lifecycle.rules.yml
+++ b/deploy/prometheus/nbu-lifecycle.rules.yml
@@ -1,0 +1,143 @@
+---
+# NetBackup lifecycle alerting rules
+# Complement to nbu.rules.yml — focuses on per-client compliance, tape, and multi-site.
+# Requires: nbu_client_jobs_count and nbu_client_last_job_success_seconds metrics
+
+groups:
+  - name: nbu_client_compliance
+    rules:
+      # Client has had no successful BACKUP job in the last 25 hours.
+      # 25h gives a 1-hour margin above the daily backup window.
+      - alert: NbuClientNoRecentBackup
+        expr: |
+          (time() - nbu_client_last_job_success_seconds{action="BACKUP"}) > 90000
+        for: 5m
+        labels:
+          severity: critical
+          team: backup
+        annotations:
+          summary: "No successful backup for client {{ $labels.client }} (policy {{ $labels.policy }})"
+          description: >
+            Client {{ $labels.client }} (policy {{ $labels.policy }}) has not had a
+            successful backup in {{ $value | humanizeDuration }}.
+            Check NetBackup job logs for this client.
+
+      # Backup copy to tape (DUPLICATION) missing or stale — 26h threshold.
+      - alert: NbuClientNoRecentTapeCopy
+        expr: |
+          (time() - nbu_client_last_job_success_seconds{action="DUPLICATION"}) > 93600
+        for: 5m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "No recent tape copy for client {{ $labels.client }} (policy {{ $labels.policy }})"
+          description: >
+            Client {{ $labels.client }} (policy {{ $labels.policy }}) has not had a
+            successful tape duplication job in {{ $value | humanizeDuration }}.
+            Verify the Storage Lifecycle Policy is running correctly.
+
+      # Replication to secondary master (IMPORT on Master 2) missing or stale — 28h threshold.
+      # This alert fires on the exporter instance monitoring Master 2.
+      - alert: NbuClientNoRecentReplication
+        expr: |
+          (time() - nbu_client_last_job_success_seconds{action="IMPORT"}) > 100800
+        for: 5m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "No recent replication for client {{ $labels.client }} (policy {{ $labels.policy }})"
+          description: >
+            Client {{ $labels.client }} (policy {{ $labels.policy }}) has not had a
+            successful replication (IMPORT) job in {{ $value | humanizeDuration }}.
+            Check inter-site connectivity and Auto Image Replication configuration.
+
+      # Client backup failure rate above threshold over the scraping window.
+      - alert: NbuClientBackupFailureRate
+        expr: |
+          (
+            sum by (client) (nbu_client_jobs_count{action="BACKUP", status!="0"})
+            /
+            clamp_min(sum by (client) (nbu_client_jobs_count{action="BACKUP"}), 1)
+          ) * 100 > 20
+        for: 30m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "High backup failure rate for client {{ $labels.client }}"
+          description: >
+            {{ $value | printf "%.0f" }}% of backup jobs for {{ $labels.client }}
+            failed in the current scraping window.
+
+  - name: nbu_tape
+    # Tape alerts require nbu_tape_drives_count and nbu_tape_media_count metrics.
+    # These are emitted by the tape collector (collectors.tape.enabled: true in config)
+    # and are only available on NetBackup 10.5+ (API v12.0+).
+    rules:
+      # Tape drive has been in DOWN state for more than 30 minutes.
+      - alert: NbuTapeDriveDown
+        expr: nbu_tape_drives_count{status="DRIVE_STATUS_DOWN"} > 0
+        for: 30m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "Tape drive DOWN on {{ $labels.site }}"
+          description: >
+            {{ $value }} {{ $labels.drive_type }} drive(s) are in DOWN state
+            (robot {{ $labels.robot_type }}) on site {{ $labels.site }}.
+            Investigate robot connectivity or drive hardware.
+
+      # Tape scratch pool is running low on available volumes.
+      # Adjust the pool label value and threshold to match your NBU configuration.
+      # The pool name is the NBU volume pool name — typically "Scratch" or "NetBackup".
+      - alert: NbuTapePoolScratchLow
+        expr: sum by (pool, site) (nbu_tape_media_count{pool="Scratch"}) < 5
+        for: 15m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "Low scratch tape count in pool {{ $labels.pool }} on {{ $labels.site }}"
+          description: >
+            Only {{ $value }} volumes remain in scratch pool {{ $labels.pool }} on
+            {{ $labels.site }}. Order or reassign tapes before the pool is exhausted.
+
+      # A disk volume within a disk pool has been in DOWN or UNKNOWN state.
+      # Requires nbu_disk_pool_volume_count (API v12.0+, NBU 10.5+).
+      - alert: NbuDiskPoolVolumeDegraded
+        expr: nbu_disk_pool_volume_count{state!="UP"} > 0
+        for: 10m
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "Disk pool volume degraded in {{ $labels.pool_name }} on {{ $labels.site }}"
+          description: >
+            {{ $value }} volume(s) in pool {{ $labels.pool_name }}
+            ({{ $labels.storage_category }}) are in state {{ $labels.state }} on
+            {{ $labels.site }}. Check storage server connectivity.
+
+  - name: nbu_multisite
+    # Multi-site rules require an nbuservers[] configuration with distinct site labels.
+    rules:
+      # Inter-site backup volume divergence: if one site backs up significantly
+      # fewer bytes than the other, it may indicate a connectivity or config issue.
+      - alert: NbuInterSiteDivergence
+        expr: |
+          (
+            sum by (site) (nbu_jobs_bytes{action="BACKUP"})
+            / on() group_left()
+            avg(sum by (site) (nbu_jobs_bytes{action="BACKUP"}))
+          ) < 0.3
+        for: 1h
+        labels:
+          severity: warning
+          team: backup
+        annotations:
+          summary: "Backup volume on site {{ $labels.site }} is unusually low"
+          description: >
+            Site {{ $labels.site }} backed up only {{ $value | humanizePercentage }}
+            of the cross-site average (threshold: 30%). Check connectivity and job scheduling.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./deploy/prometheus/nbu.rules.yml:/etc/prometheus/rules/nbu.rules.yml:ro
+      - ./deploy/prometheus/nbu-lifecycle.rules.yml:/etc/prometheus/rules/nbu-lifecycle.rules.yml:ro
       - prometheus-data:/prometheus
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"

--- a/docs/deploy-stack.md
+++ b/docs/deploy-stack.md
@@ -1,0 +1,267 @@
+# Deploying the full monitoring stack
+
+This guide deploys nbu_exporter, Prometheus, and Grafana as a single docker-compose stack with all dashboards and alerting rules pre-wired.
+
+**Result:** 7 Grafana dashboards (Overview, Jobs, Storage, Data Protection, Tape, Lifecycle, Multi-site) + Prometheus alerting rules, all running in 3 containers.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| NetBackup version | 10.0 or later (10.5+ for tape/disk metrics) |
+| NetBackup API key | Generated from NBU Admin Console → API Keys |
+| Network access | Exporter host → NBU master on port 1556 |
+| Docker + Compose | v2.x (`docker compose version`) |
+
+---
+
+## 1. Get the repo
+
+```bash
+git clone https://github.com/cbijon/nbu_exporter.git
+cd nbu_exporter
+```
+
+---
+
+## 2. Generate a NetBackup API key
+
+In the NetBackup Admin Console or web UI: **Security → API Keys → Add**.
+
+The key needs read access to: jobs, storage, catalog, alerts.
+
+---
+
+## 3. Configure
+
+### Single site
+
+```bash
+cp docs/config-examples/config-auto-detect.yaml config.yaml
+```
+
+Edit `config.yaml` and set your values:
+
+```yaml
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    logName: "log/nbu-exporter.log"
+
+nbuserver:
+    scheme: "https"
+    uri: "/netbackup"
+    host: "nbu-master.my.domain"   # ← NBU master FQDN
+    port: "1556"
+    apiKey: "your-api-key-here"    # ← generated above
+    insecureSkipVerify: false
+
+collectors:
+    tape:
+        enabled: true    # requires NBU 10.5+; set false if older
+    perClient:
+        enabled: false   # opt-in: see "Optional collectors" below
+```
+
+### Two sites (multi-site)
+
+```bash
+cp docs/config-examples/config-multisite.yaml config.yaml
+```
+
+Edit to replace the two `host` / `apiKey` / `site` placeholders. Each `site` value becomes a label on every metric — keep it short (e.g. `paris`, `lyon`).
+
+---
+
+## 4. Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts:
+- **nbu_exporter** on port 9440
+- **Prometheus** on port 9090
+- **Grafana** on port 3000 (login: `admin` / `admin`)
+
+---
+
+## 5. Verify
+
+```bash
+# Exporter health
+curl http://localhost:9440/health
+
+# Metrics endpoint (should list ~20+ nbu_* metrics)
+curl -s http://localhost:9440/metrics | grep "^nbu_" | cut -d'{' -f1 | sort -u
+
+# Prometheus scraping (should return "1")
+curl -s 'http://localhost:9090/api/v1/query?query=up{job="netbackup"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['result'][0]['value'][1])"
+```
+
+Open Grafana at `http://localhost:3000` → Dashboards → Browse → **NetBackup** folder.
+
+---
+
+## 6. Alerting rules
+
+Prometheus loads two rule files automatically:
+
+| File | Alerts |
+|---|---|
+| `deploy/prometheus/nbu.rules.yml` | Core: exporter down, scrape failures, storage full |
+| `deploy/prometheus/nbu-lifecycle.rules.yml` | Per-client compliance, tape health, inter-site divergence |
+
+To send alerts, add an Alertmanager config to `prometheus.yml`:
+
+```yaml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+```
+
+Key alerts:
+
+| Alert | Default threshold | Severity |
+|---|---|---|
+| `NbuClientNoRecentBackup` | 25 h without successful backup | critical |
+| `NbuClientNoRecentTapeCopy` | 26 h without DUPLICATION | warning |
+| `NbuClientNoRecentReplication` | 28 h without IMPORT | warning |
+| `NbuTapeDriveDown` | ≥1 drive DOWN for 15 min | warning |
+| `NbuTapePoolScratchLow` | Scratch pool < 5 volumes | warning |
+| `NbuInterSiteDivergence` | Site < 30 % of cross-site average | warning |
+
+---
+
+## 7. Optional collectors
+
+### Tape metrics (NBU 10.5+)
+
+Enabled by default in the example config above. Adds:
+- `nbu_tape_drives_count` — drive status per robot
+- `nbu_tape_media_count` — media inventory per pool
+- `nbu_disk_pool_volume_count` — disk pool volume states
+
+### Per-client lifecycle metrics
+
+Enable to track per-client compliance (required for the Lifecycle and Multi-site dashboards to show per-client rows):
+
+```yaml
+collectors:
+  perClient:
+    enabled: true
+    allowlist:         # leave empty to collect all clients
+      - srv-db-01
+      - srv-app-01
+```
+
+Adds:
+- `nbu_client_jobs_count{site, client, action, status}` — job counts per client
+- `nbu_client_last_job_success_seconds{site, client, policy, action}` — timestamp of last success
+
+---
+
+## 8. Dashboards
+
+| Dashboard | What it shows |
+|---|---|
+| **Overview** | Health tiles per site, backup success rate, storage usage, alert summary |
+| **Jobs** | Success rate, volume, duration p50/p95, dedup ratio, queued jobs |
+| **Storage** | Capacity gauges per storage unit, used vs total |
+| **Data Protection** | Alerts by severity, malware scans, catalog SLOs |
+| **Tape & Disks** | Drive status, media inventory, pool levels, disk pool volumes |
+| **Lifecycle** | Per-client compliance history (state timeline), BACKUP / DUPLICATION / IMPORT success rates, overdue clients |
+| **Multi-site** | Cross-site backup volume, replication rate, divergence ratio, per-site comparison |
+
+All dashboards have a `$site` variable (top left) to filter by site or show all at once.
+
+---
+
+## 9. Multi-site Prometheus setup
+
+For two separate exporter instances (one per site), use a single Prometheus with two scrape targets:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'netbackup'
+    scrape_interval: 60s
+    scrape_timeout: 30s
+    static_configs:
+      - targets:
+          - 'nbu-exporter-paris:9440'
+          - 'nbu-exporter-lyon:9440'
+```
+
+Each exporter tags its metrics with `site` from its config. Prometheus aggregates them; Grafana filters with `$site`.
+
+---
+
+## 10. Production hardening
+
+```yaml
+# config.yaml — recommended for production
+nbuserver:
+    insecureSkipVerify: false   # always validate NBU TLS certificate
+```
+
+```bash
+# Change Grafana default password immediately
+GF_ADMIN_PASSWORD=<strong-password> docker compose up -d
+```
+
+Consider:
+- Running the stack behind a reverse proxy (nginx/Traefik) with TLS termination
+- Storing the NBU API key in a secrets manager and injecting via env var
+- Persisting Prometheus data with a named volume (already configured in docker-compose.yml)
+- Setting `collectionInterval: "5m"` (default) and `scrapingInterval: "1h"` — don't scrape more often than NBU's job window
+
+---
+
+## Troubleshooting
+
+### Exporter starts but no `nbu_*` metrics
+
+```bash
+docker compose logs nbu_exporter | grep -E "ERROR|version"
+```
+
+Common causes:
+- Wrong API key → regenerate in NBU UI
+- NBU API not reachable → check firewall on port 1556
+- `insecureSkipVerify: false` with self-signed cert → add CA or set to `true` temporarily to diagnose
+
+### Tape metrics missing
+
+```bash
+curl -s http://localhost:9440/metrics | grep nbu_tape
+```
+
+Empty → NBU version < 10.5, or `collectors.tape.enabled: false` in config.
+
+### Grafana dashboards empty
+
+1. Check Prometheus is scraping: `http://localhost:9090/targets`
+2. Check the datasource in Grafana: Settings → Data Sources → Prometheus → Test
+3. Query `nbu_up` in Explore — if no data, scraping isn't working
+
+### Check-rules (optional)
+
+```bash
+# Validate alerting rules syntax (requires promtool in PATH)
+make check-rules
+```
+
+---
+
+## Related docs
+
+- [Configuration reference](getting-started/configuration.md)
+- [All metrics](metrics.md)
+- [Docker usage](docker.md)


### PR DESCRIPTION
This PR adds two feature sets developed on a production deployment (2 sites, 2 NBU master servers, tape robot on primary site), rebased on top of upstream main (PR #36/#37 multi-site snapshot model).

  Per-client backup lifecycle metrics

  - nbu_client_jobs_count{site, client, action, status} — job count per client/action/status
  - nbu_client_last_job_success_seconds{site, client, policy, action} — Unix timestamp of last successful job; persistent across scrape windows (SLA alerting)
  - Lifecycle Grafana dashboard (nbu-lifecycle, 25 panels, generated from grafana/gen/lifecycle.py):
    - SLA gauges (BACKUP / DUPLICATION / IMPORT success rate)
    - State timeline: per-client BACKUP compliance history (green/red over time)
    - Bar gauge: clients ranked by backup staleness with threshold colours
    - Per-client age table with 4-step threshold (23h/24h/25h)
    - Activity bars by phase, volume timeseries (P50 + P95 duration)
    - Architecture flow diagram (Markdown panel): Client → BACKUP → DUPLICATION → Tape → AIR → Remote
  - Alerting rules: NbuClientNoRecentBackup (>25h), NbuClientNoRecentTapeCopy (>26h), NbuClientNoRecentReplication (>28h), NbuClientBackupFailureRate (>20%)

  Opt-in tape & disk-pool collector (collectors.tape.enabled: true, API v12.0+ / NBU 10.5+)

  ┌──────────────────────────────┬────────────────────────────────┬──────────────────────────────────────────┐
  │            Metric            │            Endpoint            │                  Labels                  │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────────────────────┤
  │ nbu_tape_drives_count        │ GET /storage/drives            │ site, drive_type, robot_type, status     │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────────────────────┤
  │ nbu_tape_media_count         │ GET /storage/tape-media        │ site, pool, media_type, robot_type       │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────────────────────┤
  │ nbu_tape_pool_partially_full │ GET /storage/tape-volume-pools │ site, pool_name, pool_type               │
  ├──────────────────────────────┼────────────────────────────────┼──────────────────────────────────────────┤
  │ nbu_disk_pool_volume_count   │ GET /storage/disk-pools        │ site, pool_name, storage_category, state │
  └──────────────────────────────┴────────────────────────────────┴──────────────────────────────────────────┘

  Each endpoint degrades independently (one failure does not block the others). Silently skipped on API v10.0 with a startup warning — the four storage endpoints are absent from the v10.0 spec (confirmed on official Veritas OpenAPI specs on SORT for NBU 10.3).

  - Tape & Disk Pools Grafana dashboard (nbu-tape, 25 panels, generated from grafana/gen/tape.py):
    - $site filter variable on all panels
    - Infrastructure diagram panel (robot → drive → media pool → disk pool)
    - Status exact-match fixes (= instead of =~ on DRIVE_STATUS_UP/DOWN)
  - Alerting rules: NbuTapeDriveDown (DRIVE_STATUS_DOWN >30m), NbuTapePoolScratchLow (Scratch pool <5 media), NbuDiskPoolVolumeDegraded (volume not UP)

  Multi-site comparison dashboard (new)
 
  - nbu-multisite (37 panels, generated from grafana/gen/multisite.py):
    - 2-site architecture diagram with AIR replication flow
    - Per-site backup volume, job counts, success rate gauges
    - State timeline: per-site client compliance history
    - Inter-site divergence ratio (site backup volume vs cross-site average)
    - IMPORT/replication volume timeseries per site
    - Alert tables: clients missing backup (>25h) and missing replication (>28h) with site column
    - Tape drives and media per site (NBU 10.5+)
  - Multi-site alerting rule: NbuInterSiteDivergence (<30% of cross-site average for 1h)

  Architecture

  - Tape collector implements the existing subCollector interface (Name(), Collect())
  - Added to buildSubCollectorsFor() in subcollector.go with API v12.0+ gate
  - site is the first variableLabel on all four tape descriptors — consistent with upstream pattern
  - Collectors.Tape CollectorToggle added to Config.Collectors
  - New panel helpers in grafana/gen/panels.py: state_timeline(), bar_gauge(), text_panel()
  - New generators: grafana/gen/lifecycle.py, grafana/gen/multisite.py

  Minor fixes

  - docs: "3.0" → "10.0" in apiVersion references (x2 files)
  - deploy/prometheus/nbu-lifecycle.rules.yml: humanize1024 → humanizePercentage on ratio value
  - config.yaml: corrected comment ("all default to disabled" — tape is enabled by default)

  Testing note

  Unit-tested against mocks (make ci fully green: fmt / vet / lint / test-race / govulncheck, 87.8% coverage on internal/exporter). Not yet validated against a real NBU 10.5 appliance — currently on NBU 10.3.0.1, upgrade to 10.5 is planned. Happy to co-validate once upgraded or if
  you have a 10.5+ environment available.

  Test plan

  - [x] make ci passes (fmt / vet / golangci-lint / test-race / govulncheck)
  - [x] go test -race ./... — all packages green, 87.8% coverage on internal/exporter
  - [ ] Tape collector disabled by default — existing deployments unaffected
  - [ ] Tape collector silently skipped on API v10.0 with startup warning
  - [ ] Tape collector active for API v12.0 / v13.0 / v14.0 (unit-tested via buildSubCollectorsFor)
  - [ ] Grafana dashboards provision correctly via docker compose up
  - [ ] Validate tape metrics against a real NBU 10.5+ appliance (pending upgrade)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alerting rules for NetBackup client compliance monitoring (backup status, tape duplication, replication, failure rates)
  * Added tape management alerts (drive status, scratch pools, disk pool health)
  * Added multi-site divergence monitoring for backup volume consistency
  * Added new Grafana dashboards for lifecycle and tape metrics visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->