### PR TITLE
feat: opt-in tape / drive metrics collector (Feature 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tape / drive metrics** (opt-in `collectors.tape`, default off): `nbu_tape_drives_count`
+  (by state/drive_type/robot_type), `nbu_tape_drive_info` (per drive), `nbu_tape_media_count`
+  (by media_type/status), and `nbu_tape_robot_device_hosts`, collected over REST — drives on
+  NBU 10.0+, tape-media + robot device hosts on 10.5+ — with per-endpoint graceful degradation
+  and the `site` label. No CLI shell-out. See the Feature 2 design spec.
 - **Multi-site support**: a single exporter can scrape multiple NetBackup primary servers via
   a `nbuservers:` list, each with a unique `site`; every metric series carries a `site` label
   (first label). Collection adopts the family **snapshot model** — a background loop polls

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,13 +39,14 @@ The `nbu_job_duration_seconds` histogram covers completed jobs only (those with 
 !!! note
     Tape storage units are excluded from metrics collection.
 
-## NetBackup 11.2 opt-in collectors
+## Opt-in collectors
 
-These metrics require NetBackup 11.2 (API `version=14.0`) endpoints and are exposed
-by four optional sub-collectors. **All default to disabled** — enable only the ones
-your appliance and account permissions support. They are graceful: a failing
-endpoint is logged and skipped without affecting core storage/jobs metrics or
-flipping `nbu_up` to `0`.
+These metrics are exposed by optional sub-collectors. **All default to disabled** — enable
+only the ones your appliance and account permissions support. They are graceful: a failing
+endpoint is logged and skipped without affecting core storage/jobs metrics or flipping
+`nbu_up` to `0`. The alerts/malware/catalog/SLO collectors require NetBackup 11.2 (API
+`version=14.0`); the **`tape`** collector works on older releases too (`/storage/drives` on
+NBU 10.0+, `/storage/tape-media` and `/storage/robots-device-hosts` on 10.5+).
 
 | Metric | Type | Labels | Source endpoint | Source API attribute |
 |--------|------|--------|-----------------|----------------------|
@@ -55,6 +56,10 @@ flipping `nbu_up` to `0`.
 | `nbu_malware_scan_count` | Gauge | `status` | `GET /malware/latest-scan-results` | Results grouped by `scanState` |
 | `nbu_catalog_images_count` | Gauge | `malware_status`, `anomaly_status` | `GET /catalog/images` | `meta.pagination.count` per filter combination |
 | `nbu_slo_count` | Gauge | — | `GET /servicecatalog/slos` | Total number of `data[]` entries |
+| `nbu_tape_drives_count` | Gauge | `state`, `drive_type`, `robot_type` | `GET /storage/drives` | Drives grouped by `driveStatus`/`driveType`/`robotType` |
+| `nbu_tape_drive_info` | Gauge | `drive_name`, `media_server`, `drive_type`, `robot_number`, `state` | `GET /storage/drives` | One series per drive (value always `1`) |
+| `nbu_tape_media_count` | Gauge | `media_type`, `status` | `GET /storage/tape-media` | Tape volumes grouped by `mediaType` + `mediaStatus` |
+| `nbu_tape_robot_device_hosts` | Gauge | — | `GET /storage/robots-device-hosts` | Count of device hosts with robots configured |
 
 Notes on the implemented attributes (these differ from early guesses):
 
@@ -69,6 +74,12 @@ Notes on the implemented attributes (these differ from early guesses):
 - **SLO count** is a single unlabeled gauge. The 11.2 SLO response has no
   per-SLO enforcement-type attribute, so the originally planned
   `enforcement_type` label was dropped.
+- **Tape collector** (`collectors.tape`) is one collector over three endpoints with
+  per-endpoint graceful degradation. Tape media is offset-paginated and aggregated
+  client-side; `robot_type` is read from the per-drive attribute (there is no bulk
+  robot-listing endpoint, so a standalone robot type/count metric is not exposed);
+  `mediaStatus` is a free-form NetBackup status string. `drive_state` is the
+  `driveStatus` value with the `DRIVE_STATUS_` prefix stripped (`UP`/`DOWN`/`MIXED`/`DISABLED`).
 
 ### Enabling the collectors
 
@@ -81,6 +92,7 @@ collectors:
   malware: { enabled: false }
   catalog: { enabled: false }
   slo:     { enabled: false }
+  tape:    { enabled: false }
 ```
 
 !!! note "Job metrics and the missing 11.2 `admin.yaml`"

--- a/docs/superpowers/plans/2026-06-17-feature2-tape-metrics.md
+++ b/docs/superpowers/plans/2026-06-17-feature2-tape-metrics.md
@@ -1,0 +1,668 @@
+# Feature 2 — Tape / Drive Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. **One task per subagent (small), gate each on `make ci`, commit per task.** Background subagents in this environment stall on a 600s watchdog for large tasks — if a dispatch stalls, reconcile git state and finish that task inline. Never start the next task before the current one is green + committed.
+
+**Goal:** Add an opt-in `tape` sub-collector exposing NetBackup tape/drive health (drives by state/type/robot, tape-volume status mix, robot device-host count) over REST, default-off, multi-site-aware.
+
+**Architecture:** A new `tapeCollector` implementing the existing `subCollector` interface (alerts/malware/catalog/SLO pattern), built per target by `buildSubCollectorsFor`, so its metrics buffer into the per-site snapshot and carry the `site` label. It reads three `/storage/` endpoints with per-endpoint graceful degradation; tape-media is offset-paginated (loop until a short page).
+
+**Tech Stack:** Go 1.26, prometheus/client_golang, testify; `make ci` gate (fmt/vet/lint/test-race/govulncheck + 70% coverage). RTK: `rtk proxy go test …` / `rtk proxy make ci`. Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-feature2-tape-metrics-design.md`
+
+## Confirmed API facts (from `docs/veritas-10.5/storage.yaml`)
+
+- `GET /storage/drives` — `data[].attributes`: `driveName`, `driveStatus` (`DRIVE_STATUS_UP|DOWN|MIXED|DISABLED`), `driveType` (`DT_HCART`…), `robotType` (`TLD|ACS|NOT_ROBOTIC|NA`), `robotNumber` (int), `deviceHost`. Exposes `page[offset]`/`page[limit]`. Present on NBU 10.0+.
+- `GET /storage/tape-media` — `data[].attributes`: `barcode`, `mediaType` (`HCART|DLT|…`), `mediaStatus` (free-form string, e.g. `ACTIVE MULTIPLEXED`), `robotType`, `robotNumber`. `meta.pagination` like storage-units. NBU 10.5+.
+- `GET /storage/robots-device-hosts` — `data[]`: `{id: <hostname>, type: "deviceHost"}`. NBU 10.5+.
+
+## Metric set (every series carries `site` first)
+
+| Metric | Labels (after `site`) |
+|---|---|
+| `nbu_tape_drives_count` (gauge) | `state`, `drive_type`, `robot_type` |
+| `nbu_tape_drive_info` (gauge =1) | `drive_name`, `media_server`, `drive_type`, `robot_number`, `state` |
+| `nbu_tape_media_count` (gauge) | `media_type`, `status` |
+| `nbu_tape_robot_device_hosts` (gauge) | *(site only)* |
+
+`state` label = `driveStatus` with the `DRIVE_STATUS_` prefix stripped (`UP`/`DOWN`/`MIXED`/`DISABLED`).
+
+## File Structure
+
+- `internal/models/Config.go` — add `Tape CollectorToggle` to the `Collectors` struct.
+- `internal/models/Tape.go` *(new)* — `TapeDrives`, `TapeMedia`, `RobotDeviceHosts` JSON:API response structs.
+- `internal/exporter/collector_tape.go` *(new)* — `tapeCollector` (implements `subCollector`); helpers for the three endpoints + offset loop.
+- `internal/exporter/collector_tape_test.go` *(new)* — table/fixture tests + a path-routing mock client.
+- `internal/exporter/subcollector.go` — register `tape` in `buildSubCollectorsFor`.
+- `testdata/api-versions/` — new fixtures: `drives-response.json`, `tape-media-page1.json`, `tape-media-page2.json`, `robots-device-hosts-response.json`.
+- Docs: `docs/metrics.md`, `docs/config-examples/`, `CHANGELOG.md`.
+
+---
+
+## Task 1: Config — `collectors.tape` toggle
+
+**Files:** Modify `internal/models/Config.go`; Test `internal/models/Config_test.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/models/Config_test.go`:
+
+```go
+func TestCollectorsTapeToggleDefaultsDisabled(t *testing.T) {
+	cfg := &Config{}
+	if cfg.Collectors.Tape.Enabled {
+		t.Error("collectors.tape should default to disabled")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (compile error: `Tape` undefined)
+
+Run: `rtk proxy go test ./internal/models/ -run TestCollectorsTapeToggle -v`
+Expected: build failure — `cfg.Collectors.Tape undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/models/Config.go`, add `Tape` to the `Collectors` struct (after `SLO`):
+
+```go
+	Collectors struct {
+		Alerts  CollectorToggle `yaml:"alerts"`
+		Malware CollectorToggle `yaml:"malware"`
+		Catalog CollectorToggle `yaml:"catalog"`
+		SLO     CollectorToggle `yaml:"slo"`
+		Tape    CollectorToggle `yaml:"tape"`
+	} `yaml:"collectors"`
+```
+
+- [ ] **Step 4: Run — expect PASS** (`rtk proxy go test ./internal/models/ -run TestCollectorsTapeToggle -v`).
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/models/Config.go internal/models/Config_test.go
+git commit -m "feat(config): add collectors.tape toggle (default off)"
+```
+
+---
+
+## Task 2: Response models
+
+**Files:** Create `internal/models/Tape.go`. (No standalone test — exercised by the collector tests in later tasks; this task only adds types so the package still builds.)
+
+- [ ] **Step 1: Create `internal/models/Tape.go`**
+
+```go
+package models
+
+// TapeDrives is the response from GET /storage/drives (JSON:API).
+type TapeDrives struct {
+	Data []struct {
+		Attributes struct {
+			DriveName   string `json:"driveName"`
+			DriveStatus string `json:"driveStatus"` // DRIVE_STATUS_UP|DOWN|MIXED|DISABLED
+			DriveType   string `json:"driveType"`   // DT_HCART, DT_DLT, ...
+			RobotType   string `json:"robotType"`   // TLD, ACS, NOT_ROBOTIC, NA
+			RobotNumber int    `json:"robotNumber"`
+			DeviceHost  string `json:"deviceHost"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+// TapeMedia is the response from GET /storage/tape-media (JSON:API).
+type TapeMedia struct {
+	Data []struct {
+		Attributes struct {
+			Barcode     string `json:"barcode"`
+			MediaType   string `json:"mediaType"`   // HCART, DLT, HC_CLN, ...
+			MediaStatus string `json:"mediaStatus"` // free-form, e.g. "ACTIVE MULTIPLEXED"
+			RobotType   string `json:"robotType"`
+			RobotNumber int    `json:"robotNumber"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+// RobotDeviceHosts is the response from GET /storage/robots-device-hosts (JSON:API).
+// Each entry is a configured robot device host; data[].id is the hostname.
+type RobotDeviceHosts struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+```
+
+- [ ] **Step 2: Run — expect PASS** (`rtk proxy go build ./...`). Expected: builds clean.
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/models/Tape.go
+git commit -m "feat(models): tape/drive/robot-device-host JSON:API response structs"
+```
+
+---
+
+## Task 3: Drive metrics (`nbu_tape_drives_count` + `nbu_tape_drive_info`)
+
+**Files:** Create `internal/exporter/collector_tape.go`, `internal/exporter/collector_tape_test.go`; create `testdata/api-versions/drives-response.json`.
+
+- [ ] **Step 1: Create the drives fixture** `testdata/api-versions/drives-response.json`
+
+```json
+{
+  "data": [
+    {"attributes": {"driveName": "drive0", "driveStatus": "DRIVE_STATUS_UP",   "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}},
+    {"attributes": {"driveName": "drive1", "driveStatus": "DRIVE_STATUS_UP",   "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}},
+    {"attributes": {"driveName": "drive2", "driveStatus": "DRIVE_STATUS_DOWN", "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}}
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test** `internal/exporter/collector_tape_test.go`
+
+```go
+package exporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// tapeRoutedClient is a NetBackupClient mock that serves a fixture per endpoint
+// path (and per offset for paginated endpoints). A path mapped to "" yields an error
+// (used to exercise per-endpoint graceful degradation).
+type tapeRoutedClient struct {
+	t       *testing.T
+	byPath  map[string]string // path substring -> fixture file ("" => return error)
+}
+
+func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target interface{}) error {
+	c.t.Helper()
+	for sub, fixture := range c.byPath {
+		if strings.Contains(url, sub) {
+			if fixture == "" {
+				return errors.New("endpoint unavailable")
+			}
+			data, err := os.ReadFile(fixture)
+			require.NoError(c.t, err)
+			return json.Unmarshal(data, target)
+		}
+	}
+	c.t.Fatalf("unexpected URL: %s", url)
+	return nil
+}
+func (c *tapeRoutedClient) DetectAPIVersion(context.Context) (string, error) { return models.APIVersion140, nil }
+func (c *tapeRoutedClient) Close() error                                     { return nil }
+
+func TestTapeCollector_Drives(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "../../testdata/api-versions/drives-response.json",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	driveCounts := map[string]float64{} // "state|drive_type|robot_type" -> value
+	infoSites := 0
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "nbu_tape_drives_count"):
+			key := labelValue(&d, "state") + "|" + labelValue(&d, "drive_type") + "|" + labelValue(&d, "robot_type")
+			driveCounts[key] = d.GetGauge().GetValue()
+		case strings.Contains(desc, "nbu_tape_drive_info"):
+			require.Equal(t, float64(1), d.GetGauge().GetValue())
+			infoSites++
+		}
+	}
+	require.Equal(t, float64(2), driveCounts["UP|DT_HCART|TLD"])
+	require.Equal(t, float64(1), driveCounts["DOWN|DT_HCART|TLD"])
+	require.Equal(t, 3, infoSites, "one nbu_tape_drive_info per drive")
+}
+```
+
+(Add imports `encoding/json`, `errors`, `os`, and `github.com/fjacquet/nbu_exporter/internal/models` to the test file.)
+
+- [ ] **Step 3: Run — expect FAIL** (`newTapeCollector` undefined).
+
+Run: `rtk proxy go test ./internal/exporter/ -run TestTapeCollector_Drives -v`
+Expected: build failure — `undefined: newTapeCollector`.
+
+- [ ] **Step 4: Implement** `internal/exporter/collector_tape.go`
+
+```go
+package exporter
+
+import (
+	"context"
+	"strings"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	drivesPath    = "/storage/drives"
+	tapeMediaPath = "/storage/tape-media"
+	robotHostPath = "/storage/robots-device-hosts"
+)
+
+// tapeCollector is an opt-in sub-collector for tape/drive health. It reads
+// /storage/drives, /storage/tape-media and /storage/robots-device-hosts, with
+// per-endpoint graceful degradation (a missing endpoint on older NetBackup, or a
+// permission error, is logged and skipped).
+type tapeCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	site   string
+
+	drivesCount     *prometheus.Desc
+	driveInfo       *prometheus.Desc
+	mediaCount      *prometheus.Desc
+	robotHostsCount *prometheus.Desc
+}
+
+func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *tapeCollector {
+	return &tapeCollector{
+		client: client,
+		cfg:    cfg,
+		site:   site,
+		drivesCount: prometheus.NewDesc(
+			"nbu_tape_drives_count",
+			"Number of tape drives by status, drive type and robot type",
+			[]string{"site", "state", "drive_type", "robot_type"}, nil,
+		),
+		driveInfo: prometheus.NewDesc(
+			"nbu_tape_drive_info",
+			"Tape drive info (always 1; metadata in labels)",
+			[]string{"site", "drive_name", "media_server", "drive_type", "robot_number", "state"}, nil,
+		),
+		mediaCount: prometheus.NewDesc(
+			"nbu_tape_media_count",
+			"Number of tape volumes by media type and status",
+			[]string{"site", "media_type", "status"}, nil,
+		),
+		robotHostsCount: prometheus.NewDesc(
+			"nbu_tape_robot_device_hosts",
+			"Number of device hosts that have robots configured",
+			[]string{"site"}, nil,
+		),
+	}
+}
+
+func (c *tapeCollector) Name() string { return "tape" }
+
+// driveState strips the DRIVE_STATUS_ prefix so the label reads UP/DOWN/MIXED/DISABLED.
+func driveState(s string) string { return strings.TrimPrefix(s, "DRIVE_STATUS_") }
+
+func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	c.collectDrives(ctx, ch)
+	return nil
+}
+
+func (c *tapeCollector) collectDrives(ctx context.Context, ch chan<- prometheus.Metric) {
+	url := c.cfg.BuildURL(drivesPath, map[string]string{QueryParamLimit: pageLimit, QueryParamOffset: "0"})
+	var resp models.TapeDrives
+	if err := c.client.FetchData(ctx, url, &resp); err != nil {
+		log.WithError(err).WithField("site", c.site).Warn("tape: drives fetch failed; skipping")
+		return
+	}
+	type key struct{ state, driveType, robotType string }
+	counts := map[key]float64{}
+	for _, d := range resp.Data {
+		a := d.Attributes
+		state := driveState(a.DriveStatus)
+		counts[key{state, a.DriveType, a.RobotType}]++
+		ch <- prometheus.MustNewConstMetric(c.driveInfo, prometheus.GaugeValue, 1,
+			c.site, a.DriveName, a.DeviceHost, a.DriveType, strconv.Itoa(a.RobotNumber), state)
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(c.drivesCount, prometheus.GaugeValue, v,
+			c.site, k.state, k.driveType, k.robotType)
+	}
+}
+```
+
+(Add `strconv` to the import list.)
+
+- [ ] **Step 5: Run — expect PASS** (`rtk proxy go test ./internal/exporter/ -run TestTapeCollector_Drives -v`).
+- [ ] **Step 6: `make ci` checkpoint** green.
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/exporter/collector_tape.go internal/exporter/collector_tape_test.go testdata/api-versions/drives-response.json
+git commit -m "feat(exporter): tape collector drive metrics (count + per-drive info)"
+```
+
+---
+
+## Task 4: Tape-media metrics with offset pagination
+
+**Files:** Modify `internal/exporter/collector_tape.go`, `internal/exporter/collector_tape_test.go`; create `testdata/api-versions/tape-media-page1.json`, `tape-media-page2.json`.
+
+- [ ] **Step 1: Create two-page media fixtures**
+
+`testdata/api-versions/tape-media-page1.json` (the loop terminates on an **empty** page — it advances `page[offset]` by the number of rows returned and stops when a page has zero rows — so small fixtures work: page1 has 2 rows, page2 has 1, and any further offset returns an empty page):
+
+```json
+{
+  "data": [
+    {"attributes": {"barcode": "ABC001", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}},
+    {"attributes": {"barcode": "ABC002", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}}
+  ]
+}
+```
+
+`testdata/api-versions/tape-media-page2.json`:
+
+```json
+{
+  "data": [
+    {"attributes": {"barcode": "ABC003", "mediaType": "HCART", "mediaStatus": "FROZEN", "robotType": "TLD", "robotNumber": 0}}
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test** — add to `collector_tape_test.go`. This needs the mock to return page1 then page2 by `page[offset]`. Extend `tapeRoutedClient.FetchData` to honor an optional per-path offset map (add field `byOffset map[string]map[string]string` keyed by path substring then offset value), and add this test:
+
+```go
+func TestTapeCollector_MediaPaginated(t *testing.T) {
+	client := &tapeRoutedClient{
+		t: t,
+		byPath: map[string]string{
+			"/storage/drives":              "",
+			"/storage/robots-device-hosts": "",
+		},
+		byOffset: map[string]map[string]string{
+			"/storage/tape-media": {
+				"0": "../../testdata/api-versions/tape-media-page1.json",
+				"2": "../../testdata/api-versions/tape-media-page2.json",
+			},
+		},
+	}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	media := map[string]float64{} // "media_type|status" -> value
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		if strings.Contains(m.Desc().String(), "nbu_tape_media_count") {
+			require.Equal(t, "site1", labelValue(&d, "site"))
+			media[labelValue(&d, "media_type")+"|"+labelValue(&d, "status")] = d.GetGauge().GetValue()
+		}
+	}
+	require.Equal(t, float64(2), media["HCART|ACTIVE"], "both pages aggregated")
+	require.Equal(t, float64(1), media["HCART|FROZEN"])
+}
+```
+
+Update `tapeRoutedClient.FetchData` to check `byOffset` first (parse the `page[offset]=` value out of `url`; an offset not in the map returns an empty `{"data":[]}` page, which is what ends the collector's loop). The collector advances `page[offset]` by the number of rows returned and stops on the first empty page:
+
+```go
+func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target interface{}) error {
+	c.t.Helper()
+	for sub, offsets := range c.byOffset {
+		if strings.Contains(url, sub) {
+			off := "0"
+			if i := strings.Index(url, "page[offset]="); i >= 0 {
+				rest := url[i+len("page[offset]="):]
+				if j := strings.IndexByte(rest, '&'); j >= 0 {
+					off = rest[:j]
+				} else {
+					off = rest
+				}
+			}
+			fixture, ok := offsets[off]
+			if !ok { // past the last page -> empty result
+				return json.Unmarshal([]byte(`{"data":[]}`), target)
+			}
+			data, err := os.ReadFile(fixture)
+			require.NoError(c.t, err)
+			return json.Unmarshal(data, target)
+		}
+	}
+	for sub, fixture := range c.byPath { /* unchanged from Task 3 */ }
+	c.t.Fatalf("unexpected URL: %s", url)
+	return nil
+}
+```
+
+(Keep the `byPath` loop body from Task 3 after the `byOffset` loop. Add `byOffset map[string]map[string]string` to the struct.)
+
+- [ ] **Step 3: Run — expect FAIL** (no media metrics emitted yet).
+
+Run: `rtk proxy go test ./internal/exporter/ -run TestTapeCollector_MediaPaginated -v`
+Expected: FAIL — `media["HCART|ACTIVE"]` is 0.
+
+- [ ] **Step 4: Implement** — add media collection + offset loop to `collector_tape.go`, and call it from `Collect`:
+
+```go
+func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	c.collectDrives(ctx, ch)
+	c.collectMedia(ctx, ch)
+	return nil
+}
+
+func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.Metric) {
+	type key struct{ mediaType, status string }
+	counts := map[key]float64{}
+	offset := 0
+	for page := 0; page < maxMediaPages; page++ {
+		url := c.cfg.BuildURL(tapeMediaPath, map[string]string{
+			QueryParamLimit:  pageLimit,
+			QueryParamOffset: strconv.Itoa(offset),
+		})
+		var resp models.TapeMedia
+		if err := c.client.FetchData(ctx, url, &resp); err != nil {
+			log.WithError(err).WithField("site", c.site).Warn("tape: tape-media fetch failed; skipping")
+			return
+		}
+		if len(resp.Data) == 0 { // empty page: no more rows
+			break
+		}
+		for _, d := range resp.Data {
+			counts[key{d.Attributes.MediaType, d.Attributes.MediaStatus}]++
+		}
+		offset += len(resp.Data) // advance by rows returned; loop ends on the next empty page
+		if ctx.Err() != nil {
+			break
+		}
+		if page == maxMediaPages-1 {
+			log.WithField("site", c.site).Warnf("tape: tape-media pagination hit the %d-page cap; counts may be truncated", maxMediaPages)
+		}
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(c.mediaCount, prometheus.GaugeValue, v, c.site, k.mediaType, k.status)
+	}
+}
+```
+
+Add `const maxMediaPages = 1000` near the path constants in `collector_tape.go` — a safety cap (≈100k volumes at `pageLimit=100`) so a backend that ignores `page[offset]` cannot loop forever; hitting it is logged (no silent truncation).
+
+- [ ] **Step 5: Run — expect PASS** (`rtk proxy go test ./internal/exporter/ -run TestTapeCollector -v`). Both drive + media tests pass.
+- [ ] **Step 6: `make ci` checkpoint** green.
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/exporter/collector_tape.go internal/exporter/collector_tape_test.go testdata/api-versions/tape-media-page1.json testdata/api-versions/tape-media-page2.json
+git commit -m "feat(exporter): tape collector media metrics with offset pagination"
+```
+
+---
+
+## Task 5: Robot device-host count, registration, and graceful degradation
+
+**Files:** Modify `internal/exporter/collector_tape.go`, `internal/exporter/subcollector.go`, `internal/exporter/collector_tape_test.go`; create `testdata/api-versions/robots-device-hosts-response.json`.
+
+- [ ] **Step 1: Create the robots fixture** `testdata/api-versions/robots-device-hosts-response.json`
+
+```json
+{
+  "data": [
+    {"id": "host1.example.com", "type": "deviceHost"},
+    {"id": "host2.example.com", "type": "deviceHost"}
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing tests** — add to `collector_tape_test.go`:
+
+```go
+func TestTapeCollector_RobotHostsAndRegistration(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "../../testdata/api-versions/robots-device-hosts-response.json",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	var got float64
+	found := false
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		if strings.Contains(m.Desc().String(), "nbu_tape_robot_device_hosts") {
+			require.Equal(t, "site1", labelValue(&d, "site"))
+			got = d.GetGauge().GetValue()
+			found = true
+		}
+	}
+	require.True(t, found, "nbu_tape_robot_device_hosts must be emitted")
+	require.Equal(t, float64(2), got)
+}
+
+// TestTapeCollector_GracefulDegradation: all endpoints fail -> Collect returns nil, emits nothing.
+func TestTapeCollector_GracefulDegradation(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 4)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
+}
+
+// TestBuildSubCollectorsFor_Tape: the tape collector is built when enabled.
+func TestBuildSubCollectorsFor_Tape(t *testing.T) {
+	cfg := testConfig()
+	cfg.Collectors.Tape.Enabled = true
+	subs := buildSubCollectorsFor(&errClient{}, cfg, "site1")
+	found := false
+	for _, s := range subs {
+		if s.Name() == "tape" {
+			found = true
+		}
+	}
+	require.True(t, found, "tape collector should be built when collectors.tape.enabled")
+}
+```
+
+- [ ] **Step 3: Run — expect FAIL** (robots metric not emitted; tape not registered).
+
+Run: `rtk proxy go test ./internal/exporter/ -run 'TestTapeCollector_RobotHostsAndRegistration|TestTapeCollector_GracefulDegradation|TestBuildSubCollectorsFor_Tape' -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement** — add robots collection and call it from `Collect`:
+
+```go
+func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	c.collectDrives(ctx, ch)
+	c.collectMedia(ctx, ch)
+	c.collectRobotHosts(ctx, ch)
+	return nil
+}
+
+func (c *tapeCollector) collectRobotHosts(ctx context.Context, ch chan<- prometheus.Metric) {
+	url := c.cfg.BuildURL(robotHostPath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.RobotDeviceHosts
+	if err := c.client.FetchData(ctx, url, &resp); err != nil {
+		log.WithError(err).WithField("site", c.site).Warn("tape: robots-device-hosts fetch failed; skipping")
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.robotHostsCount, prometheus.GaugeValue, float64(len(resp.Data)), c.site)
+}
+```
+
+Register in `internal/exporter/subcollector.go` `buildSubCollectorsFor`, after the SLO block:
+
+```go
+	if cfg.Collectors.Tape.Enabled {
+		subs = append(subs, newTapeCollector(client, cfg, site))
+	}
+```
+
+- [ ] **Step 5: Run — expect PASS** (the three tests above + the whole `TestTapeCollector*` set).
+- [ ] **Step 6: `make ci` checkpoint** green (`rtk proxy make ci`).
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/exporter/collector_tape.go internal/exporter/subcollector.go internal/exporter/collector_tape_test.go testdata/api-versions/robots-device-hosts-response.json
+git commit -m "feat(exporter): tape collector robot-device-host count + register opt-in tape collector"
+```
+
+---
+
+## Task 6: Docs + CHANGELOG
+
+**Files:** `docs/metrics.md`, `docs/config-examples/README.md`, `CHANGELOG.md`.
+
+- [ ] **Step 1:** In `docs/metrics.md`, under "## NetBackup 11.2 opt-in collectors", add the four tape metrics to the table and a note that the `tape` collector covers `/storage/drives` (NBU 10.0+), `/storage/tape-media` + `/storage/robots-device-hosts` (10.5+), with per-endpoint graceful degradation; and add `tape: { enabled: false }` to the `collectors:` example block.
+
+```markdown
+| `nbu_tape_drives_count` | Gauge | `state`, `drive_type`, `robot_type` | `GET /storage/drives` | Drives grouped by status/type/robot type |
+| `nbu_tape_drive_info` | Gauge | `drive_name`, `media_server`, `drive_type`, `robot_number`, `state` | `GET /storage/drives` | One series per drive (value always 1) |
+| `nbu_tape_media_count` | Gauge | `media_type`, `status` | `GET /storage/tape-media` | Tape volumes grouped by media type + `mediaStatus` |
+| `nbu_tape_robot_device_hosts` | Gauge | — | `GET /storage/robots-device-hosts` | Count of device hosts with robots configured |
+```
+
+- [ ] **Step 2:** In `docs/config-examples/README.md`, add a row/sentence noting `collectors.tape` enables drive/tape/robot metrics (opt-in, 10.0+ for drives).
+
+- [ ] **Step 3:** In `CHANGELOG.md` `[Unreleased]` → Added:
+
+```markdown
+- **Tape / drive metrics** (opt-in `collectors.tape`, default off): `nbu_tape_drives_count`,
+  `nbu_tape_drive_info`, `nbu_tape_media_count`, `nbu_tape_robot_device_hosts` over REST
+  (`/storage/drives` on NBU 10.0+; `/storage/tape-media` + `/storage/robots-device-hosts` on 10.5+),
+  with per-endpoint graceful degradation and the `site` label. See the Feature 2 design spec.
+```
+
+- [ ] **Step 4:** `make ci` green (`rtk proxy make ci`).
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/metrics.md docs/config-examples/README.md CHANGELOG.md
+git commit -m "docs: document opt-in tape/drive metrics collector"
+```
+
+---
+
+## Final
+
+- [ ] Whole-implementation review (spec coverage: drives count+info ✓, media count w/ pagination ✓, robot-device-host count ✓, opt-in toggle ✓, per-endpoint graceful degradation ✓, `site` label ✓, version degradation ✓).
+- [ ] `make ci` green; quick manual sanity: enable `collectors.tape` against a mock returning the three fixtures → `/metrics` shows the four `nbu_tape_*` metrics with `site`.
+- [ ] superpowers:finishing-a-development-branch.
+
+## Acceptance criteria (from spec)
+
+- Opt-in `tape` collector, default off; drives report on NBU 10.0+, tape-media/robots on 10.5+, with a missing endpoint logged+skipped (never flips `nbu_up`).
+- `nbu_tape_drives_count{state,drive_type,robot_type}`, `nbu_tape_drive_info` per drive, `nbu_tape_media_count{media_type,status}` (offset-paginated aggregation), `nbu_tape_robot_device_hosts` — all `site`-labelled.
+- No CLI shell-out; REST only. Bounded label cardinality regardless of fleet size.

--- a/docs/superpowers/plans/2026-06-17-feature2-tape-metrics.md
+++ b/docs/superpowers/plans/2026-06-17-feature2-tape-metrics.md
@@ -409,21 +409,18 @@ func TestTapeCollector_MediaPaginated(t *testing.T) {
 }
 ```
 
-Update `tapeRoutedClient.FetchData` to check `byOffset` first (parse the `page[offset]=` value out of `url`; an offset not in the map returns an empty `{"data":[]}` page, which is what ends the collector's loop). The collector advances `page[offset]` by the number of rows returned and stops on the first empty page:
+Update `tapeRoutedClient.FetchData` to check `byOffset` first. **`cfg.BuildURL` URL-encodes query params** (the URL contains `page%5Boffset%5D=`, not `page[offset]=`), so parse the offset with `net/url` (which decodes) rather than raw string matching. An offset not in the map returns an empty `{"data":[]}` page, which ends the collector's loop. The collector advances `page[offset]` by the number of rows returned and stops on the first empty page:
 
 ```go
-func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target interface{}) error {
+func (c *tapeRoutedClient) FetchData(_ context.Context, rawURL string, target interface{}) error {
 	c.t.Helper()
 	for sub, offsets := range c.byOffset {
-		if strings.Contains(url, sub) {
-			off := "0"
-			if i := strings.Index(url, "page[offset]="); i >= 0 {
-				rest := url[i+len("page[offset]="):]
-				if j := strings.IndexByte(rest, '&'); j >= 0 {
-					off = rest[:j]
-				} else {
-					off = rest
-				}
+		if strings.Contains(rawURL, sub) {
+			u, err := neturl.Parse(rawURL)
+			require.NoError(c.t, err)
+			off := u.Query().Get("page[offset]")
+			if off == "" {
+				off = "0"
 			}
 			fixture, ok := offsets[off]
 			if !ok { // past the last page -> empty result
@@ -435,12 +432,12 @@ func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target inter
 		}
 	}
 	for sub, fixture := range c.byPath { /* unchanged from Task 3 */ }
-	c.t.Fatalf("unexpected URL: %s", url)
+	c.t.Fatalf("unexpected URL: %s", rawURL)
 	return nil
 }
 ```
 
-(Keep the `byPath` loop body from Task 3 after the `byOffset` loop. Add `byOffset map[string]map[string]string` to the struct.)
+(Keep the `byPath` loop body from Task 3 after the `byOffset` loop. Add `byOffset map[string]map[string]string` to the struct, and the import `neturl "net/url"`.)
 
 - [ ] **Step 3: Run — expect FAIL** (no media metrics emitted yet).
 

--- a/docs/superpowers/specs/2026-06-17-feature2-tape-metrics-design.md
+++ b/docs/superpowers/specs/2026-06-17-feature2-tape-metrics-design.md
@@ -1,0 +1,139 @@
+# Feature 2 — Tape / Drive / Robot Metrics (opt-in sub-collector)
+
+- **Date:** 2026-06-17
+- **Status:** Design (approved — pending spec review)
+- **Deciders:** Frederic Jacquet
+- **Related:** [ADR-0002 (opt-in sub-collector framework)](../../adr/0002-opt-in-sub-collector-framework.md),
+  [feature deferrals rationale](2026-06-16-nbu-feature-deferrals.md),
+  [ADR-0004 (multi-site snapshot model)](../../adr/0004-multisite-snapshot-collection-model.md)
+
+## Context & Goal
+
+Charles's request (Feature 2) asks for tape library visibility: drives, tape media (volumes),
+and robots. The deferral note settled the approach: **REST, not CLI shell-out** (shelling out to
+`bpmedialist`/`vmquery` would force the exporter onto a master/media server, breaking the
+remote-HTTP-only model), shipped as an **opt-in sub-collector** per ADR-0002.
+
+Goal: a single opt-in `tape` sub-collector exposing bounded-cardinality drive/media/robot health
+metrics, default-off, that works across NBU versions via per-endpoint graceful degradation and
+carries the `site` label automatically (multi-site, ADR-0004).
+
+## Scope
+
+Three `/storage/` endpoints (validated against the checked-in OpenAPI bundles):
+
+| Endpoint | NBU availability | Notes |
+|----------|------------------|-------|
+| `GET /storage/drives` | **10.0+** (`docs/veritas-10.3/storage.yaml`) | present on all supported NBU |
+| `GET /storage/tape-media` | **10.5+** (`docs/veritas-10.5/storage.yaml`) | absent on NBU 10.0–10.4 |
+| `GET /storage/robots-device-hosts` | **10.5+** | returns a flat **list of device-host names** only |
+
+The collector must **degrade per endpoint**: on NBU 10.0–10.4 the tape-media and robots endpoints
+are absent (404/406) — those are logged and skipped while drives still report. The same applies
+to any per-endpoint permission error. A failing endpoint never flips `nbu_up` to 0.
+
+**Robot correction (validated against 10.5 + 11.0 specs):** there is **no bulk robot-listing
+endpoint** — only `/storage/robots-device-hosts` (hostnames: `data[].id`, `type: deviceHost`) and
+a per-robot `GET /storage/robots/{robotId}`. So a `robots_count{robot_type}` / per-robot `info`
+metric is **not** buildable without N+1 per-robot calls (rejected). Robot context is instead taken
+from the **`robotType` / `robotNumber` attributes already present on each drive** (and tape
+volume). 11.0/API-13.0 is identical here, so this is version-robust.
+
+Out of scope (separate features): alerting rules for tape (**Feature 4**), per-client metrics
+(**Feature 3**), and any tape *write* operations (move/rescan/erase) — this collector is read-only.
+
+## Metrics
+
+Every series carries `site` as its first label (shared label builder; ADR-0004 invariant). The
+metric-specific labels:
+
+| Metric | Type | Labels (after `site`) | Meaning |
+|--------|------|-----------------------|---------|
+| `nbu_tape_drives_count` | Gauge | `state`, `drive_type`, `robot_type` | Number of drives grouped by status + type + robot type |
+| `nbu_tape_media_count` | Gauge | `media_type`, `status` | Number of tape volumes grouped by media type + status |
+| `nbu_tape_robot_device_hosts` | Gauge | *(none beyond `site`)* | Number of device hosts that have robots configured |
+| `nbu_tape_drive_info` | Gauge (=1) | `drive_name`, `media_server`, `drive_type`, `robot_number`, `state` | One series per drive (tens) — identifies *which* drive is down |
+
+**State vocabularies (confirmed enums in `storage.yaml`):**
+
+- drive `state` ← `driveStatus` field (`driveStatusEnum`): `UP`, `DOWN`, `MIXED`, `DISABLED`
+- drive `drive_type` ← `driveType` field (`driveTypeEnum`): `DT_HCART`, `DT_DLT`, `DT_HCART2`, … (low cardinality)
+- `robot_type` ← `robotType` field **on the drive** (`robotTypeEnum`): `NA`, `NOT_ROBOTIC`, `ACS`, `TLD`
+- media `media_type` ← `mediaType` field (`tapeMediaTypeEnum`): `HCART`, `DLT`, …, plus cleaning media (`HC_CLN`, `DLT_CLN`, …)
+- media `status` ← **`mediaStatus`** field (free-form string, e.g. `ACTIVE MULTIPLEXED`)
+
+**Cardinality:** `count` metrics are bounded by enum cross-products regardless of fleet size.
+The per-entity info metric is emitted **only** for drives (tens), **never** for tape media (can be
+thousands of volumes). Per-entity values like media barcode/serial and drive serial are kept out
+of all labels. Including `state` as a `drive_info` label is the
+kube-state-metrics idiom; the only cost is mild series churn when a drive's state changes, which
+is infrequent and acceptable.
+
+## Collection, pagination & degradation
+
+- The collector implements the existing `subCollector` interface (`Name() string`,
+  `Collect(ctx, ch) error`) and is built per target by `buildSubCollectorsFor(client, cfg, site)`,
+  so its metrics are buffered into the `SiteSnapshot` and re-emitted per scrape (no live fetch on
+  scrape).
+- **Aggregate from `data[]`** (discover states from the data, like the alerts/malware collectors)
+  rather than count-only filtered queries — `mediaStatus` is free-form so it cannot be enumerated
+  up front, and drives must be enumerated anyway for their info metric.
+  - **drives** → aggregate `driveStatus × driveType × robotType` into `nbu_tape_drives_count`, and
+    emit one `nbu_tape_drive_info` per drive.
+  - **tape-media** → aggregate `mediaType × mediaStatus` into `nbu_tape_media_count`.
+  - **robots-device-hosts** → `nbu_tape_robot_device_hosts` = `len(data)` (count of device hosts).
+- **Pagination:** drives are tens → a single page (`page[limit]`) suffices. robots-device-hosts is
+  a short host list. **Tape media can be thousands → offset-paginate** with `page[offset]`/
+  `page[limit]` (drives confirmed to expose `page[offset]`; tape-media returns the same
+  `meta.pagination` shape as `/storage/storage-units`, so reuse the existing `/storage/` offset
+  loop — worst case a non-paginating endpoint returns a single page and the loop terminates). Runs
+  on the 5m collection cycle, not per scrape.
+- **Graceful degradation:** each endpoint fetch is independent; an error (absent endpoint on 10.x,
+  permission denied, transient failure) is logged with `site` + endpoint and skipped. Successful
+  endpoints still emit. Mirrors the per-combination degradation already in the catalog collector.
+
+## Configuration
+
+One opt-in toggle (default disabled), consistent with the other sub-collectors:
+
+```yaml
+collectors:
+  tape:
+    enabled: false   # drives + tape-media + robot-device-host count
+```
+
+## Testing
+
+- JSON fixtures per endpoint under `testdata/`: `drives` (mixed `driveStatus`/`driveType`/
+  `robotType`), `tape-media` (**multi-page**, to exercise offset pagination + aggregation),
+  `robots-device-hosts` (a couple of host entries).
+- An "absent endpoint" / error fixture proving per-endpoint graceful degradation (drives succeed,
+  tape-media 404 → only drive metrics emitted, `Collect` returns nil, `nbu_up` unaffected).
+- Assertions mirror existing sub-collector tests: bounded labels, `site` first label, correct
+  counts, `nbu_tape_drive_info` present per drive (drives only).
+
+## Confirmed field names (validated against `docs/veritas-10.5/storage.yaml`)
+
+- **drives** `data[].attributes`: `driveName`, `driveStatus`, `driveType`, `robotType`,
+  `robotNumber`, `deviceHost` (used for `media_server`). GET exposes `page[offset]`/`page[limit]`.
+- **tape-media** `data[].attributes`: `barcode`, `mediaType`, `mediaStatus`, `robotType`,
+  `robotNumber`, `robotHost`. Response carries `meta.pagination` (same shape as storage-units).
+- **robots-device-hosts** `data[]`: `{ id: <hostname>, type: "deviceHost" }` — host list only.
+
+## Open items (verify at implementation time — do not change the shape above)
+
+1. The exact `mediaStatus` value space in the wild (free-form string; the collector groups on
+   whatever the API returns — no fixed enum assumed).
+2. Confirm the tape-media offset loop terminates correctly against the live `meta.pagination`
+   (the existing `/storage/storage-units` loop is the reference).
+
+## Consequences
+
+- **Positive:** tape-library health (drives down by state/type/robot, tape-volume status mix,
+  robot device-host count) becomes observable over the remote HTTP model; bounded cardinality;
+  works on 10.x (drives) through 11.x; per-site via the snapshot model; unlocks Feature 4 tape
+  alerting.
+- **Trade-offs:** tape-media collection pulls all volumes each cycle (mitigated by opt-in + 5m
+  cycle); `drive_info{state}` churns on state change (accepted). 11.2 `storage.yaml` is not in the
+  repo bundle — the endpoints are backward-compatible, but a follow-up should add the 11.2 bundle
+  to confirm (mirrors the existing 11.2 `admin.yaml` gap).

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -68,7 +68,18 @@ func driveState(s string) string { return strings.TrimPrefix(s, "DRIVE_STATUS_")
 func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	c.collectDrives(ctx, ch)
 	c.collectMedia(ctx, ch)
+	c.collectRobotHosts(ctx, ch)
 	return nil
+}
+
+func (c *tapeCollector) collectRobotHosts(ctx context.Context, ch chan<- prometheus.Metric) {
+	url := c.cfg.BuildURL(robotHostPath, map[string]string{QueryParamLimit: pageLimit})
+	var resp models.RobotDeviceHosts
+	if err := c.client.FetchData(ctx, url, &resp); err != nil {
+		log.WithError(err).WithField("site", c.site).Warn("tape: robots-device-hosts fetch failed; skipping")
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.robotHostsCount, prometheus.GaugeValue, float64(len(resp.Data)), c.site)
 }
 
 func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.Metric) {

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -67,7 +67,41 @@ func driveState(s string) string { return strings.TrimPrefix(s, "DRIVE_STATUS_")
 
 func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	c.collectDrives(ctx, ch)
+	c.collectMedia(ctx, ch)
 	return nil
+}
+
+func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.Metric) {
+	type key struct{ mediaType, status string }
+	counts := map[key]float64{}
+	offset := 0
+	for page := 0; page < maxMediaPages; page++ {
+		url := c.cfg.BuildURL(tapeMediaPath, map[string]string{
+			QueryParamLimit:  pageLimit,
+			QueryParamOffset: strconv.Itoa(offset),
+		})
+		var resp models.TapeMedia
+		if err := c.client.FetchData(ctx, url, &resp); err != nil {
+			log.WithError(err).WithField("site", c.site).Warn("tape: tape-media fetch failed; skipping")
+			return
+		}
+		if len(resp.Data) == 0 { // empty page: no more rows
+			break
+		}
+		for _, d := range resp.Data {
+			counts[key{d.Attributes.MediaType, d.Attributes.MediaStatus}]++
+		}
+		offset += len(resp.Data) // advance by rows returned; loop ends on the next empty page
+		if ctx.Err() != nil {
+			break
+		}
+		if page == maxMediaPages-1 {
+			log.WithField("site", c.site).Warnf("tape: tape-media pagination hit the %d-page cap; counts may be truncated", maxMediaPages)
+		}
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(c.mediaCount, prometheus.GaugeValue, v, c.site, k.mediaType, k.status)
+	}
 }
 
 func (c *tapeCollector) collectDrives(ctx context.Context, ch chan<- prometheus.Metric) {

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -15,6 +15,7 @@ const (
 	tapeMediaPath = "/storage/tape-media"
 	robotHostPath = "/storage/robots-device-hosts"
 	maxMediaPages = 1000 // safety cap so a backend ignoring page[offset] cannot loop forever
+	pageLimitInt  = 100  // int form of pageLimit ("100"), for full-page truncation checks
 )
 
 // tapeCollector is an opt-in sub-collector for tape/drive health. It reads
@@ -79,6 +80,11 @@ func (c *tapeCollector) collectRobotHosts(ctx context.Context, ch chan<- prometh
 		log.WithError(err).WithField("site", c.site).Warn("tape: robots-device-hosts fetch failed; skipping")
 		return
 	}
+	// This endpoint returns a flat list (no pagination). If it fills a full page the
+	// count may be truncated — surface it rather than silently under-reporting.
+	if len(resp.Data) >= pageLimitInt {
+		log.WithField("site", c.site).Warnf("tape: robots-device-hosts returned a full page (%s); count may be truncated", pageLimit)
+	}
 	ch <- prometheus.MustNewConstMetric(c.robotHostsCount, prometheus.GaugeValue, float64(len(resp.Data)), c.site)
 }
 
@@ -93,8 +99,10 @@ func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.M
 		})
 		var resp models.TapeMedia
 		if err := c.client.FetchData(ctx, url, &resp); err != nil {
-			log.WithError(err).WithField("site", c.site).Warn("tape: tape-media fetch failed; skipping")
-			return
+			// Break (not return) so counts already aggregated from earlier pages are
+			// still emitted — degraded-but-partial rather than all-or-nothing.
+			log.WithError(err).WithField("site", c.site).Warn("tape: tape-media fetch failed; emitting partial counts")
+			break
 		}
 		if len(resp.Data) == 0 { // empty page: no more rows
 			break

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -1,0 +1,93 @@
+package exporter
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	drivesPath    = "/storage/drives"
+	tapeMediaPath = "/storage/tape-media"
+	robotHostPath = "/storage/robots-device-hosts"
+	maxMediaPages = 1000 // safety cap so a backend ignoring page[offset] cannot loop forever
+)
+
+// tapeCollector is an opt-in sub-collector for tape/drive health. It reads
+// /storage/drives, /storage/tape-media and /storage/robots-device-hosts, with
+// per-endpoint graceful degradation (a missing endpoint on older NetBackup, or a
+// permission error, is logged and skipped).
+type tapeCollector struct {
+	client NetBackupClient
+	cfg    models.Config
+	site   string
+
+	drivesCount     *prometheus.Desc
+	driveInfo       *prometheus.Desc
+	mediaCount      *prometheus.Desc
+	robotHostsCount *prometheus.Desc
+}
+
+func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *tapeCollector {
+	return &tapeCollector{
+		client: client,
+		cfg:    cfg,
+		site:   site,
+		drivesCount: prometheus.NewDesc(
+			"nbu_tape_drives_count",
+			"Number of tape drives by status, drive type and robot type",
+			[]string{"site", "state", "drive_type", "robot_type"}, nil,
+		),
+		driveInfo: prometheus.NewDesc(
+			"nbu_tape_drive_info",
+			"Tape drive info (always 1; metadata in labels)",
+			[]string{"site", "drive_name", "media_server", "drive_type", "robot_number", "state"}, nil,
+		),
+		mediaCount: prometheus.NewDesc(
+			"nbu_tape_media_count",
+			"Number of tape volumes by media type and status",
+			[]string{"site", "media_type", "status"}, nil,
+		),
+		robotHostsCount: prometheus.NewDesc(
+			"nbu_tape_robot_device_hosts",
+			"Number of device hosts that have robots configured",
+			[]string{"site"}, nil,
+		),
+	}
+}
+
+func (c *tapeCollector) Name() string { return "tape" }
+
+// driveState strips the DRIVE_STATUS_ prefix so the label reads UP/DOWN/MIXED/DISABLED.
+func driveState(s string) string { return strings.TrimPrefix(s, "DRIVE_STATUS_") }
+
+func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	c.collectDrives(ctx, ch)
+	return nil
+}
+
+func (c *tapeCollector) collectDrives(ctx context.Context, ch chan<- prometheus.Metric) {
+	url := c.cfg.BuildURL(drivesPath, map[string]string{QueryParamLimit: pageLimit, QueryParamOffset: "0"})
+	var resp models.TapeDrives
+	if err := c.client.FetchData(ctx, url, &resp); err != nil {
+		log.WithError(err).WithField("site", c.site).Warn("tape: drives fetch failed; skipping")
+		return
+	}
+	type key struct{ state, driveType, robotType string }
+	counts := map[key]float64{}
+	for _, d := range resp.Data {
+		a := d.Attributes
+		state := driveState(a.DriveStatus)
+		counts[key{state, a.DriveType, a.RobotType}]++
+		ch <- prometheus.MustNewConstMetric(c.driveInfo, prometheus.GaugeValue, 1,
+			c.site, a.DriveName, a.DeviceHost, a.DriveType, strconv.Itoa(a.RobotNumber), state)
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(c.drivesCount, prometheus.GaugeValue, v,
+			c.site, k.state, k.driveType, k.robotType)
+	}
+}

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -1,0 +1,74 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// tapeRoutedClient is a NetBackupClient mock that serves a fixture per endpoint
+// path. A path mapped to "" yields an error (to exercise graceful degradation).
+type tapeRoutedClient struct {
+	t      *testing.T
+	byPath map[string]string // path substring -> fixture file ("" => return error)
+}
+
+func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target interface{}) error {
+	c.t.Helper()
+	for sub, fixture := range c.byPath {
+		if strings.Contains(url, sub) {
+			if fixture == "" {
+				return errors.New("endpoint unavailable")
+			}
+			data, err := os.ReadFile(fixture)
+			require.NoError(c.t, err)
+			return json.Unmarshal(data, target)
+		}
+	}
+	c.t.Fatalf("unexpected URL: %s", url)
+	return nil
+}
+func (c *tapeRoutedClient) DetectAPIVersion(context.Context) (string, error) {
+	return models.APIVersion140, nil
+}
+func (c *tapeRoutedClient) Close() error { return nil }
+
+func TestTapeCollector_Drives(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "../../testdata/api-versions/drives-response.json",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	driveCounts := map[string]float64{} // "state|drive_type|robot_type" -> value
+	infoCount := 0
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "nbu_tape_drives_count"):
+			key := labelValue(&d, "state") + "|" + labelValue(&d, "drive_type") + "|" + labelValue(&d, "robot_type")
+			driveCounts[key] = d.GetGauge().GetValue()
+		case strings.Contains(desc, "nbu_tape_drive_info"):
+			require.Equal(t, float64(1), d.GetGauge().GetValue())
+			infoCount++
+		}
+	}
+	require.Equal(t, float64(2), driveCounts["UP|DT_HCART|TLD"])
+	require.Equal(t, float64(1), driveCounts["DOWN|DT_HCART|TLD"])
+	require.Equal(t, 3, infoCount, "one nbu_tape_drive_info per drive")
+}

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -125,3 +125,57 @@ func TestTapeCollector_MediaPaginated(t *testing.T) {
 	require.Equal(t, float64(2), media["HCART|ACTIVE"], "both pages aggregated")
 	require.Equal(t, float64(1), media["HCART|FROZEN"])
 }
+
+func TestTapeCollector_RobotHostsAndRegistration(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "../../testdata/api-versions/robots-device-hosts-response.json",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 16)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	var got float64
+	found := false
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		if strings.Contains(m.Desc().String(), "nbu_tape_robot_device_hosts") {
+			require.Equal(t, "site1", labelValue(&d, "site"))
+			got = d.GetGauge().GetValue()
+			found = true
+		}
+	}
+	require.True(t, found, "nbu_tape_robot_device_hosts must be emitted")
+	require.Equal(t, float64(2), got)
+}
+
+// All endpoints fail -> Collect returns nil and emits nothing (graceful degradation).
+func TestTapeCollector_GracefulDegradation(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 4)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+	require.Empty(t, ch)
+}
+
+// The tape collector is built only when collectors.tape is enabled.
+func TestBuildSubCollectorsFor_Tape(t *testing.T) {
+	cfg := testConfig()
+	cfg.Collectors.Tape.Enabled = true
+	subs := buildSubCollectorsFor(&errClient{}, cfg, "site1")
+	found := false
+	for _, s := range subs {
+		if s.Name() == "tape" {
+			found = true
+		}
+	}
+	require.True(t, found, "tape collector should be built when collectors.tape.enabled")
+}

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	neturl "net/url"
 	"os"
 	"strings"
 	"testing"
@@ -14,17 +15,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// tapeRoutedClient is a NetBackupClient mock that serves a fixture per endpoint
-// path. A path mapped to "" yields an error (to exercise graceful degradation).
+// tapeRoutedClient is a NetBackupClient mock. byPath serves a fixture per endpoint
+// path substring ("" => return an error, to exercise graceful degradation). byOffset
+// serves paginated fixtures keyed by path substring then page[offset] value; an offset
+// not in the map returns an empty page (which ends the collector's pagination loop).
 type tapeRoutedClient struct {
-	t      *testing.T
-	byPath map[string]string // path substring -> fixture file ("" => return error)
+	t        *testing.T
+	byPath   map[string]string
+	byOffset map[string]map[string]string
 }
 
-func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target interface{}) error {
+func (c *tapeRoutedClient) FetchData(_ context.Context, rawURL string, target interface{}) error {
 	c.t.Helper()
+	for sub, offsets := range c.byOffset {
+		if strings.Contains(rawURL, sub) {
+			u, err := neturl.Parse(rawURL)
+			require.NoError(c.t, err)
+			off := u.Query().Get("page[offset]")
+			if off == "" {
+				off = "0"
+			}
+			fixture, ok := offsets[off]
+			if !ok { // past the last page -> empty result
+				return json.Unmarshal([]byte(`{"data":[]}`), target)
+			}
+			data, err := os.ReadFile(fixture)
+			require.NoError(c.t, err)
+			return json.Unmarshal(data, target)
+		}
+	}
 	for sub, fixture := range c.byPath {
-		if strings.Contains(url, sub) {
+		if strings.Contains(rawURL, sub) {
 			if fixture == "" {
 				return errors.New("endpoint unavailable")
 			}
@@ -33,7 +54,7 @@ func (c *tapeRoutedClient) FetchData(_ context.Context, url string, target inter
 			return json.Unmarshal(data, target)
 		}
 	}
-	c.t.Fatalf("unexpected URL: %s", url)
+	c.t.Fatalf("unexpected URL: %s", rawURL)
 	return nil
 }
 func (c *tapeRoutedClient) DetectAPIVersion(context.Context) (string, error) {
@@ -71,4 +92,36 @@ func TestTapeCollector_Drives(t *testing.T) {
 	require.Equal(t, float64(2), driveCounts["UP|DT_HCART|TLD"])
 	require.Equal(t, float64(1), driveCounts["DOWN|DT_HCART|TLD"])
 	require.Equal(t, 3, infoCount, "one nbu_tape_drive_info per drive")
+}
+
+func TestTapeCollector_MediaPaginated(t *testing.T) {
+	client := &tapeRoutedClient{
+		t: t,
+		byPath: map[string]string{
+			"/storage/drives":              "",
+			"/storage/robots-device-hosts": "",
+		},
+		byOffset: map[string]map[string]string{
+			"/storage/tape-media": {
+				"0": "../../testdata/api-versions/tape-media-page1.json",
+				"2": "../../testdata/api-versions/tape-media-page2.json",
+			},
+		},
+	}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	media := map[string]float64{} // "media_type|status" -> value
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		if strings.Contains(m.Desc().String(), "nbu_tape_media_count") {
+			require.Equal(t, "site1", labelValue(&d, "site"))
+			media[labelValue(&d, "media_type")+"|"+labelValue(&d, "status")] = d.GetGauge().GetValue()
+		}
+	}
+	require.Equal(t, float64(2), media["HCART|ACTIVE"], "both pages aggregated")
+	require.Equal(t, float64(1), media["HCART|FROZEN"])
 }

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -39,6 +39,9 @@ func (c *tapeRoutedClient) FetchData(_ context.Context, rawURL string, target in
 			if !ok { // past the last page -> empty result
 				return json.Unmarshal([]byte(`{"data":[]}`), target)
 			}
+			if fixture == "" { // simulate a fetch error at this offset (mid-pagination)
+				return errors.New("endpoint unavailable")
+			}
 			data, err := os.ReadFile(fixture)
 			require.NoError(c.t, err)
 			return json.Unmarshal(data, target)
@@ -178,4 +181,36 @@ func TestBuildSubCollectorsFor_Tape(t *testing.T) {
 		}
 	}
 	require.True(t, found, "tape collector should be built when collectors.tape.enabled")
+}
+
+// TestTapeCollector_MediaPartialOnError verifies that a mid-pagination fetch error
+// still emits the counts accumulated from earlier pages (degraded-but-partial).
+func TestTapeCollector_MediaPartialOnError(t *testing.T) {
+	client := &tapeRoutedClient{
+		t: t,
+		byPath: map[string]string{
+			"/storage/drives":              "",
+			"/storage/robots-device-hosts": "",
+		},
+		byOffset: map[string]map[string]string{
+			"/storage/tape-media": {
+				"0": "../../testdata/api-versions/tape-media-page1.json",
+				"2": "", // page 2 errors mid-pagination
+			},
+		},
+	}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 32)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	media := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		if strings.Contains(m.Desc().String(), "nbu_tape_media_count") {
+			media[labelValue(&d, "media_type")+"|"+labelValue(&d, "status")] = d.GetGauge().GetValue()
+		}
+	}
+	require.Equal(t, float64(2), media["HCART|ACTIVE"], "page-1 counts emitted despite the page-2 error")
 }

--- a/internal/exporter/subcollector.go
+++ b/internal/exporter/subcollector.go
@@ -27,6 +27,9 @@ func buildSubCollectorsFor(client NetBackupClient, cfg models.Config, site strin
 	if cfg.Collectors.SLO.Enabled {
 		subs = append(subs, newSLOCollector(client, cfg, site))
 	}
+	if cfg.Collectors.Tape.Enabled {
+		subs = append(subs, newTapeCollector(client, cfg, site))
+	}
 	return subs
 }
 

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -125,6 +125,7 @@ type Config struct {
 		Malware CollectorToggle `yaml:"malware"`
 		Catalog CollectorToggle `yaml:"catalog"`
 		SLO     CollectorToggle `yaml:"slo"`
+		Tape    CollectorToggle `yaml:"tape"`
 	} `yaml:"collectors"`
 }
 

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -1898,6 +1898,13 @@ func TestConfigNbuServersRequireUniqueSite(t *testing.T) {
 	}
 }
 
+func TestCollectorsTapeToggleDefaultsDisabled(t *testing.T) {
+	cfg := &Config{}
+	if cfg.Collectors.Tape.Enabled {
+		t.Error("collectors.tape should default to disabled")
+	}
+}
+
 // TestConfigCollectionIntervalDefault verifies that SetDefaults populates
 // Server.CollectionInterval with "5m" when not set.
 func TestConfigCollectionIntervalDefault(t *testing.T) {

--- a/internal/models/Tape.go
+++ b/internal/models/Tape.go
@@ -1,0 +1,36 @@
+package models
+
+// TapeDrives is the response from GET /storage/drives (JSON:API).
+type TapeDrives struct {
+	Data []struct {
+		Attributes struct {
+			DriveName   string `json:"driveName"`
+			DriveStatus string `json:"driveStatus"` // DRIVE_STATUS_UP|DOWN|MIXED|DISABLED
+			DriveType   string `json:"driveType"`   // DT_HCART, DT_DLT, ...
+			RobotType   string `json:"robotType"`   // TLD, ACS, NOT_ROBOTIC, NA
+			RobotNumber int    `json:"robotNumber"`
+			DeviceHost  string `json:"deviceHost"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+// TapeMedia is the response from GET /storage/tape-media (JSON:API).
+type TapeMedia struct {
+	Data []struct {
+		Attributes struct {
+			Barcode     string `json:"barcode"`
+			MediaType   string `json:"mediaType"`   // HCART, DLT, HC_CLN, ...
+			MediaStatus string `json:"mediaStatus"` // free-form, e.g. "ACTIVE MULTIPLEXED"
+			RobotType   string `json:"robotType"`
+			RobotNumber int    `json:"robotNumber"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+// RobotDeviceHosts is the response from GET /storage/robots-device-hosts (JSON:API).
+// Each entry is a configured robot device host; data[].id is the hostname.
+type RobotDeviceHosts struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}

--- a/testdata/api-versions/drives-response.json
+++ b/testdata/api-versions/drives-response.json
@@ -1,0 +1,7 @@
+{
+  "data": [
+    {"attributes": {"driveName": "drive0", "driveStatus": "DRIVE_STATUS_UP",   "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}},
+    {"attributes": {"driveName": "drive1", "driveStatus": "DRIVE_STATUS_UP",   "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}},
+    {"attributes": {"driveName": "drive2", "driveStatus": "DRIVE_STATUS_DOWN", "driveType": "DT_HCART", "robotType": "TLD", "robotNumber": 0, "deviceHost": "ms1.example.com"}}
+  ]
+}

--- a/testdata/api-versions/robots-device-hosts-response.json
+++ b/testdata/api-versions/robots-device-hosts-response.json
@@ -1,0 +1,6 @@
+{
+  "data": [
+    {"id": "host1.example.com", "type": "deviceHost"},
+    {"id": "host2.example.com", "type": "deviceHost"}
+  ]
+}

--- a/testdata/api-versions/tape-media-page1.json
+++ b/testdata/api-versions/tape-media-page1.json
@@ -1,0 +1,6 @@
+{
+  "data": [
+    {"attributes": {"barcode": "ABC001", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}},
+    {"attributes": {"barcode": "ABC002", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}}
+  ]
+}

--- a/testdata/api-versions/tape-media-page2.json
+++ b/testdata/api-versions/tape-media-page2.json
@@ -1,0 +1,5 @@
+{
+  "data": [
+    {"attributes": {"barcode": "ABC003", "mediaType": "HCART", "mediaStatus": "FROZEN", "robotType": "TLD", "robotNumber": 0}}
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **`tape`** sub-collector (ADR-0002 framework, default off) exposing NetBackup tape-library health over REST — no CLI shell-out. It runs per-target inside the background snapshot collection loop, so every series carries the `site` label, and degrades per-endpoint across NetBackup versions.

**Metrics** (all `site`-labelled):
- `nbu_tape_drives_count{state,drive_type,robot_type}` + `nbu_tape_drive_info{drive_name,media_server,drive_type,robot_number,state}=1` ← `GET /storage/drives` (NBU 10.0+)
- `nbu_tape_media_count{media_type,status}` ← `GET /storage/tape-media` (10.5+, offset-paginated, aggregated client-side)
- `nbu_tape_robot_device_hosts` ← `GET /storage/robots-device-hosts` (10.5+)

**Design decisions** (grounded in `docs/veritas-10.5`/`11.0` `storage.yaml`):
- **Per-endpoint graceful degradation** — a missing endpoint on older NetBackup (tape-media/robots are 10.5+) or a permission error is logged and skipped; drives still report; `nbu_up` is never flipped.
- **No bulk robot-listing endpoint exists** at any checked version, so there's no standalone robot type/count metric; `robot_type` is taken from the per-drive attribute, and `robots-device-hosts` yields only a device-host count.
- **Bounded cardinality** — count metrics use enum-bounded labels only; per-entity `info` is drives-only (tens), never tape media (thousands).
- Tape-media pagination terminates on an empty page (advancing `page[offset]` by rows returned) with a `maxMediaPages` safety cap against a backend that ignores the offset; a mid-pagination error emits the partial counts already gathered.

## Test plan
- [x] `make ci` green: `go vet`, `golangci-lint` (0 issues), `go test -race`, `govulncheck`, **84.8%** total coverage (≥70% gate)
- [x] 6 fixture-based tests: drives count+info, paginated media (multi-page), robot-host count, all-endpoints-fail graceful degradation, opt-in registration gate, and partial-emit on mid-pagination error
- [x] Fresh-eyes code review; both findings fixed (partial-emit on error; full-page truncation warning)

## Docs
`docs/metrics.md` (opt-in collectors table + tape note + `tape` toggle), CHANGELOG `[Unreleased]`, design spec + TDD plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in tape drive and media metrics collector for NetBackup tape environments (disabled by default).

* **Documentation**
  * Updated metrics documentation with new tape-related Prometheus metrics, configuration examples, and implementation details.
  * Added implementation plan and design specifications for the tape metrics feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->