### PR TITLE
feat: multi-site Grafana dashboards with $site selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-site Grafana dashboards**: every generated dashboard now carries a `site` template
+  variable (multi-value + "All", sourced from `label_values(nbu_up, site)`) as the first selector,
+  and every panel query is filtered by `site=~"$site"` with `site` threaded into each `by (…)`
+  grouping and legend — so series from multiple NetBackup primaries no longer collapse together or
+  double-count. The Overview gains a per-site availability row (one UP/DOWN tile per primary,
+  repeated over `$site`) so a down master is obvious. The filter/grouping is centralized in the
+  `grafana/gen/` generator (`panels.with_site`), and `build_dashboards.py` now fails the build if any
+  dashboard is missing the `site` selector or leaves a query unfiltered. See the Multi-Site
+  Dashboards design spec.
 - **Alerting rules** (`deploy/prometheus/`): two optional, site-aware Prometheus rule files —
   `rules-perclient.yml` (`NbuClientBackupStale` >25h warning, `NbuClientBackupCritical` >48h
   critical) and `rules-tape.yml` (`NbuTapeDriveDown` / `NbuTapeDriveDisabled` per site) — each with

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -21,15 +21,29 @@ compose files mount the JSON read-only into `/var/lib/grafana/dashboards`; Grafa
 folder every 30 seconds, so regenerating the JSON updates the dashboards in place. Edits made in the
 Grafana UI are allowed (`allowUiUpdates: true`) but are not written back to the JSON files.
 
-Panel titles are bilingual (French / English). Every dashboard uses the `${datasource}` template
+Panel titles are bilingual (English / French). Every dashboard uses the `${datasource}` template
 variable (defaulting to the provisioned **Prometheus**), so it keeps working if re-pointed at another
 Prometheus.
 
+### The `$site` selector (multi-site)
+
+Every dashboard also carries a **`$site`** template variable — the first selector after the
+datasource — populated from `label_values(nbu_up, site)` and configured as multi-value with an
+**All** option. Each panel query is filtered by `site=~"$site"`, and per-series panels add `site`
+to their grouping and legend, so when one exporter scrapes several NetBackup primaries (see
+multi-site support) the series neither collapse together nor double-count. Selecting one or more
+sites filters the whole dashboard; "All" shows every site. The Overview's **Sites** row shows one
+UP/DOWN availability tile per primary (repeated over `$site`), so a down master stands out at a
+glance.
+
 ## The four dashboards
+
+All four dashboards share the `$site` selector (above); the table below lists each one's
+**additional** variables.
 
 | Dashboard | File / UID | Focus | Extra variables |
 |-----------|------------|-------|-----------------|
-| **Overview** | `nbu-overview.json` / `nbu-overview` | One-screen health and headline KPIs (success rate, failed backups, storage % used, infected files, alerts) that link out to the domain dashboards | — |
+| **Overview** | `nbu-overview.json` / `nbu-overview` | One-screen health and headline KPIs (per-site availability, success rate, failed backups, storage % used, infected files, alerts) that link out to the domain dashboards | — |
 | **Jobs** | `nbu-jobs.json` / `nbu-jobs` | Backup outcomes, job states, jobs by policy, backup volume, queued jobs, duration p50/p95, files, deduplication | `$policy_type` |
 | **Storage** | `nbu-storage.json` / `nbu-storage` | Capacity utilization, used-vs-total trend, per-unit table, max concurrent jobs, max fragment size | `$storage_unit` |
 | **Data Protection** | `nbu-dataprotection.json` / `nbu-dataprotection` | NetBackup 11.2 collectors: alerts by severity/category, malware scanned vs infected and scan status, catalog malware/anomaly posture, configured SLOs | — |

--- a/docs/superpowers/specs/2026-06-17-multisite-dashboards-design.md
+++ b/docs/superpowers/specs/2026-06-17-multisite-dashboards-design.md
@@ -1,7 +1,7 @@
 # Multi-Site Grafana Dashboards — Design
 
 **Date:** 2026-06-17
-**Status:** Draft for review (depends on Feature 1 shipping the `site` label)
+**Status:** Implemented (Feature 1's `site` label shipped in PR #36)
 **Scope:** Add a `site` template variable and per-site filtering to the generated Grafana
 dashboards, so the multi-site exporter (Feature 1) is usable in one Grafana view.
 **Depends on:** [`2026-06-17-feature1-multisite-design.md`](2026-06-17-feature1-multisite-design.md)
@@ -77,9 +77,21 @@ multiple masters collapse together or double-count.
 - Generator remains the single source of truth (no hand-edited JSON); regenerated output
   committed.
 
-## Open questions for review
+## Open questions for review — resolved
 
-1. Variable source metric: `nbu_up` (always present per site) vs a broader metric — `nbu_up`
-   recommended (one series per site regardless of which collectors are enabled).
-2. Overview "Sites" row: repeated stat panels vs a single status table — which reads better
-   for 2–handful of sites? (Suggest a small table.)
+1. Variable source metric: **`nbu_up`** — chosen (one series per site regardless of which
+   collectors are enabled).
+2. Overview "Sites" row: implemented as a **stat panel repeated over `$site`** (one UP/DOWN tile
+   per primary) rather than a status table — a down master shows as a full red tile, which reads
+   more obviously than a table cell for the typical 2–handful of sites.
+
+## Implementation notes
+
+- The `site=~"$site"` filter and `by (site, …)` grouping are centralized in
+  `grafana/gen/panels.py` (`with_site()`), applied in `target()` and `table_info()` so no panel
+  expression is hand-edited; legends gain a `{{site}}` prefix only where the series keep a per-site
+  label (scalar KPI aggregates stay unprefixed). Both rewrites are idempotent.
+- `grafana/gen/variables.py` adds `site_var()` and the `dashboard()` assembler injects it as the
+  first non-datasource templating entry on every dashboard.
+- `grafana/gen/validate.py` gains `check_site_wiring()`, and `build_dashboards.py` fails the build
+  if any dashboard is missing the `site` selector or leaves a query unfiltered.

--- a/grafana/build_dashboards.py
+++ b/grafana/build_dashboards.py
@@ -2,13 +2,14 @@
 """Generate all nbu_exporter Grafana dashboards from grafana/gen/.
 
 Run from the repo root:  python3 grafana/build_dashboards.py
-Each dashboard is validated against the known nbu_* metric set before writing.
+Each dashboard is validated against the known nbu_* metric set and the multi-site
+template-variable contract before writing.
 """
 import json
 import sys
 
 from grafana.gen import overview, jobs, storage, dataprotection
-from grafana.gen.validate import check_dashboard
+from grafana.gen.validate import check_dashboard, check_site_wiring
 
 OUTPUTS = [
     ("grafana/nbu-overview.json", overview.build),
@@ -25,6 +26,10 @@ def main():
         unknown = check_dashboard(dash)
         if unknown:
             failures.append(f"{path}: unknown metrics {unknown}")
+            continue
+        site_problems = check_site_wiring(dash)
+        if site_problems:
+            failures.append(f"{path}: multi-site wiring: {site_problems}")
             continue
         with open(path, "w") as f:
             json.dump(dash, f, indent=2)

--- a/grafana/gen/dataprotection.py
+++ b/grafana/gen/dataprotection.py
@@ -8,26 +8,26 @@ def build():
     p.reset_ids()
     out = []
 
-    out.append(p.row("Alertes / Alerts", 0))
-    out.append(p.barchart("Alertes par sévérité / Alerts by severity",
+    out.append(p.row("Alerts / Alertes", 0))
+    out.append(p.barchart("Alerts by severity / Alertes par sévérité",
                           "sum by (severity) (nbu_alerts_count)", 0, 1, 12, 8, legend="{{severity}}"))
-    out.append(p.table_info("Alertes par catégorie / Alerts by category",
+    out.append(p.table_info("Alerts by category / Alertes par catégorie",
                             "sum by (category, severity) (nbu_alerts_count)", 12, 1, 12, 8))
 
-    out.append(p.row("Malware / Malware", 9))
-    out.append(p.timeseries("Fichiers scannés vs infectés / Files scanned vs infected",
-                            [p.target("nbu_malware_files_scanned", "scannés / scanned"),
-                             p.target("nbu_malware_files_infected", "infectés / infected")],
+    out.append(p.row("Malware", 9))
+    out.append(p.timeseries("Files scanned vs infected / Fichiers scannés vs infectés",
+                            [p.target("nbu_malware_files_scanned", "scanned / scannés"),
+                             p.target("nbu_malware_files_infected", "infected / infectés")],
                             0, 10, 12, 8))
-    out.append(p.barchart("Statut des scans / Scan status",
+    out.append(p.barchart("Scan status / Statut des scans",
                           "sum by (status) (nbu_malware_scan_count)", 12, 10, 12, 8, legend="{{status}}"))
 
-    out.append(p.row("Catalogue & SLO / Catalog & SLO", 18))
-    out.append(p.barchart("Posture malware / Malware posture",
+    out.append(p.row("Catalog & SLO / Catalogue & SLO", 18))
+    out.append(p.barchart("Malware posture / Posture malware",
                           "sum by (malware_status) (nbu_catalog_images_count)", 0, 19, 8, 8, legend="{{malware_status}}"))
-    out.append(p.barchart("Posture anomalies / Anomaly posture",
+    out.append(p.barchart("Anomaly posture / Posture anomalies",
                           "sum by (anomaly_status) (nbu_catalog_images_count)", 8, 19, 8, 8, legend="{{anomaly_status}}"))
-    out.append(p.stat("SLO configurés / Configured SLOs",
+    out.append(p.stat("Configured SLOs / SLO configurés",
                       "sum(nbu_slo_count)", 16, 19, 8, 8))
 
-    return dashboard("nbu-dataprotection", "NetBackup — Protection des données / Data Protection", out)
+    return dashboard("nbu-dataprotection", "NetBackup — Data Protection / Protection des données", out)

--- a/grafana/gen/jobs.py
+++ b/grafana/gen/jobs.py
@@ -8,33 +8,33 @@ def build():
     p.reset_ids()
     out = []
 
-    out.append(p.row("Résultats / Outcomes", 0))
-    out.append(p.stat("Taux succès BACKUP / Backup success rate",
+    out.append(p.row("Outcomes / Résultats", 0))
+    out.append(p.stat("Backup success rate / Taux succès BACKUP",
                       'sum(nbu_status_count{action="BACKUP",status="0"}) '
                       '/ clamp_min(sum(nbu_status_count{action="BACKUP"}), 1) * 100',
                       0, 1, 6, 8, unit="percent", color_mode="background",
                       thresholds=[{"color": "red", "value": None}, {"color": "yellow", "value": 90}, {"color": "green", "value": 99}]))
-    out.append(p.piechart("États des jobs / Job states",
+    out.append(p.piechart("Job states / États des jobs",
                           "sum by (state) (nbu_jobs_state_count)", 6, 1, 9, 8))
-    out.append(p.barchart("Jobs par politique / Jobs by policy",
+    out.append(p.barchart("Jobs by policy / Jobs par politique",
                           'sum by (policy_type) (nbu_jobs_count{action="BACKUP",policy_type=~"$policy_type"})',
                           15, 1, 9, 8))
 
-    out.append(p.row("Volume & file / Volume & queue", 9))
-    out.append(p.timeseries("Volume sauvegardé / Backup volume",
+    out.append(p.row("Volume & queue / Volume & file", 9))
+    out.append(p.timeseries("Backup volume / Volume sauvegardé",
                             [p.target('sum by (policy_type) (nbu_jobs_bytes{action="BACKUP",policy_type=~"$policy_type"})', "{{policy_type}}")],
                             0, 10, 12, 8, unit="bytes", stack=True))
-    out.append(p.barchart("Jobs en file / Queued jobs",
+    out.append(p.barchart("Queued jobs / Jobs en file",
                           "sum by (reason) (nbu_jobs_queued_count)", 12, 10, 12, 8, legend="{{reason}}"))
 
-    out.append(p.row("Durées & efficacité / Durations & efficiency", 18))
-    out.append(p.timeseries("Durée jobs p50/p95 / Job duration p50/p95",
+    out.append(p.row("Durations & efficiency / Durées & efficacité", 18))
+    out.append(p.timeseries("Job duration p50/p95 / Durée jobs p50/p95",
                             [p.target('histogram_quantile(0.95, sum by (le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~"$policy_type"}))', "p95 {{policy_type}}"),
                              p.target('histogram_quantile(0.50, sum by (le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~"$policy_type"}))', "p50 {{policy_type}}")],
                             0, 19, 16, 8, unit="s", fill=0))
-    out.append(p.stat("Fichiers traités / Files processed",
+    out.append(p.stat("Files processed / Fichiers traités",
                       'sum(nbu_jobs_files_count{policy_type=~"$policy_type"})', 16, 19, 4, 8))
-    out.append(p.stat("Dédup moyenne / Mean dedup ratio",
+    out.append(p.stat("Mean dedup ratio / Dédup moyenne",
                       'avg(nbu_jobs_dedup_ratio{policy_type=~"$policy_type"})', 20, 19, 4, 8, unit="none"))
 
-    return dashboard("nbu-jobs", "NetBackup — Sauvegardes / Jobs", out, extra_vars=[policy_type_var()])
+    return dashboard("nbu-jobs", "NetBackup — Jobs / Sauvegardes", out, extra_vars=[policy_type_var()])

--- a/grafana/gen/overview.py
+++ b/grafana/gen/overview.py
@@ -11,40 +11,44 @@ def build():
     p.reset_ids()
     out = []
 
-    out.append(p.row("Santé / Health", 0))
-    out.append(p.stat("Disponibilité / Availability", "nbu_up", 0, 1, 5, 4,
-                      mappings=UP_MAP, color_mode="background",
+    # Per-site availability: one tile per NetBackup primary (repeats over $site), so a
+    # down master is immediately obvious even with "All" sites selected.
+    out.append(p.row("Sites", 0))
+    out.append(p.stat("$site", "nbu_up", 0, 1, 4, 4,
+                      mappings=UP_MAP, color_mode="background", legend="{{site}}", repeat="site",
                       thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 1}]))
-    out.append(p.stat("Version API / API version", "nbu_api_version", 5, 1, 4, 4,
+
+    out.append(p.row("Health / Santé", 5))
+    out.append(p.stat("API version / Version API", "nbu_api_version", 0, 6, 6, 4,
                       text_mode="name", legend="{{version}}"))
-    out.append(p.stat("Fraîcheur scrape / Scrape staleness",
-                      "time() - nbu_last_scrape_timestamp_seconds", 9, 1, 6, 4,
+    out.append(p.stat("Scrape staleness / Fraîcheur scrape",
+                      "time() - nbu_last_scrape_timestamp_seconds", 6, 6, 8, 4,
                       unit="s", legend="{{source}}",
                       thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 300}, {"color": "red", "value": 900}]))
-    out.append(p.timeseries("Latence API / API latency",
-                            [p.target("nbu_response_time_ms", "réponse / response")],
-                            15, 1, 9, 4, unit="ms"))
+    out.append(p.timeseries("API latency / Latence API",
+                            [p.target("nbu_response_time_ms", "response / réponse")],
+                            14, 6, 10, 4, unit="ms"))
 
-    out.append(p.row("Indicateurs clés / Key indicators", 5))
-    out.append(p.stat("Taux succès BACKUP / Backup success rate",
+    out.append(p.row("Key indicators / Indicateurs clés", 10))
+    out.append(p.stat("Backup success rate / Taux succès BACKUP",
                       'sum(nbu_status_count{action="BACKUP",status="0"}) '
                       '/ clamp_min(sum(nbu_status_count{action="BACKUP"}), 1) * 100',
-                      0, 6, 5, 5, unit="percent", color_mode="background",
+                      0, 11, 5, 5, unit="percent", color_mode="background",
                       thresholds=[{"color": "red", "value": None}, {"color": "yellow", "value": 90}, {"color": "green", "value": 99}]))
-    out.append(p.stat("Échecs BACKUP / Failed backups",
+    out.append(p.stat("Failed backups / Échecs BACKUP",
                       'sum(nbu_status_count{action="BACKUP"}) '
                       '- sum(nbu_status_count{action="BACKUP",status="0"})',
-                      5, 6, 5, 5,
+                      5, 11, 5, 5,
                       thresholds=[{"color": "green", "value": None}, {"color": "red", "value": 1}]))
-    out.append(p.stat("Stockage % utilisé / Storage % used",
+    out.append(p.stat("Storage % used / Stockage % utilisé",
                       'sum(nbu_disk_bytes{size="used"}) / clamp_min(sum(nbu_disk_bytes), 1) * 100',
-                      10, 6, 4, 5, unit="percent",
+                      10, 11, 4, 5, unit="percent",
                       thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 80}, {"color": "red", "value": 90}]))
-    out.append(p.stat("Fichiers infectés / Infected files",
-                      "sum(nbu_malware_files_infected)", 14, 6, 5, 5,
+    out.append(p.stat("Infected files / Fichiers infectés",
+                      "sum(nbu_malware_files_infected)", 14, 11, 5, 5,
                       thresholds=[{"color": "green", "value": None}, {"color": "red", "value": 1}]))
-    out.append(p.barchart("Alertes par sévérité / Alerts by severity",
-                          "sum by (severity) (nbu_alerts_count)", 19, 6, 5, 5,
+    out.append(p.barchart("Alerts by severity / Alertes par sévérité",
+                          "sum by (severity) (nbu_alerts_count)", 19, 11, 5, 5,
                           legend="{{severity}}"))
 
-    return dashboard("nbu-overview", "NetBackup — Vue d'ensemble / Overview", out)
+    return dashboard("nbu-overview", "NetBackup — Overview / Vue d'ensemble", out)

--- a/grafana/gen/panels.py
+++ b/grafana/gen/panels.py
@@ -1,5 +1,7 @@
 """Shared Grafana panel/layout helpers for the nbu_exporter dashboards."""
 
+import re
+
 DS = "${datasource}"
 _id = 0
 
@@ -20,15 +22,71 @@ def ds():
     return {"type": "prometheus", "uid": DS}
 
 
+# --- Multi-site query rewriting -------------------------------------------------
+# Every dashboard filters its queries by the `site` template variable so series from
+# multiple NetBackup primaries neither collapse together nor double-count. Instead of
+# hand-editing each PromQL string, every expression flows through with_site(): it
+# injects site=~"$site" into each nbu_* selector and adds `site` to any `by (...)`
+# grouping. Both steps are idempotent, so already-wired exprs pass through unchanged.
+SITE_MATCHER = 'site=~"$site"'
+
+_SELECTOR_RE = re.compile(r"(nbu_[a-z0-9_]+)(\{[^{}]*\})?")
+_BY_RE = re.compile(r"\bby\s*\(\s*([^)]*)\)")
+# Vector aggregations that drop the `site` label unless it is named in `by (...)`.
+# (Metric names like nbu_storage_max_… don't match — the keyword is `_`-bounded there.)
+_AGG_RE = re.compile(r"\b(sum|avg|count|min|max|group|stddev|stdvar|topk|bottomk|count_values)\b")
+
+
+def _filter_selectors(expr):
+    def repl(m):
+        name, braces = m.group(1), m.group(2)
+        if braces is None:
+            return f"{name}{{{SITE_MATCHER}}}"
+        inner = braces[1:-1].strip()
+        if re.search(r"(^|,)\s*site\s*=", inner):  # already filtered by site
+            return m.group(0)
+        return f"{name}{{{inner},{SITE_MATCHER}}}" if inner else f"{name}{{{SITE_MATCHER}}}"
+    return _SELECTOR_RE.sub(repl, expr)
+
+
+def _group_by_site(expr):
+    def repl(m):
+        labels = [g.strip() for g in m.group(1).split(",") if g.strip()]
+        if "site" in labels:
+            return m.group(0)
+        return "by (" + ", ".join(["site"] + labels) + ")"
+    return _BY_RE.sub(repl, expr)
+
+
+def with_site(expr):
+    """Filter an expression by the site variable and group per-site (idempotent)."""
+    return _group_by_site(_filter_selectors(expr))
+
+
+def _carries_site(expr):
+    """True if the rewritten expr yields series that keep a distinguishing `site` label."""
+    if "by (site" in expr:           # explicitly grouped per-site
+        return True
+    return not _AGG_RE.search(expr)  # no label-dropping aggregation wraps it
+
+
+def _legend_with_site(expr, legend):
+    """Prefix a legend with {{site}} when the series carry a per-site label."""
+    if not _carries_site(expr) or "{{site}}" in legend:
+        return legend
+    return "{{site}} / " + legend if legend else "{{site}}"
+
+
 def gridpos(x, y, w, h):
     return {"x": x, "y": y, "w": w, "h": h}
 
 
 def target(expr, legend="", instant=False):
+    expr = with_site(expr)
     return {
         "datasource": ds(),
         "expr": expr,
-        "legendFormat": legend,
+        "legendFormat": _legend_with_site(expr, legend),
         "range": not instant,
         "instant": instant,
         "refId": "A",
@@ -47,8 +105,8 @@ def row(title, y):
 
 
 def stat(title, expr, x, y, w, h, unit="none", mappings=None, thresholds=None,
-         text_mode="auto", legend="", color_mode="value"):
-    return {
+         text_mode="auto", legend="", color_mode="value", repeat=None):
+    panel = {
         "type": "stat",
         "id": nid(),
         "title": title,
@@ -76,6 +134,11 @@ def stat(title, expr, x, y, w, h, unit="none", mappings=None, thresholds=None,
         },
         "targets": [target(expr, legend, instant=True)],
     }
+    if repeat:
+        # Render one panel per value of the given template variable (e.g. site).
+        panel["repeat"] = repeat
+        panel["repeatDirection"] = "h"
+    return panel
 
 
 def gauge(title, expr, x, y, w, h, legend="{{name}}"):
@@ -190,7 +253,7 @@ def table_info(title, expr, x, y, w, h):
         "options": {"showHeader": True},
         "targets": [{
             "datasource": ds(),
-            "expr": expr,
+            "expr": with_site(expr),
             "format": "table",
             "instant": True,
             "refId": "A",

--- a/grafana/gen/storage.py
+++ b/grafana/gen/storage.py
@@ -8,24 +8,24 @@ def build():
     p.reset_ids()
     out = []
 
-    out.append(p.row("Capacité / Capacity", 0))
-    out.append(p.gauge("% Utilisé / % Used",
+    out.append(p.row("Capacity / Capacité", 0))
+    out.append(p.gauge("% Used / % Utilisé",
                        'sum by (name) (nbu_disk_bytes{name=~"$storage_unit",size="used"}) '
                        '/ sum by (name) (nbu_disk_bytes{name=~"$storage_unit"}) * 100',
                        0, 1, 8, 8))
-    out.append(p.timeseries("Capacité utilisée / Used capacity",
+    out.append(p.timeseries("Used capacity / Capacité utilisée",
                             [p.target('sum by (name) (nbu_disk_bytes{name=~"$storage_unit",size="used"})', "{{name}} used"),
                              p.target('nbu_disk_capacity_bytes{name=~"$storage_unit"}', "{{name}} total")],
                             8, 1, 16, 8, unit="bytes"))
 
-    out.append(p.row("Unités / Units", 9))
-    out.append(p.table_info("Unités de stockage / Storage units",
+    out.append(p.row("Units / Unités", 9))
+    out.append(p.table_info("Storage units / Unités de stockage",
                             'nbu_storage_info{name=~"$storage_unit"}', 0, 10, 16, 8))
-    out.append(p.stat("Jobs simultanés max / Max concurrent jobs",
+    out.append(p.stat("Max concurrent jobs / Jobs simultanés max",
                       'nbu_storage_max_concurrent_jobs{name=~"$storage_unit"}', 16, 10, 4, 8,
                       legend="{{name}}"))
-    out.append(p.stat("Taille fragment max / Max fragment size",
+    out.append(p.stat("Max fragment size / Taille fragment max",
                       'nbu_storage_max_fragment_size_bytes{name=~"$storage_unit"}', 20, 10, 4, 8,
                       unit="bytes", legend="{{name}}"))
 
-    return dashboard("nbu-storage", "NetBackup — Stockage / Storage", out, extra_vars=[storage_unit_var()])
+    return dashboard("nbu-storage", "NetBackup — Storage / Stockage", out, extra_vars=[storage_unit_var()])

--- a/grafana/gen/validate.py
+++ b/grafana/gen/validate.py
@@ -61,3 +61,50 @@ def check_dashboard(dash):
                 if name not in KNOWN_METRICS:
                     unknown.add(token)
     return sorted(unknown)
+
+
+# The site template variable contract (multi-site dashboards). Every dashboard must
+# carry one `site` selector and filter every query by it, so series from multiple
+# NetBackup primaries neither collapse together nor double-count.
+SITE_FILTER = 'site=~"$site"'
+SITE_VAR_QUERY = "label_values(nbu_up, site)"
+
+
+def _var_query(var):
+    """The PromQL query string of a Grafana query variable (dict or bare string form)."""
+    q = var.get("query", "")
+    return q.get("query", "") if isinstance(q, dict) else q
+
+
+def check_site_wiring(dash):
+    """Return a sorted list of multi-site wiring problems for the dashboard.
+
+    Enforces the multi-site dashboard contract:
+      - exactly one `site` query variable, sourced from label_values(nbu_up, site),
+        multi-value + includeAll, and the first non-datasource templating entry;
+      - every panel target expression is filtered by site=~"$site".
+    """
+    problems = []
+    tmpl = dash.get("templating", {}).get("list", [])
+
+    site_vars = [v for v in tmpl if v.get("name") == "site"]
+    if not site_vars:
+        problems.append("missing 'site' template variable")
+    else:
+        if len(site_vars) > 1:
+            problems.append("duplicate 'site' template variable")
+        sv = site_vars[0]
+        if SITE_VAR_QUERY not in _var_query(sv):
+            problems.append(f"site var not sourced from {SITE_VAR_QUERY}")
+        if not sv.get("multi") or not sv.get("includeAll"):
+            problems.append("site var must be multi-value + includeAll")
+        non_ds = [v for v in tmpl if v.get("type") != "datasource"]
+        if not non_ds or non_ds[0].get("name") != "site":
+            problems.append("site var must be the first non-datasource templating entry")
+
+    for panel in dash.get("panels", []):
+        for expr in _iter_exprs(panel):
+            if SITE_FILTER not in expr:
+                problems.append(f"expr not filtered by site: {expr[:70]}")
+
+    return sorted(set(problems))

--- a/grafana/gen/variables.py
+++ b/grafana/gen/variables.py
@@ -31,6 +31,12 @@ def _query_var(name, label, metric, value_label):
     }
 
 
+def site_var():
+    # One series per NetBackup primary regardless of which collectors are enabled,
+    # so nbu_up is the most reliable source for the site list.
+    return _query_var("site", "Site", "nbu_up", "site")
+
+
 def storage_unit_var():
     return _query_var("storage_unit", "Storage unit", "nbu_disk_bytes", "name")
 
@@ -54,8 +60,12 @@ def dashboard_links():
 
 
 def dashboard(uid, title, panels, extra_vars=None):
-    """Assemble a full dashboard dict. `extra_vars` are appended after the datasource var."""
-    templating = {"list": [datasource_var()] + (extra_vars or [])}
+    """Assemble a full dashboard dict.
+
+    The `site` selector is wired onto every dashboard as the first non-datasource
+    variable; `extra_vars` (dashboard-specific selectors) follow it.
+    """
+    templating = {"list": [datasource_var(), site_var()] + (extra_vars or [])}
     return {
         "uid": uid,
         "title": title,

--- a/grafana/nbu-dataprotection.json
+++ b/grafana/nbu-dataprotection.json
@@ -1,6 +1,6 @@
 {
   "uid": "nbu-dataprotection",
-  "title": "NetBackup \u2014 Protection des donn\u00e9es / Data Protection",
+  "title": "NetBackup \u2014 Data Protection / Protection des donn\u00e9es",
   "tags": [
     "netbackup",
     "nbu",
@@ -41,6 +41,28 @@
         "current": {},
         "hide": 0,
         "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
       }
     ]
   },
@@ -62,7 +84,7 @@
     {
       "type": "row",
       "id": 1,
-      "title": "Alertes / Alerts",
+      "title": "Alerts / Alertes",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -75,7 +97,7 @@
     {
       "type": "barchart",
       "id": 2,
-      "title": "Alertes par s\u00e9v\u00e9rit\u00e9 / Alerts by severity",
+      "title": "Alerts by severity / Alertes par s\u00e9v\u00e9rit\u00e9",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -109,8 +131,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (severity) (nbu_alerts_count)",
-          "legendFormat": "{{severity}}",
+          "expr": "sum by (site, severity) (nbu_alerts_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{severity}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -120,7 +142,7 @@
     {
       "type": "table",
       "id": 3,
-      "title": "Alertes par cat\u00e9gorie / Alerts by category",
+      "title": "Alerts by category / Alertes par cat\u00e9gorie",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -148,7 +170,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (category, severity) (nbu_alerts_count)",
+          "expr": "sum by (site, category, severity) (nbu_alerts_count{site=~\"$site\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -176,7 +198,7 @@
     {
       "type": "row",
       "id": 4,
-      "title": "Malware / Malware",
+      "title": "Malware",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -189,7 +211,7 @@
     {
       "type": "timeseries",
       "id": 5,
-      "title": "Fichiers scann\u00e9s vs infect\u00e9s / Files scanned vs infected",
+      "title": "Files scanned vs infected / Fichiers scann\u00e9s vs infect\u00e9s",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -239,8 +261,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_malware_files_scanned",
-          "legendFormat": "scann\u00e9s / scanned",
+          "expr": "nbu_malware_files_scanned{site=~\"$site\"}",
+          "legendFormat": "{{site}} / scanned / scann\u00e9s",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -250,8 +272,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_malware_files_infected",
-          "legendFormat": "infect\u00e9s / infected",
+          "expr": "nbu_malware_files_infected{site=~\"$site\"}",
+          "legendFormat": "{{site}} / infected / infect\u00e9s",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -261,7 +283,7 @@
     {
       "type": "barchart",
       "id": 6,
-      "title": "Statut des scans / Scan status",
+      "title": "Scan status / Statut des scans",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -295,8 +317,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (status) (nbu_malware_scan_count)",
-          "legendFormat": "{{status}}",
+          "expr": "sum by (site, status) (nbu_malware_scan_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{status}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -306,7 +328,7 @@
     {
       "type": "row",
       "id": 7,
-      "title": "Catalogue & SLO / Catalog & SLO",
+      "title": "Catalog & SLO / Catalogue & SLO",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -319,7 +341,7 @@
     {
       "type": "barchart",
       "id": 8,
-      "title": "Posture malware / Malware posture",
+      "title": "Malware posture / Posture malware",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -353,8 +375,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (malware_status) (nbu_catalog_images_count)",
-          "legendFormat": "{{malware_status}}",
+          "expr": "sum by (site, malware_status) (nbu_catalog_images_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{malware_status}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -364,7 +386,7 @@
     {
       "type": "barchart",
       "id": 9,
-      "title": "Posture anomalies / Anomaly posture",
+      "title": "Anomaly posture / Posture anomalies",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -398,8 +420,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (anomaly_status) (nbu_catalog_images_count)",
-          "legendFormat": "{{anomaly_status}}",
+          "expr": "sum by (site, anomaly_status) (nbu_catalog_images_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{anomaly_status}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -409,7 +431,7 @@
     {
       "type": "stat",
       "id": 10,
-      "title": "SLO configur\u00e9s / Configured SLOs",
+      "title": "Configured SLOs / SLO configur\u00e9s",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -459,7 +481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_slo_count)",
+          "expr": "sum(nbu_slo_count{site=~\"$site\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,

--- a/grafana/nbu-jobs.json
+++ b/grafana/nbu-jobs.json
@@ -1,6 +1,6 @@
 {
   "uid": "nbu-jobs",
-  "title": "NetBackup \u2014 Sauvegardes / Jobs",
+  "title": "NetBackup \u2014 Jobs / Sauvegardes",
   "tags": [
     "netbackup",
     "nbu",
@@ -41,6 +41,28 @@
         "current": {},
         "hide": 0,
         "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
       },
       {
         "name": "policy_type",
@@ -84,7 +106,7 @@
     {
       "type": "row",
       "id": 1,
-      "title": "R\u00e9sultats / Outcomes",
+      "title": "Outcomes / R\u00e9sultats",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -97,7 +119,7 @@
     {
       "type": "stat",
       "id": 2,
-      "title": "Taux succ\u00e8s BACKUP / Backup success rate",
+      "title": "Backup success rate / Taux succ\u00e8s BACKUP",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -155,7 +177,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_status_count{action=\"BACKUP\",status=\"0\"}) / clamp_min(sum(nbu_status_count{action=\"BACKUP\"}), 1) * 100",
+          "expr": "sum(nbu_status_count{action=\"BACKUP\",status=\"0\",site=~\"$site\"}) / clamp_min(sum(nbu_status_count{action=\"BACKUP\",site=~\"$site\"}), 1) * 100",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -166,7 +188,7 @@
     {
       "type": "piechart",
       "id": 3,
-      "title": "\u00c9tats des jobs / Job states",
+      "title": "Job states / \u00c9tats des jobs",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -209,8 +231,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (state) (nbu_jobs_state_count)",
-          "legendFormat": "{{state}}",
+          "expr": "sum by (site, state) (nbu_jobs_state_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{state}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -220,7 +242,7 @@
     {
       "type": "barchart",
       "id": 4,
-      "title": "Jobs par politique / Jobs by policy",
+      "title": "Jobs by policy / Jobs par politique",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -254,8 +276,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (policy_type) (nbu_jobs_count{action=\"BACKUP\",policy_type=~\"$policy_type\"})",
-          "legendFormat": "{{policy_type}}",
+          "expr": "sum by (site, policy_type) (nbu_jobs_count{action=\"BACKUP\",policy_type=~\"$policy_type\",site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{policy_type}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -265,7 +287,7 @@
     {
       "type": "row",
       "id": 5,
-      "title": "Volume & file / Volume & queue",
+      "title": "Volume & queue / Volume & file",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -278,7 +300,7 @@
     {
       "type": "timeseries",
       "id": 6,
-      "title": "Volume sauvegard\u00e9 / Backup volume",
+      "title": "Backup volume / Volume sauvegard\u00e9",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -328,8 +350,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (policy_type) (nbu_jobs_bytes{action=\"BACKUP\",policy_type=~\"$policy_type\"})",
-          "legendFormat": "{{policy_type}}",
+          "expr": "sum by (site, policy_type) (nbu_jobs_bytes{action=\"BACKUP\",policy_type=~\"$policy_type\",site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{policy_type}}",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -339,7 +361,7 @@
     {
       "type": "barchart",
       "id": 7,
-      "title": "Jobs en file / Queued jobs",
+      "title": "Queued jobs / Jobs en file",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -373,8 +395,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (nbu_jobs_queued_count)",
-          "legendFormat": "{{reason}}",
+          "expr": "sum by (site, reason) (nbu_jobs_queued_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{reason}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -384,7 +406,7 @@
     {
       "type": "row",
       "id": 8,
-      "title": "Dur\u00e9es & efficacit\u00e9 / Durations & efficiency",
+      "title": "Durations & efficiency / Dur\u00e9es & efficacit\u00e9",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -397,7 +419,7 @@
     {
       "type": "timeseries",
       "id": 9,
-      "title": "Dur\u00e9e jobs p50/p95 / Job duration p50/p95",
+      "title": "Job duration p50/p95 / Dur\u00e9e jobs p50/p95",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -447,8 +469,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~\"$policy_type\"}))",
-          "legendFormat": "p95 {{policy_type}}",
+          "expr": "histogram_quantile(0.95, sum by (site, le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~\"$policy_type\",site=~\"$site\"}))",
+          "legendFormat": "{{site}} / p95 {{policy_type}}",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -458,8 +480,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~\"$policy_type\"}))",
-          "legendFormat": "p50 {{policy_type}}",
+          "expr": "histogram_quantile(0.50, sum by (site, le, policy_type) (nbu_job_duration_seconds_bucket{policy_type=~\"$policy_type\",site=~\"$site\"}))",
+          "legendFormat": "{{site}} / p50 {{policy_type}}",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -469,7 +491,7 @@
     {
       "type": "stat",
       "id": 10,
-      "title": "Fichiers trait\u00e9s / Files processed",
+      "title": "Files processed / Fichiers trait\u00e9s",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -519,7 +541,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_jobs_files_count{policy_type=~\"$policy_type\"})",
+          "expr": "sum(nbu_jobs_files_count{policy_type=~\"$policy_type\",site=~\"$site\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -530,7 +552,7 @@
     {
       "type": "stat",
       "id": 11,
-      "title": "D\u00e9dup moyenne / Mean dedup ratio",
+      "title": "Mean dedup ratio / D\u00e9dup moyenne",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -580,7 +602,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg(nbu_jobs_dedup_ratio{policy_type=~\"$policy_type\"})",
+          "expr": "avg(nbu_jobs_dedup_ratio{policy_type=~\"$policy_type\",site=~\"$site\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,

--- a/grafana/nbu-overview.json
+++ b/grafana/nbu-overview.json
@@ -1,6 +1,6 @@
 {
   "uid": "nbu-overview",
-  "title": "NetBackup \u2014 Vue d'ensemble / Overview",
+  "title": "NetBackup \u2014 Overview / Vue d'ensemble",
   "tags": [
     "netbackup",
     "nbu",
@@ -41,6 +41,28 @@
         "current": {},
         "hide": 0,
         "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
       }
     ]
   },
@@ -62,7 +84,7 @@
     {
       "type": "row",
       "id": 1,
-      "title": "Sant\u00e9 / Health",
+      "title": "Sites",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -75,7 +97,7 @@
     {
       "type": "stat",
       "id": 2,
-      "title": "Disponibilit\u00e9 / Availability",
+      "title": "$site",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -83,7 +105,7 @@
       "gridPos": {
         "x": 0,
         "y": 1,
-        "w": 5,
+        "w": 4,
         "h": 4
       },
       "fieldConfig": {
@@ -143,26 +165,41 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_up",
-          "legendFormat": "",
+          "expr": "nbu_up{site=~\"$site\"}",
+          "legendFormat": "{{site}}",
           "range": false,
           "instant": true,
           "refId": "A"
         }
-      ]
+      ],
+      "repeat": "site",
+      "repeatDirection": "h"
+    },
+    {
+      "type": "row",
+      "id": 3,
+      "title": "Health / Sant\u00e9",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
     },
     {
       "type": "stat",
-      "id": 3,
-      "title": "Version API / API version",
+      "id": 4,
+      "title": "API version / Version API",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
-        "x": 5,
-        "y": 1,
-        "w": 4,
+        "x": 0,
+        "y": 6,
+        "w": 6,
         "h": 4
       },
       "fieldConfig": {
@@ -204,8 +241,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_api_version",
-          "legendFormat": "{{version}}",
+          "expr": "nbu_api_version{site=~\"$site\"}",
+          "legendFormat": "{{site}} / {{version}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -214,16 +251,16 @@
     },
     {
       "type": "stat",
-      "id": 4,
-      "title": "Fra\u00eecheur scrape / Scrape staleness",
+      "id": 5,
+      "title": "Scrape staleness / Fra\u00eecheur scrape",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
-        "x": 9,
-        "y": 1,
-        "w": 6,
+        "x": 6,
+        "y": 6,
+        "w": 8,
         "h": 4
       },
       "fieldConfig": {
@@ -273,8 +310,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "time() - nbu_last_scrape_timestamp_seconds",
-          "legendFormat": "{{source}}",
+          "expr": "time() - nbu_last_scrape_timestamp_seconds{site=~\"$site\"}",
+          "legendFormat": "{{site}} / {{source}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -283,16 +320,16 @@
     },
     {
       "type": "timeseries",
-      "id": 5,
-      "title": "Latence API / API latency",
+      "id": 6,
+      "title": "API latency / Latence API",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
-        "x": 15,
-        "y": 1,
-        "w": 9,
+        "x": 14,
+        "y": 6,
+        "w": 10,
         "h": 4
       },
       "fieldConfig": {
@@ -334,8 +371,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_response_time_ms",
-          "legendFormat": "r\u00e9ponse / response",
+          "expr": "nbu_response_time_ms{site=~\"$site\"}",
+          "legendFormat": "{{site}} / response / r\u00e9ponse",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -344,12 +381,12 @@
     },
     {
       "type": "row",
-      "id": 6,
-      "title": "Indicateurs cl\u00e9s / Key indicators",
+      "id": 7,
+      "title": "Key indicators / Indicateurs cl\u00e9s",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 5,
+        "y": 10,
         "w": 24,
         "h": 1
       },
@@ -357,15 +394,15 @@
     },
     {
       "type": "stat",
-      "id": 7,
-      "title": "Taux succ\u00e8s BACKUP / Backup success rate",
+      "id": 8,
+      "title": "Backup success rate / Taux succ\u00e8s BACKUP",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "x": 0,
-        "y": 6,
+        "y": 11,
         "w": 5,
         "h": 5
       },
@@ -416,7 +453,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_status_count{action=\"BACKUP\",status=\"0\"}) / clamp_min(sum(nbu_status_count{action=\"BACKUP\"}), 1) * 100",
+          "expr": "sum(nbu_status_count{action=\"BACKUP\",status=\"0\",site=~\"$site\"}) / clamp_min(sum(nbu_status_count{action=\"BACKUP\",site=~\"$site\"}), 1) * 100",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -426,15 +463,15 @@
     },
     {
       "type": "stat",
-      "id": 8,
-      "title": "\u00c9checs BACKUP / Failed backups",
+      "id": 9,
+      "title": "Failed backups / \u00c9checs BACKUP",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "x": 5,
-        "y": 6,
+        "y": 11,
         "w": 5,
         "h": 5
       },
@@ -481,7 +518,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_status_count{action=\"BACKUP\"}) - sum(nbu_status_count{action=\"BACKUP\",status=\"0\"})",
+          "expr": "sum(nbu_status_count{action=\"BACKUP\",site=~\"$site\"}) - sum(nbu_status_count{action=\"BACKUP\",status=\"0\",site=~\"$site\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -491,15 +528,15 @@
     },
     {
       "type": "stat",
-      "id": 9,
-      "title": "Stockage % utilis\u00e9 / Storage % used",
+      "id": 10,
+      "title": "Storage % used / Stockage % utilis\u00e9",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "x": 10,
-        "y": 6,
+        "y": 11,
         "w": 4,
         "h": 5
       },
@@ -550,7 +587,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_disk_bytes{size=\"used\"}) / clamp_min(sum(nbu_disk_bytes), 1) * 100",
+          "expr": "sum(nbu_disk_bytes{size=\"used\",site=~\"$site\"}) / clamp_min(sum(nbu_disk_bytes{site=~\"$site\"}), 1) * 100",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -560,15 +597,15 @@
     },
     {
       "type": "stat",
-      "id": 10,
-      "title": "Fichiers infect\u00e9s / Infected files",
+      "id": 11,
+      "title": "Infected files / Fichiers infect\u00e9s",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "x": 14,
-        "y": 6,
+        "y": 11,
         "w": 5,
         "h": 5
       },
@@ -615,7 +652,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(nbu_malware_files_infected)",
+          "expr": "sum(nbu_malware_files_infected{site=~\"$site\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -625,15 +662,15 @@
     },
     {
       "type": "barchart",
-      "id": 11,
-      "title": "Alertes par s\u00e9v\u00e9rit\u00e9 / Alerts by severity",
+      "id": 12,
+      "title": "Alerts by severity / Alertes par s\u00e9v\u00e9rit\u00e9",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "gridPos": {
         "x": 19,
-        "y": 6,
+        "y": 11,
         "w": 5,
         "h": 5
       },
@@ -660,8 +697,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (severity) (nbu_alerts_count)",
-          "legendFormat": "{{severity}}",
+          "expr": "sum by (site, severity) (nbu_alerts_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{severity}}",
           "range": false,
           "instant": true,
           "refId": "A"

--- a/grafana/nbu-storage.json
+++ b/grafana/nbu-storage.json
@@ -1,6 +1,6 @@
 {
   "uid": "nbu-storage",
-  "title": "NetBackup \u2014 Stockage / Storage",
+  "title": "NetBackup \u2014 Storage / Stockage",
   "tags": [
     "netbackup",
     "nbu",
@@ -41,6 +41,28 @@
         "current": {},
         "hide": 0,
         "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
       },
       {
         "name": "storage_unit",
@@ -84,7 +106,7 @@
     {
       "type": "row",
       "id": 1,
-      "title": "Capacit\u00e9 / Capacity",
+      "title": "Capacity / Capacit\u00e9",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -97,7 +119,7 @@
     {
       "type": "gauge",
       "id": 2,
-      "title": "% Utilis\u00e9 / % Used",
+      "title": "% Used / % Utilis\u00e9",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -154,8 +176,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (name) (nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\"}) / sum by (name) (nbu_disk_bytes{name=~\"$storage_unit\"}) * 100",
-          "legendFormat": "{{name}}",
+          "expr": "sum by (site, name) (nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\",site=~\"$site\"}) / sum by (site, name) (nbu_disk_bytes{name=~\"$storage_unit\",site=~\"$site\"}) * 100",
+          "legendFormat": "{{site}} / {{name}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -165,7 +187,7 @@
     {
       "type": "timeseries",
       "id": 3,
-      "title": "Capacit\u00e9 utilis\u00e9e / Used capacity",
+      "title": "Used capacity / Capacit\u00e9 utilis\u00e9e",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -215,8 +237,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (name) (nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\"})",
-          "legendFormat": "{{name}} used",
+          "expr": "sum by (site, name) (nbu_disk_bytes{name=~\"$storage_unit\",size=\"used\",site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{name}} used",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -226,8 +248,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_disk_capacity_bytes{name=~\"$storage_unit\"}",
-          "legendFormat": "{{name}} total",
+          "expr": "nbu_disk_capacity_bytes{name=~\"$storage_unit\",site=~\"$site\"}",
+          "legendFormat": "{{site}} / {{name}} total",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -237,7 +259,7 @@
     {
       "type": "row",
       "id": 4,
-      "title": "Unit\u00e9s / Units",
+      "title": "Units / Unit\u00e9s",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -250,7 +272,7 @@
     {
       "type": "table",
       "id": 5,
-      "title": "Unit\u00e9s de stockage / Storage units",
+      "title": "Storage units / Unit\u00e9s de stockage",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -278,7 +300,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_storage_info{name=~\"$storage_unit\"}",
+          "expr": "nbu_storage_info{name=~\"$storage_unit\",site=~\"$site\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -306,7 +328,7 @@
     {
       "type": "stat",
       "id": 6,
-      "title": "Jobs simultan\u00e9s max / Max concurrent jobs",
+      "title": "Max concurrent jobs / Jobs simultan\u00e9s max",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -356,8 +378,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_storage_max_concurrent_jobs{name=~\"$storage_unit\"}",
-          "legendFormat": "{{name}}",
+          "expr": "nbu_storage_max_concurrent_jobs{name=~\"$storage_unit\",site=~\"$site\"}",
+          "legendFormat": "{{site}} / {{name}}",
           "range": false,
           "instant": true,
           "refId": "A"
@@ -367,7 +389,7 @@
     {
       "type": "stat",
       "id": 7,
-      "title": "Taille fragment max / Max fragment size",
+      "title": "Max fragment size / Taille fragment max",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -417,8 +439,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "nbu_storage_max_fragment_size_bytes{name=~\"$storage_unit\"}",
-          "legendFormat": "{{name}}",
+          "expr": "nbu_storage_max_fragment_size_bytes{name=~\"$storage_unit\",site=~\"$site\"}",
+          "legendFormat": "{{site}} / {{name}}",
           "range": false,
           "instant": true,
           "refId": "A"


### PR DESCRIPTION
## Summary

Adds a multi-site `$site` selector to the generated Grafana dashboards so one exporter scraping multiple NetBackup primaries is usable in a single Grafana view.

- `$site` template variable (multi + All, from `label_values(nbu_up, site)`) as the first selector on every dashboard
- Every panel query filtered by `site=~"$site"`; `site` threaded into each `by (...)` grouping and `{{site}}` added to per-series legends (scalar KPIs left unprefixed)
- Overview **Sites** row: one UP/DOWN availability tile per primary (repeated over `$site`) so a down master is obvious
- Filter/grouping centralized in `grafana/gen/panels.with_site()` (idempotent) — no hand-edited JSON
- `build_dashboards.py` fails the build (`validate.check_site_wiring`) if a dashboard lacks the `site` selector or leaves a query unfiltered
- Panel labels switched to English-first (`English / French`)

## Test plan

- `python3 -m grafana.build_dashboards` passes the metric + site-wiring gates; regenerated JSON is deterministic and valid
- Verified every expr is site-filtered, `by (site, le, ...)` keeps `le`, no `by (site, site)` doubling, and division panels match per-site on both sides
- `make ci` green (Go unaffected)
- Remaining: live two-site compose check (dropdown lists both sites, All shows both, a stopped master shows nbu_up=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Grafana dashboards now support multi-site filtering via a new site selector, enabling location-specific monitoring across Overview, Jobs, Data Protection, and Storage dashboards
  * Overview dashboard displays per-site availability status indicators

* **Style**
  * Updated dashboard panel titles to English/French ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->