### PR TITLE
feat: reconcile PR #39 — tape/disk-pool endpoints, per-client lifecycle, dashboards, alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-client lifecycle metrics & three new dashboards** (reconciled from PR #39, thanks
+  **@cbijon**): per-client **lifecycle** metrics behind the `collectors.perClient` opt-in +
+  allowlist — `nbu_client_jobs_count{client,action,status}` and
+  `nbu_client_last_job_success_seconds{client,policy,action}` covering the full
+  BACKUP → DUPLICATION → IMPORT lifecycle, derived from the main jobs scrape and bounded to
+  allowlisted clients — plus three generated dashboards on the same `site`-wired generator:
+  **Lifecycle** (`nbu-lifecycle`), **Tape & Disk Pools** (`nbu-tape`), and **Multi-site**
+  (`nbu-multisite`). #39's tape metrics were folded into the existing `collectors.tape` as a
+  superset (two extra endpoints — see Tape metrics below), and its richer tape label schema was
+  adopted (raw `DRIVE_STATUS_*` `status`; media keyed by `pool`/`media_type`/`robot_type`).
 - **Multi-site Grafana dashboards**: every generated dashboard now carries a `site` template
   variable (multi-value + "All", sourced from `label_values(nbu_up, site)`) as the first selector,
   and every panel query is filtered by `site=~"$site"` with `site` threaded into each `by (…)`
@@ -18,20 +28,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `grafana/gen/` generator (`panels.with_site`), and `build_dashboards.py` now fails the build if any
   dashboard is missing the `site` selector or leaves a query unfiltered. See the Multi-Site
   Dashboards design spec.
-- **Alerting rules** (`deploy/prometheus/`): two optional, site-aware Prometheus rule files —
-  `rules-perclient.yml` (`NbuClientBackupStale` >25h warning, `NbuClientBackupCritical` >48h
-  critical) and `rules-tape.yml` (`NbuTapeDriveDown` / `NbuTapeDriveDisabled` per site) — each with
-  promtool unit tests, plus a `make check-rules` target. The generic `nbu.rules.yml` is unchanged.
+- **Alerting rules** (`deploy/prometheus/`): three optional, site-aware Prometheus rule files —
+  `rules-perclient.yml` (`NbuClientBackupStale` >25h, `NbuClientBackupCritical` >48h,
+  `NbuClientNoRecentTapeCopy` >26h, `NbuClientNoRecentReplication` >28h,
+  `NbuClientBackupFailureRate` >20%), `rules-tape.yml` (`NbuTapeDriveDown` / `NbuTapeDriveDisabled`,
+  `NbuTapePoolScratchLow`, `NbuDiskPoolVolumeDegraded`), and `rules-multisite.yml`
+  (`NbuInterSiteDivergence`) — each with promtool unit tests, plus a `make check-rules` target. The
+  generic `nbu.rules.yml` is unchanged.
 - **Per-client last-successful-backup metric** (opt-in `collectors.perClient`, default off):
   `nbu_client_last_successful_backup_timestamp_seconds{site,client}` for each allowlisted client,
   from a targeted `/admin/jobs` query (latest `status=0` BACKUP, `sort=-endTime`, `page[limit]=1`).
   An exact-name allowlist bounds the `client` cardinality; an empty allowlist emits nothing. Enables
   a "no backup in N hours" alert. See the Feature 3 design spec.
 - **Tape / drive metrics** (opt-in `collectors.tape`, default off): `nbu_tape_drives_count`
-  (by state/drive_type/robot_type), `nbu_tape_drive_info` (per drive), `nbu_tape_media_count`
-  (by media_type/status), and `nbu_tape_robot_device_hosts`, collected over REST — drives on
-  NBU 10.0+, tape-media + robot device hosts on 10.5+ — with per-endpoint graceful degradation
-  and the `site` label. No CLI shell-out. See the Feature 2 design spec.
+  (by drive_type/robot_type/raw `status`), `nbu_tape_drive_info` (per drive), `nbu_tape_media_count`
+  (by pool/media_type/robot_type), `nbu_tape_robot_device_hosts`, plus `nbu_tape_pool_partially_full`
+  (`/storage/tape-volume-pools`) and `nbu_disk_pool_volume_count` (`/storage/disk-pools`), collected
+  over REST — drives on NBU 10.0+, the rest on 10.5+ (API v12.0+) — with per-endpoint graceful
+  degradation and the `site` label. No CLI shell-out. See the Feature 2 design spec.
 - **Multi-site support**: a single exporter can scrape multiple NetBackup primary servers via
   a `nbuservers:` list, each with a unique `site`; every metric series carries a `site` label
   (first label). Collection adopts the family **snapshot model** — a background loop polls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-06-17
+
 ### Added
 
 - **Per-client lifecycle metrics & three new dashboards** (reconciled from PR #39, thanks
@@ -76,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** every metric series now carries a `site` label as its first label (multi-site
+  support). Single-site deployments keep working, but PromQL that pins exact label sets or
+  aggregates without `by (site)`, plus recording rules and dashboards from v3.x, should be
+  reviewed. The opt-in `tape` collector's labels also moved to the richer schema: drives expose
+  the raw `DRIVE_STATUS_*` `status` (was a stripped `state`) and `nbu_tape_media_count` is keyed
+  by `pool`/`media_type`/`robot_type` (was `media_type`/`status`).
 - Repo hygiene: removed a 22 MB committed `go test -c` binary and empty doc stubs, untracked
   `.planning/` and `.serena/` tool state (now gitignored), and fixed a stale `3.0` reference
   in `config-auto-detect.yaml` ([#35](https://github.com/fjacquet/nbu_exporter/pull/35)).

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ vuln:
 
 # Validate + unit-test the Prometheus alerting rules (requires promtool).
 check-rules:
-	promtool check rules deploy/prometheus/nbu.rules.yml deploy/prometheus/rules-perclient.yml deploy/prometheus/rules-tape.yml
-	promtool test rules deploy/prometheus/rules-perclient_test.yml deploy/prometheus/rules-tape_test.yml
+	promtool check rules deploy/prometheus/nbu.rules.yml deploy/prometheus/rules-perclient.yml deploy/prometheus/rules-tape.yml deploy/prometheus/rules-multisite.yml
+	promtool test rules deploy/prometheus/rules-perclient_test.yml deploy/prometheus/rules-tape_test.yml deploy/prometheus/rules-multisite_test.yml
 
 # Aggregate gate run by CI.
 ci: fmt-check vet lint test-race vuln

--- a/charts/nbu-exporter/values.yaml
+++ b/charts/nbu-exporter/values.yaml
@@ -99,6 +99,10 @@ config: |
     malware: { enabled: false }
     catalog: { enabled: false }
     slo:     { enabled: false }
+    tape:    { enabled: false }   # tape/disk-pool metrics (NBU 10.0+; pools need 10.5+)
+    perClient:                    # per-client compliance + lifecycle (allowlist required)
+      enabled: false
+      allowlist: []               # exact client names; empty => no per-client series
 
 env: []
 # - name: NBU1_HOSTNAME

--- a/config.yaml
+++ b/config.yaml
@@ -92,9 +92,19 @@ opentelemetry:
 #     insecure: false
 #     samplingRate: 0.01
 
-# Optional: opt-in NetBackup 11.2 metric collectors (all default to disabled)
+# Optional: opt-in metric collectors (all default to disabled).
+# alerts/malware/catalog/slo require NetBackup 11.2 (API version=14.0).
 collectors:
   alerts:  { enabled: false }
   malware: { enabled: false }
   catalog: { enabled: false }
   slo:     { enabled: false }
+  # Tape drives, media pools, partially-full volume pools and disk-pool volumes.
+  # Works on NBU 10.0+ (drive/media); volume-pool and disk-pool rows need 10.5+.
+  tape:    { enabled: false }
+  # Per-client backup compliance + lifecycle (BACKUP/DUPLICATION/IMPORT). The
+  # client label is high-cardinality, so an explicit allowlist is required —
+  # an empty allowlist emits nothing.
+  perClient:
+    enabled: false
+    allowlist: []   # exact client names, e.g. ["db01", "app02"]

--- a/deploy/prometheus/rules-multisite.yml
+++ b/deploy/prometheus/rules-multisite.yml
@@ -1,0 +1,32 @@
+# Optional Prometheus alerting rules — inter-site backup divergence.
+#
+# Only meaningful with a multi-target deployment: an nbuservers[] config (or several
+# exporters) producing distinct `site` labels. Builds on the core nbu_jobs_bytes metric.
+# Load alongside nbu.rules.yml:
+#
+#   rule_files:
+#     - /etc/prometheus/rules/nbu.rules.yml
+#     - /etc/prometheus/rules/rules-multisite.yml
+#
+# Validate:  make check-rules
+#
+# `for: 1h` rides out short-lived schedule skew between sites (a site whose nightly
+# window simply starts later) before paging. Tune the 30% threshold to your topology.
+groups:
+  - name: nbu_multisite
+    rules:
+      # A site backing up far less than the cross-site average can signal a
+      # connectivity, scheduling, or configuration problem at that site.
+      - alert: NbuInterSiteDivergence
+        expr: |
+          (
+            sum by (site) (nbu_jobs_bytes{action="BACKUP"})
+            / on() group_left()
+            avg(sum by (site) (nbu_jobs_bytes{action="BACKUP"}))
+          ) < 0.3
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backup volume on site {{ $labels.site }} is unusually low"
+          description: "Site {{ $labels.site }} backed up less than 30% of the cross-site average BACKUP volume. Check connectivity and job scheduling."

--- a/deploy/prometheus/rules-multisite_test.yml
+++ b/deploy/prometheus/rules-multisite_test.yml
@@ -1,0 +1,29 @@
+# promtool test rules deploy/prometheus/rules-multisite_test.yml
+rule_files:
+  - rules-multisite.yml
+tests:
+  - interval: 1m
+    input_series:
+      # Three sites; lyon backs up far less than the cross-site average.
+      - series: 'nbu_jobs_bytes{site="paris",action="BACKUP",policy_type="Standard"}'
+        values: '1000x70'
+      - series: 'nbu_jobs_bytes{site="nyc",action="BACKUP",policy_type="Standard"}'
+        values: '1000x70'
+      - series: 'nbu_jobs_bytes{site="lyon",action="BACKUP",policy_type="Standard"}'
+        values: '10x70'
+    alert_rule_test:
+      # avg = (1000+1000+10)/3 ≈ 670; lyon ratio ≈ 0.015 (< 0.3), sustained past for:1h -> fires.
+      # paris and nyc ratios ≈ 1.49 -> silent.
+      - eval_time: 65m
+        alertname: NbuInterSiteDivergence
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: lyon
+            exp_annotations:
+              summary: "Backup volume on site lyon is unusually low"
+              description: "Site lyon backed up less than 30% of the cross-site average BACKUP volume. Check connectivity and job scheduling."
+      # Before the 1h hold window -> no alert yet.
+      - eval_time: 30m
+        alertname: NbuInterSiteDivergence
+        exp_alerts: []

--- a/deploy/prometheus/rules-perclient.yml
+++ b/deploy/prometheus/rules-perclient.yml
@@ -1,7 +1,8 @@
-# Optional Prometheus alerting rules — per-client backup staleness.
+# Optional Prometheus alerting rules — per-client backup compliance.
 #
 # Requires the opt-in per-client collector (collectors.perClient), which produces
-# nbu_client_last_successful_backup_timestamp_seconds. Load alongside nbu.rules.yml:
+# nbu_client_last_successful_backup_timestamp_seconds plus the phase-aware
+# nbu_client_last_job_success_seconds and nbu_client_jobs_count. Load alongside nbu.rules.yml:
 #
 #   rule_files:
 #     - /etc/prometheus/rules/nbu.rules.yml
@@ -31,3 +32,37 @@ groups:
         annotations:
           summary: "Client {{ $labels.client }} has no successful backup in over 48h (site {{ $labels.site }})"
           description: "Client {{ $labels.client }} on site {{ $labels.site }} has not completed a successful backup in over 48 hours."
+      # Tape copy (DUPLICATION) for a client is missing/stale — 26h (1h margin over the daily SLP).
+      # Uses the phase-aware nbu_client_last_job_success_seconds; primary-backup staleness is
+      # already covered by NbuClientBackupStale above.
+      - alert: NbuClientNoRecentTapeCopy
+        expr: (time() - nbu_client_last_job_success_seconds{action="DUPLICATION"}) > 93600
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No recent tape copy for client {{ $labels.client }} (policy {{ $labels.policy }}, site {{ $labels.site }})"
+          description: "Client {{ $labels.client }} (policy {{ $labels.policy }}) on site {{ $labels.site }} has had no successful tape duplication (DUPLICATION) job in over 26 hours. Verify the Storage Lifecycle Policy is running."
+      # Inter-site replication (IMPORT / Auto Image Replication) missing/stale — 28h.
+      - alert: NbuClientNoRecentReplication
+        expr: (time() - nbu_client_last_job_success_seconds{action="IMPORT"}) > 100800
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No recent replication for client {{ $labels.client }} (policy {{ $labels.policy }}, site {{ $labels.site }})"
+          description: "Client {{ $labels.client }} (policy {{ $labels.policy }}) on site {{ $labels.site }} has had no successful replication (IMPORT) job in over 28 hours. Check inter-site connectivity and Auto Image Replication."
+      # Client BACKUP failure rate above 20% in the current scraping window.
+      - alert: NbuClientBackupFailureRate
+        expr: |
+          (
+            sum by (site, client) (nbu_client_jobs_count{action="BACKUP", status!="0"})
+            /
+            clamp_min(sum by (site, client) (nbu_client_jobs_count{action="BACKUP"}), 1)
+          ) * 100 > 20
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High backup failure rate for client {{ $labels.client }} (site {{ $labels.site }})"
+          description: "More than 20% of BACKUP jobs for client {{ $labels.client }} on site {{ $labels.site }} failed in the current scraping window."

--- a/deploy/prometheus/rules-perclient_test.yml
+++ b/deploy/prometheus/rules-perclient_test.yml
@@ -35,3 +35,81 @@ tests:
             exp_annotations:
               summary: "Client clientA has no successful backup in over 48h (site paris)"
               description: "Client clientA on site paris has not completed a successful backup in over 48 hours."
+
+  # NbuClientNoRecentTapeCopy: last successful DUPLICATION (tape copy) older than 26h.
+  - interval: 5m
+    input_series:
+      - series: 'nbu_client_last_job_success_seconds{site="paris",client="db01",policy="gold",action="DUPLICATION"}'
+        values: '0x360'
+    alert_rule_test:
+      # 24h elapsed (< 26h threshold) -> silent.
+      - eval_time: 24h
+        alertname: NbuClientNoRecentTapeCopy
+        exp_alerts: []
+      # 27h elapsed (> 26h threshold), past for:5m -> fires.
+      - eval_time: 27h
+        alertname: NbuClientNoRecentTapeCopy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: paris
+              client: db01
+              policy: gold
+              action: DUPLICATION
+            exp_annotations:
+              summary: "No recent tape copy for client db01 (policy gold, site paris)"
+              description: "Client db01 (policy gold) on site paris has had no successful tape duplication (DUPLICATION) job in over 26 hours. Verify the Storage Lifecycle Policy is running."
+
+  # NbuClientNoRecentReplication: last successful IMPORT (AIR replication) older than 28h.
+  - interval: 5m
+    input_series:
+      - series: 'nbu_client_last_job_success_seconds{site="paris",client="db01",policy="gold",action="IMPORT"}'
+        values: '0x420'
+    alert_rule_test:
+      # 27h elapsed (< 28h threshold) -> silent.
+      - eval_time: 27h
+        alertname: NbuClientNoRecentReplication
+        exp_alerts: []
+      # 29h elapsed (> 28h threshold), past for:5m -> fires.
+      - eval_time: 29h
+        alertname: NbuClientNoRecentReplication
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: paris
+              client: db01
+              policy: gold
+              action: IMPORT
+            exp_annotations:
+              summary: "No recent replication for client db01 (policy gold, site paris)"
+              description: "Client db01 (policy gold) on site paris has had no successful replication (IMPORT) job in over 28 hours. Check inter-site connectivity and Auto Image Replication."
+
+  # NbuClientBackupFailureRate: >20% of a client's BACKUP jobs failed in the window.
+  - interval: 1m
+    input_series:
+      # db01: 3 failed / 10 total = 30% -> fires.
+      - series: 'nbu_client_jobs_count{site="paris",client="db01",action="BACKUP",status="0"}'
+        values: '7x40'
+      - series: 'nbu_client_jobs_count{site="paris",client="db01",action="BACKUP",status="1"}'
+        values: '3x40'
+      # app02: 1 failed / 10 total = 10% -> silent (proves per-client selectivity).
+      - series: 'nbu_client_jobs_count{site="paris",client="app02",action="BACKUP",status="0"}'
+        values: '9x40'
+      - series: 'nbu_client_jobs_count{site="paris",client="app02",action="BACKUP",status="1"}'
+        values: '1x40'
+    alert_rule_test:
+      # Past for:30m -> only db01 (30%) fires; app02 (10%) stays silent.
+      - eval_time: 35m
+        alertname: NbuClientBackupFailureRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: paris
+              client: db01
+            exp_annotations:
+              summary: "High backup failure rate for client db01 (site paris)"
+              description: "More than 20% of BACKUP jobs for client db01 on site paris failed in the current scraping window."
+      # Before the 30m hold window -> no alert yet.
+      - eval_time: 20m
+        alertname: NbuClientBackupFailureRate
+        exp_alerts: []

--- a/deploy/prometheus/rules-tape.yml
+++ b/deploy/prometheus/rules-tape.yml
@@ -17,7 +17,7 @@ groups:
   - name: nbu_tape
     rules:
       - alert: NbuTapeDriveDown
-        expr: sum by (site) (nbu_tape_drives_count{state="DOWN"}) > 0
+        expr: sum by (site) (nbu_tape_drives_count{status="DRIVE_STATUS_DOWN"}) > 0
         for: 15m
         labels:
           severity: warning
@@ -25,7 +25,7 @@ groups:
           summary: "Tape drive(s) DOWN on site {{ $labels.site }}"
           description: "One or more tape drives are DOWN on site {{ $labels.site }}."
       - alert: NbuTapeDriveDisabled
-        expr: sum by (site) (nbu_tape_drives_count{state="DISABLED"}) > 0
+        expr: sum by (site) (nbu_tape_drives_count{status="DRIVE_STATUS_DISABLED"}) > 0
         for: 30m
         labels:
           severity: warning

--- a/deploy/prometheus/rules-tape.yml
+++ b/deploy/prometheus/rules-tape.yml
@@ -1,7 +1,8 @@
-# Optional Prometheus alerting rules — tape drive health.
+# Optional Prometheus alerting rules — tape drive, volume-pool, and disk-pool health.
 #
 # Requires the opt-in tape collector (collectors.tape), which produces
-# nbu_tape_drives_count. Load alongside nbu.rules.yml:
+# nbu_tape_drives_count, nbu_tape_media_count, and nbu_disk_pool_volume_count
+# (the latter two on NetBackup 10.5+ / API v12.0+). Load alongside nbu.rules.yml:
 #
 #   rule_files:
 #     - /etc/prometheus/rules/nbu.rules.yml
@@ -32,3 +33,22 @@ groups:
         annotations:
           summary: "Tape drive(s) DISABLED on site {{ $labels.site }}"
           description: "One or more tape drives are DISABLED on site {{ $labels.site }}."
+      # Scratch volume pool running low. Requires nbu_tape_media_count (tape collector).
+      # The pool name is the NBU volume pool — adjust "Scratch" to match your config.
+      - alert: NbuTapePoolScratchLow
+        expr: sum by (pool, site) (nbu_tape_media_count{pool="Scratch"}) < 5
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Tape scratch pool {{ $labels.pool }} low on site {{ $labels.site }}"
+          description: "Fewer than 5 volumes remain in scratch pool {{ $labels.pool }} on site {{ $labels.site }}. Order or reassign tapes before the pool is exhausted."
+      # A disk-pool volume is not UP. Requires nbu_disk_pool_volume_count (API v12.0+, NBU 10.5+).
+      - alert: NbuDiskPoolVolumeDegraded
+        expr: sum by (site, pool_name, storage_category, state) (nbu_disk_pool_volume_count{state!="UP"}) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk pool volume not UP in {{ $labels.pool_name }} on site {{ $labels.site }}"
+          description: "One or more volumes in disk pool {{ $labels.pool_name }} ({{ $labels.storage_category }}) are in state {{ $labels.state }} on site {{ $labels.site }}. Check storage server connectivity."

--- a/deploy/prometheus/rules-tape_test.yml
+++ b/deploy/prometheus/rules-tape_test.yml
@@ -4,9 +4,9 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'nbu_tape_drives_count{site="paris",state="DOWN",drive_type="DT_HCART",robot_type="TLD"}'
+      - series: 'nbu_tape_drives_count{site="paris",status="DRIVE_STATUS_DOWN",drive_type="DT_HCART",robot_type="TLD"}'
         values: '1x60'
-      - series: 'nbu_tape_drives_count{site="paris",state="UP",drive_type="DT_HCART",robot_type="TLD"}'
+      - series: 'nbu_tape_drives_count{site="paris",status="DRIVE_STATUS_UP",drive_type="DT_HCART",robot_type="TLD"}'
         values: '3x60'
     alert_rule_test:
       # One DOWN drive, true > for:15m -> warning fires (sum by site drops drive_type/robot_type).

--- a/deploy/prometheus/rules-tape_test.yml
+++ b/deploy/prometheus/rules-tape_test.yml
@@ -23,3 +23,50 @@ tests:
       - eval_time: 40m
         alertname: NbuTapeDriveDisabled
         exp_alerts: []
+
+  # NbuTapePoolScratchLow: scratch volume pool running low for 15m.
+  - interval: 1m
+    input_series:
+      - series: 'nbu_tape_media_count{site="paris",pool="Scratch",media_type="HCART",robot_type="TLD"}'
+        values: '3x30'
+      - series: 'nbu_tape_media_count{site="paris",pool="NetBackup",media_type="HCART",robot_type="TLD"}'
+        values: '50x30'
+    alert_rule_test:
+      # Only 3 volumes in the Scratch pool (< 5), sustained past for:15m -> fires.
+      # The NetBackup pool (50 volumes) is excluded by the pool="Scratch" matcher.
+      - eval_time: 20m
+        alertname: NbuTapePoolScratchLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              pool: Scratch
+              site: paris
+            exp_annotations:
+              summary: "Tape scratch pool Scratch low on site paris"
+              description: "Fewer than 5 volumes remain in scratch pool Scratch on site paris. Order or reassign tapes before the pool is exhausted."
+      # Before the 15m hold window -> no alert yet.
+      - eval_time: 5m
+        alertname: NbuTapePoolScratchLow
+        exp_alerts: []
+
+  # NbuDiskPoolVolumeDegraded: a disk-pool volume not UP for 10m.
+  - interval: 1m
+    input_series:
+      - series: 'nbu_disk_pool_volume_count{site="paris",pool_name="dp_main",storage_category="AdvancedDisk",state="DOWN"}'
+        values: '1x20'
+      - series: 'nbu_disk_pool_volume_count{site="paris",pool_name="dp_main",storage_category="AdvancedDisk",state="UP"}'
+        values: '8x20'
+    alert_rule_test:
+      # One DOWN volume sustained past for:10m -> fires; the UP series is filtered out.
+      - eval_time: 15m
+        alertname: NbuDiskPoolVolumeDegraded
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              site: paris
+              pool_name: dp_main
+              storage_category: AdvancedDisk
+              state: DOWN
+            exp_annotations:
+              summary: "Disk pool volume not UP in dp_main on site paris"
+              description: "One or more volumes in disk pool dp_main (AdvancedDisk) are in state DOWN on site paris. Check storage server connectivity."

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -60,6 +60,9 @@ services:
       - ./grafana/nbu-jobs.json:/var/lib/grafana/dashboards/nbu-jobs.json:ro
       - ./grafana/nbu-storage.json:/var/lib/grafana/dashboards/nbu-storage.json:ro
       - ./grafana/nbu-dataprotection.json:/var/lib/grafana/dashboards/nbu-dataprotection.json:ro
+      - ./grafana/nbu-lifecycle.json:/var/lib/grafana/dashboards/nbu-lifecycle.json:ro
+      - ./grafana/nbu-tape.json:/var/lib/grafana/dashboards/nbu-tape.json:ro
+      - ./grafana/nbu-multisite.json:/var/lib/grafana/dashboards/nbu-multisite.json:ro
       # Companion dashboard (Grafana 1860) — requires a node_exporter scraped alongside.
       - ./grafana/node-exporter-full.json:/var/lib/grafana/dashboards/node-exporter-full.json:ro
       - grafana-storage:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       - ./grafana/nbu-jobs.json:/var/lib/grafana/dashboards/nbu-jobs.json:ro
       - ./grafana/nbu-storage.json:/var/lib/grafana/dashboards/nbu-storage.json:ro
       - ./grafana/nbu-dataprotection.json:/var/lib/grafana/dashboards/nbu-dataprotection.json:ro
+      - ./grafana/nbu-lifecycle.json:/var/lib/grafana/dashboards/nbu-lifecycle.json:ro
+      - ./grafana/nbu-tape.json:/var/lib/grafana/dashboards/nbu-tape.json:ro
+      - ./grafana/nbu-multisite.json:/var/lib/grafana/dashboards/nbu-multisite.json:ro
       # Companion dashboard (Grafana 1860) — requires a node_exporter scraped alongside.
       - ./grafana/node-exporter-full.json:/var/lib/grafana/dashboards/node-exporter-full.json:ro
       - grafana-storage:/var/lib/grafana

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -36,9 +36,9 @@ sites filters the whole dashboard; "All" shows every site. The Overview's **Site
 UP/DOWN availability tile per primary (repeated over `$site`), so a down master stands out at a
 glance.
 
-## The four dashboards
+## The seven dashboards
 
-All four dashboards share the `$site` selector (above); the table below lists each one's
+All dashboards share the `$site` selector (above); the table below lists each one's
 **additional** variables.
 
 | Dashboard | File / UID | Focus | Extra variables |
@@ -47,10 +47,16 @@ All four dashboards share the `$site` selector (above); the table below lists ea
 | **Jobs** | `nbu-jobs.json` / `nbu-jobs` | Backup outcomes, job states, jobs by policy, backup volume, queued jobs, duration p50/p95, files, deduplication | `$policy_type` |
 | **Storage** | `nbu-storage.json` / `nbu-storage` | Capacity utilization, used-vs-total trend, per-unit table, max concurrent jobs, max fragment size | `$storage_unit` |
 | **Data Protection** | `nbu-dataprotection.json` / `nbu-dataprotection` | NetBackup 11.2 collectors: alerts by severity/category, malware scanned vs infected and scan status, catalog malware/anomaly posture, configured SLOs | — |
+| **Lifecycle** | `nbu-lifecycle.json` / `nbu-lifecycle` | Per-client compliance across the full lifecycle (BACKUP → DUPLICATION → IMPORT): success rate per phase, age-of-last-success table, overdue clients | `$client` |
+| **Tape & Disk Pools** | `nbu-tape.json` / `nbu-tape` | Tape drive status, media by pool/type, partially-full volume pools, and disk-pool volume health | — |
+| **Multi-site** | `nbu-multisite.json` / `nbu-multisite` | Side-by-side cross-site comparison of backup volume, success rate, inter-site replication, divergence, and per-site tape | `$client` |
 
 The **Data Protection** dashboard's panels stay empty until the optional 11.2 collectors are enabled
 in `config.yaml` (`collectors.{alerts,malware,catalog,slo}.enabled: true`) and the appliance returns
-data, so it is safe to leave in place on older NetBackup versions.
+data, so it is safe to leave in place on older NetBackup versions. Likewise **Lifecycle** and the
+per-site/`$client` panels on **Multi-site** stay empty until `collectors.perClient` is enabled with a
+non-empty `allowlist`, and **Tape & Disk Pools** needs `collectors.tape` (NBU 10.5+ for the
+volume-pool and disk-pool rows).
 
 The previous single overview and the legacy "NBU Statistics" dashboard have been retired; their views
 now live in the Overview, Jobs, and Storage dashboards above.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -46,7 +46,8 @@ only the ones your appliance and account permissions support. They are graceful:
 endpoint is logged and skipped without affecting core storage/jobs metrics or flipping
 `nbu_up` to `0`. The alerts/malware/catalog/SLO collectors require NetBackup 11.2 (API
 `version=14.0`); the **`tape`** collector works on older releases too (`/storage/drives` on
-NBU 10.0+, `/storage/tape-media` and `/storage/robots-device-hosts` on 10.5+).
+NBU 10.0+; `/storage/tape-media`, `/storage/robots-device-hosts`, `/storage/tape-volume-pools`
+and `/storage/disk-pools` on 10.5+).
 
 | Metric | Type | Labels | Source endpoint | Source API attribute |
 |--------|------|--------|-----------------|----------------------|
@@ -56,11 +57,15 @@ NBU 10.0+, `/storage/tape-media` and `/storage/robots-device-hosts` on 10.5+).
 | `nbu_malware_scan_count` | Gauge | `status` | `GET /malware/latest-scan-results` | Results grouped by `scanState` |
 | `nbu_catalog_images_count` | Gauge | `malware_status`, `anomaly_status` | `GET /catalog/images` | `meta.pagination.count` per filter combination |
 | `nbu_slo_count` | Gauge | — | `GET /servicecatalog/slos` | Total number of `data[]` entries |
-| `nbu_tape_drives_count` | Gauge | `state`, `drive_type`, `robot_type` | `GET /storage/drives` | Drives grouped by `driveStatus`/`driveType`/`robotType` |
-| `nbu_tape_drive_info` | Gauge | `drive_name`, `media_server`, `drive_type`, `robot_number`, `state` | `GET /storage/drives` | One series per drive (value always `1`) |
-| `nbu_tape_media_count` | Gauge | `media_type`, `status` | `GET /storage/tape-media` | Tape volumes grouped by `mediaType` + `mediaStatus` |
+| `nbu_tape_drives_count` | Gauge | `drive_type`, `robot_type`, `status` | `GET /storage/drives` | Drives grouped by `driveType`/`robotType`/`driveStatus` (raw `DRIVE_STATUS_*`) |
+| `nbu_tape_drive_info` | Gauge | `drive_name`, `media_server`, `drive_type`, `robot_number`, `status` | `GET /storage/drives` | One series per drive (value always `1`) |
+| `nbu_tape_media_count` | Gauge | `pool`, `media_type`, `robot_type` | `GET /storage/tape-media` | Tape volumes grouped by volume pool, `mediaType` and robot type |
 | `nbu_tape_robot_device_hosts` | Gauge | — | `GET /storage/robots-device-hosts` | Count of device hosts with robots configured |
+| `nbu_tape_pool_partially_full` | Gauge | `pool_name`, `pool_type` | `GET /storage/tape-volume-pools` | Partially-full tape volumes per volume pool (API v12.0+) |
+| `nbu_disk_pool_volume_count` | Gauge | `pool_name`, `storage_category`, `state` | `GET /storage/disk-pools` | Disk-pool volumes grouped by pool, storage category and state (API v12.0+) |
 | `nbu_client_last_successful_backup_timestamp_seconds` | Gauge | `client` | `GET /admin/jobs` (per allowlisted client) | `endTime` of the latest `status=0` BACKUP for the client |
+| `nbu_client_jobs_count` | Gauge | `client`, `action`, `status` | `GET /admin/jobs` (main scrape) | Per-allowlisted-client job count by action and status in the scrape window |
+| `nbu_client_last_job_success_seconds` | Gauge | `client`, `policy`, `action` | `GET /admin/jobs` (main scrape) | Unix ts of the last `status=0` job per allowlisted client, policy and lifecycle phase |
 
 Notes on the implemented attributes (these differ from early guesses):
 
@@ -75,19 +80,27 @@ Notes on the implemented attributes (these differ from early guesses):
 - **SLO count** is a single unlabeled gauge. The 11.2 SLO response has no
   per-SLO enforcement-type attribute, so the originally planned
   `enforcement_type` label was dropped.
-- **Tape collector** (`collectors.tape`) is one collector over three endpoints with
-  per-endpoint graceful degradation. Tape media is offset-paginated and aggregated
-  client-side; `robot_type` is read from the per-drive attribute (there is no bulk
-  robot-listing endpoint, so a standalone robot type/count metric is not exposed);
-  `mediaStatus` is a free-form NetBackup status string. `drive_state` is the
-  `driveStatus` value with the `DRIVE_STATUS_` prefix stripped (`UP`/`DOWN`/`MIXED`/`DISABLED`).
+- **Tape collector** (`collectors.tape`) is one collector over five endpoints with
+  per-endpoint graceful degradation. The `tape-volume-pools` and `disk-pools` endpoints are
+  API v12.0+ (NBU 10.5+) and are skipped with a debug log on older releases. Tape media is
+  offset-paginated and aggregated client-side; `robot_type` is read from the per-drive
+  attribute (there is no bulk robot-listing endpoint, so a standalone robot type/count metric
+  is not exposed). The drive `status` label carries the **raw** `driveStatus` enum
+  (`DRIVE_STATUS_UP`/`DRIVE_STATUS_DOWN`/`DRIVE_STATUS_DISABLED`/…) and `nbu_tape_media_count`
+  is keyed by volume `pool`, `media_type` and `robot_type`.
 - **Per-client collector** (`collectors.perClient`) requires an explicit `allowlist` because the
   `client` label is high-cardinality (hundreds of clients) — an **empty allowlist emits nothing**.
   For each allowlisted client it issues one targeted `/admin/jobs` query
   (`filter clientName eq '<c>' and jobType eq 'BACKUP' and status eq 0`, `sort=-endTime`,
-  `page[limit]=1`) and emits that job's `endTime`, so it always reflects the last success with no
-  lookback gap. Feed a "no successful backup in N hours" alert with
+  `page[limit]=1`) and emits that job's `endTime` as
+  `nbu_client_last_successful_backup_timestamp_seconds`, so it always reflects the last success
+  with no lookback gap. Feed a "no successful backup in N hours" alert with
   `time() - nbu_client_last_successful_backup_timestamp_seconds > N*3600`.
+  The same collector also emits two **lifecycle** metrics derived from the main jobs scrape
+  (not a separate query), bucketed to allowlisted clients only: `nbu_client_jobs_count`
+  (job count per `action`/`status`) and `nbu_client_last_job_success_seconds` (last `status=0`
+  timestamp per `policy`/`action`, covering BACKUP → DUPLICATION → IMPORT). The last-success
+  timestamps are cached per site/client/policy/action so they carry forward across scrapes.
 
 ### Enabling the collectors
 
@@ -147,10 +160,13 @@ scrape_configs:
 ```
 
 Alerting rules live in `deploy/prometheus/`: the generic `nbu.rules.yml` (availability,
-staleness, backup-success-rate, storage) plus two **optional** files loaded only if you enabled
-the matching opt-in collector — `rules-perclient.yml` (per-client backup staleness;
-needs `collectors.perClient`) and `rules-tape.yml` (tape drive DOWN/DISABLED; needs
-`collectors.tape`). Load them via `rule_files` and validate with `make check-rules`.
+staleness, backup-success-rate, storage) plus three **optional** files loaded only if you
+enabled the matching opt-in collector (or run multi-target) — `rules-perclient.yml`
+(per-client backup staleness, tape-copy/replication lag, backup failure rate; needs
+`collectors.perClient`), `rules-tape.yml` (tape drive DOWN/DISABLED, low scratch pool,
+degraded disk-pool volume; needs `collectors.tape`), and `rules-multisite.yml` (inter-site
+backup divergence; needs distinct `site` labels). Load them via `rule_files` and validate
+with `make check-rules`.
 
 ## Dashboards
 
@@ -159,7 +175,7 @@ The Grafana dashboards are **generated** by `python3 grafana/build_dashboards.py
 single source of truth and a metric-reference validator fails the build on any
 unknown `nbu_*` name. Regenerate after changing the builders in `grafana/gen/`.
 
-Four focused dashboards live in the `grafana/` directory:
+Seven focused dashboards live in the `grafana/` directory:
 
 | File | uid | Focus |
 |------|-----|-------|
@@ -167,11 +183,18 @@ Four focused dashboards live in the `grafana/` directory:
 | `grafana/nbu-jobs.json` | `nbu-jobs` | Backup outcomes, states, volume, queue, durations, dedup |
 | `grafana/nbu-storage.json` | `nbu-storage` | Capacity utilization, storage units, limits |
 | `grafana/nbu-dataprotection.json` | `nbu-dataprotection` | Alerts, malware scans, catalog posture, SLOs (11.2) |
+| `grafana/nbu-lifecycle.json` | `nbu-lifecycle` | Per-client compliance across BACKUP → DUPLICATION → IMPORT (needs `collectors.perClient`) |
+| `grafana/nbu-tape.json` | `nbu-tape` | Tape drives, media pools, partially-full volumes, disk-pool volumes (needs `collectors.tape`, NBU 10.5+) |
+| `grafana/nbu-multisite.json` | `nbu-multisite` | Cross-site backup volume, replication, and compliance comparison |
 
 The dashboards cross-link to each other via the shared `netbackup` tag (a tag-based
 dashboard-links dropdown) and use the `${datasource}` template variable so they work
-on any server. Jobs adds a `policy_type` variable and Storage adds a `storage_unit`
-variable for per-unit / per-policy filtering.
+on any server. Every dashboard carries a multi-value `site` selector (sourced from
+`label_values(nbu_up, site)`) as its first variable and filters every query by
+`site=~"$site"`, so series from multiple NetBackup primaries neither collapse nor
+double-count; `nbu-multisite` additionally groups `by (site)` to compare sites side by
+side. Jobs adds a `policy_type` variable, Storage adds a `storage_unit` variable, and
+Lifecycle / Multi-site add a `client` filter for per-unit / per-policy / per-client views.
 
 The legacy "NBU Statistics" dashboard (the original 2021 export) was retired; its
 views now live in the Storage and Jobs dashboards.

--- a/grafana/build_dashboards.py
+++ b/grafana/build_dashboards.py
@@ -8,7 +8,7 @@ template-variable contract before writing.
 import json
 import sys
 
-from grafana.gen import overview, jobs, storage, dataprotection
+from grafana.gen import overview, jobs, storage, dataprotection, tape, lifecycle, multisite
 from grafana.gen.validate import check_dashboard, check_site_wiring
 
 OUTPUTS = [
@@ -16,6 +16,9 @@ OUTPUTS = [
     ("grafana/nbu-jobs.json", jobs.build),
     ("grafana/nbu-storage.json", storage.build),
     ("grafana/nbu-dataprotection.json", dataprotection.build),
+    ("grafana/nbu-tape.json", tape.build),
+    ("grafana/nbu-lifecycle.json", lifecycle.build),
+    ("grafana/nbu-multisite.json", multisite.build),
 ]
 
 

--- a/grafana/gen/lifecycle.py
+++ b/grafana/gen/lifecycle.py
@@ -1,0 +1,470 @@
+"""Backup lifecycle dashboard: per-client compliance across all phases (BACKUP → DUPLICATION → IMPORT)."""
+
+from grafana.gen.panels import ds, nid, gridpos, reset_ids, piechart, state_timeline, bar_gauge, text_panel
+from grafana.gen.variables import dashboard, client_filter_var
+
+# ── Lifecycle flow diagram (Markdown) ─────────────────────────────────────────
+_FLOW_MD = """\
+## Cycle de vie d'une sauvegarde / Backup Lifecycle Flow
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Client                  Site Principal / Primary Site          Site distant  │
+│  ──────                  ───────────────────────────────        ────────────  │
+│                                                                               │
+│  [Données]               ┌─────────────────┐                                 │
+│     │                    │  NBU Master 1   │                                  │
+│     │── BACKUP ──────────▶  (sauvegarde)   │                                  │
+│                          │                 │── DUPLICATION ──▶ [Bande / Tape] │
+│                          │                 │                                  │
+│                          │                 │── AIR ──────────▶ NBU Master 2   │
+│                          └─────────────────┘                       │          │
+│                                                                    │          │
+│                                                               IMPORT reçu     │
+│                                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+| Phase | Métrique | SLA |
+|-------|---------|-----|
+| BACKUP | `nbu_client_last_job_success_seconds{action="BACKUP"}` | < 25h |
+| DUPLICATION | `nbu_client_last_job_success_seconds{action="DUPLICATION"}` | < 26h |
+| IMPORT (AIR) | `nbu_client_last_job_success_seconds{action="IMPORT"}` | < 28h |
+"""
+
+
+def _stat_bg(title, description, expr, x, y, w, h, thresholds, unit="none"):
+    return {
+        "type": "stat",
+        "id": nid(),
+        "title": title,
+        "description": description,
+        "datasource": ds(),
+        "gridPos": gridpos(x, y, w, h),
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "textMode": "auto",
+        },
+        "targets": [{"datasource": ds(), "expr": expr, "instant": True, "refId": "A"}],
+    }
+
+
+def _stat_sparkline(title, description, expr, x, y, w, h, unit="none", thresholds=None):
+    if thresholds is None:
+        thresholds = [{"color": "text", "value": None}]
+    return {
+        "type": "stat",
+        "id": nid(),
+        "title": title,
+        "description": description,
+        "datasource": ds(),
+        "gridPos": gridpos(x, y, w, h),
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "textMode": "auto",
+        },
+        "targets": [{"datasource": ds(), "expr": expr, "refId": "A"}],
+    }
+
+
+def _gauge(title, description, expr, x, y, w, h, legend=""):
+    return {
+        "id": nid(),
+        "type": "gauge",
+        "title": title,
+        "description": description,
+        "gridPos": {"x": x, "y": y, "w": w, "h": h},
+        "datasource": ds(),
+        "targets": [{"datasource": ds(), "expr": expr, "instant": True, "refId": "A", "legendFormat": legend}],
+        "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "orientation": "auto",
+            "showThresholdLabels": False,
+            "showThresholdMarkers": True,
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "percent",
+                "min": 0,
+                "max": 100,
+                "color": {"mode": "thresholds"},
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "red", "value": None},
+                        {"color": "yellow", "value": 70},
+                        {"color": "green", "value": 90},
+                    ],
+                },
+            },
+            "overrides": [],
+        },
+    }
+
+
+def _table_lifecycle():
+    return {
+        "id": nid(),
+        "type": "table",
+        "title": "Ancienneté de la dernière réussite par client et phase / Age of last success per client & phase",
+        "description": (
+            "Ancienneté (en secondes) de la dernière réussite pour chaque client/politique/phase. "
+            "Jaune = proche du seuil (>23h), Orange = dépassé 24h, Rouge = violation SLA (>25h). "
+            "Trier la colonne Ancienneté pour voir les clients les plus critiques en premier."
+        ),
+        "gridPos": {"x": 0, "y": 46, "w": 24, "h": 12},
+        "datasource": ds(),
+        "targets": [{"datasource": ds(), "expr": 'sort_desc(time() - nbu_client_last_job_success_seconds{client=~"$client_filter", site=~"$site"})', "instant": True, "format": "table", "refId": "A"}],
+        "transformations": [
+            {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {"Time": True, "__name__": True},
+                    "indexByName": {"client": 0, "policy": 1, "action": 2, "site": 3, "Value": 4},
+                    "renameByName": {
+                        "client": "Client",
+                        "policy": "Politique / Policy",
+                        "action": "Phase",
+                        "site": "Site",
+                        "Value": "Ancienneté / Age",
+                    },
+                },
+            }
+        ],
+        "options": {
+            "showHeader": True,
+            "sortBy": [{"displayName": "Ancienneté / Age", "desc": True}],
+            "footer": {"show": False},
+        },
+        "fieldConfig": {
+            "defaults": {"custom": {"align": "left", "displayMode": "color-text", "filterable": True}},
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": "Ancienneté / Age"},
+                    "properties": [
+                        {"id": "unit", "value": "s"},
+                        {"id": "custom.displayMode", "value": "color-background"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "green", "value": None},
+                                    {"color": "yellow", "value": 82800},
+                                    {"color": "orange", "value": 86400},
+                                    {"color": "red", "value": 90000},
+                                ],
+                            },
+                        },
+                        {"id": "color", "value": {"mode": "thresholds"}},
+                    ],
+                },
+                {
+                    "matcher": {"id": "byName", "options": "Phase"},
+                    "properties": [
+                        {
+                            "id": "mappings",
+                            "value": [
+                                {"type": "value", "options": {"BACKUP": {"text": "Sauvegarde primaire", "color": "blue", "index": 0}}},
+                                {"type": "value", "options": {"DUPLICATION": {"text": "Copie bande", "color": "purple", "index": 1}}},
+                                {"type": "value", "options": {"IMPORT": {"text": "Réplication AIR", "color": "orange", "index": 2}}},
+                            ],
+                        }
+                    ],
+                },
+                {"matcher": {"id": "byName", "options": "Site"}, "properties": [{"id": "custom.width", "value": 100}]},
+            ],
+        },
+    }
+
+
+def _table_overdue(title, description, action_filter, x, y, w, h, value_col, age_threshold):
+    return {
+        "id": nid(),
+        "type": "table",
+        "title": title,
+        "description": description,
+        "gridPos": {"x": x, "y": y, "w": w, "h": h},
+        "datasource": ds(),
+        "targets": [{"datasource": ds(), "expr": f'sort_desc(time() - nbu_client_last_job_success_seconds{{action="{action_filter}", client=~"$client_filter", site=~"$site"}}) > {age_threshold}', "instant": True, "format": "table", "refId": "A"}],
+        "transformations": [
+            {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {"Time": True, "__name__": True, "action": True},
+                    "indexByName": {"site": 0, "client": 1, "policy": 2, "Value": 3},
+                    "renameByName": {"site": "Site", "client": "Client", "policy": "Politique / Policy", "Value": value_col},
+                },
+            }
+        ],
+        "options": {
+            "showHeader": True,
+            "sortBy": [{"displayName": value_col, "desc": True}],
+            "footer": {"show": True, "reducer": ["count"], "countRows": True},
+        },
+        "fieldConfig": {
+            "defaults": {"custom": {"align": "left", "filterable": True}},
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": value_col},
+                    "properties": [
+                        {"id": "unit", "value": "s"},
+                        {"id": "custom.displayMode", "value": "color-background"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "yellow", "value": None},
+                                    {"color": "orange", "value": 172800},
+                                    {"color": "red", "value": 259200},
+                                ],
+                            },
+                        },
+                        {"id": "color", "value": {"mode": "thresholds"}},
+                    ],
+                },
+                {"matcher": {"id": "byName", "options": "Site"}, "properties": [{"id": "custom.width", "value": 100}]},
+            ],
+        },
+    }
+
+
+def _timeseries_phase_bars(y):
+    return {
+        "id": nid(),
+        "type": "timeseries",
+        "title": "Jobs réussis par phase / Successful jobs by phase",
+        "description": "Nombre de jobs status=0 par type dans la fenêtre de scraping. Les barres représentent le rythme d'activité de chaque phase du cycle de vie.",
+        "gridPos": {"x": 0, "y": y, "w": 16, "h": 9},
+        "datasource": ds(),
+        "targets": [
+            {"datasource": ds(), "expr": 'sum by (action) (nbu_client_jobs_count{status="0", action=~"BACKUP|DUPLICATION|IMPORT|RESTORE", client=~"$client_filter", site=~"$site"})', "refId": "A", "legendFormat": "{{action}}"}
+        ],
+        "options": {
+            "tooltip": {"mode": "multi", "sort": "desc"},
+            "legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max", "sum"]},
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "short",
+                "custom": {"drawStyle": "bars", "fillOpacity": 70, "lineWidth": 0, "barAlignment": 0, "spanNulls": False, "showPoints": "never"},
+            },
+            "overrides": [
+                {"matcher": {"id": "byName", "options": "BACKUP"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]},
+                {"matcher": {"id": "byName", "options": "DUPLICATION"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "purple"}}]},
+                {"matcher": {"id": "byName", "options": "IMPORT"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+                {"matcher": {"id": "byName", "options": "RESTORE"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]},
+            ],
+        },
+    }
+
+
+def _timeseries_volume(y):
+    return {
+        "id": nid(),
+        "type": "timeseries",
+        "title": "Volume transféré par phase / Data transferred by phase",
+        "description": "Octets transférés par type de job. Note : le filtre Client ne s'applique pas ici — nbu_jobs_bytes n'a pas de label client.",
+        "gridPos": {"x": 0, "y": y, "w": 24, "h": 8},
+        "datasource": ds(),
+        "targets": [
+            {"datasource": ds(), "expr": 'sum by (action) (nbu_jobs_bytes{action=~"BACKUP|DUPLICATION|IMPORT", site=~"$site"})', "refId": "A", "legendFormat": "{{action}}"}
+        ],
+        "options": {
+            "tooltip": {"mode": "multi", "sort": "desc"},
+            "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]},
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "decbytes",
+                "custom": {"drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "spanNulls": False},
+            },
+            "overrides": [
+                {"matcher": {"id": "byName", "options": "BACKUP"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]},
+                {"matcher": {"id": "byName", "options": "DUPLICATION"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "purple"}}]},
+                {"matcher": {"id": "byName", "options": "IMPORT"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+            ],
+        },
+    }
+
+
+def _timeseries_duration(y):
+    return {
+        "id": nid(),
+        "type": "timeseries",
+        "title": "Durée P95 et P50 des jobs BACKUP par politique / P95 & P50 BACKUP duration per policy",
+        "description": "Percentiles 50 (médiane) et 95 de la durée des jobs BACKUP par type de politique. Une dérive vers le haut indique un ralentissement (charge réseau, volumétrie croissante).",
+        "gridPos": {"x": 0, "y": y, "w": 24, "h": 8},
+        "datasource": ds(),
+        "targets": [
+            {"datasource": ds(), "expr": 'histogram_quantile(0.95, sum by (policy_type, le) (rate(nbu_job_duration_seconds_bucket{action="BACKUP", site=~"$site"}[$__rate_interval])))', "refId": "A", "legendFormat": "P95 {{policy_type}}"},
+            {"datasource": ds(), "expr": 'histogram_quantile(0.50, sum by (policy_type, le) (rate(nbu_job_duration_seconds_bucket{action="BACKUP", site=~"$site"}[$__rate_interval])))', "refId": "B", "legendFormat": "P50 {{policy_type}}"},
+        ],
+        "options": {
+            "tooltip": {"mode": "multi", "sort": "desc"},
+            "legend": {"displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"]},
+        },
+        "fieldConfig": {
+            "defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "spanNulls": True}, "color": {"mode": "palette-classic"}},
+            "overrides": [],
+        },
+    }
+
+
+def build():
+    reset_ids()
+    panels = [
+        # ── Schéma du cycle de vie / Lifecycle flow diagram ───────────────────
+        text_panel(
+            "Schéma du cycle de vie / Lifecycle Flow",
+            _FLOW_MD,
+            0, 0, 24, 10,
+        ),
+
+        # ── Row 1: KPIs ───────────────────────────────────────────────────────
+        {"id": nid(), "type": "row", "title": "Vue d'ensemble / Overview", "gridPos": {"x": 0, "y": 10, "w": 24, "h": 1}, "collapsed": False},
+        _stat_bg(
+            "Clients sauvegardés (24h)",
+            "Clients ayant eu au moins un backup primaire réussi dans les dernières 24h.",
+            'count(nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} > (time() - 86400)) or on() vector(0)',
+            0, 11, 6, 4,
+            [{"color": "red", "value": None}, {"color": "yellow", "value": 1}, {"color": "green", "value": 5}],
+        ),
+        _stat_bg(
+            "Clients sans backup (>25h)",
+            "Clients en violation du SLA journalier — dernier backup primaire > 25h.",
+            'count(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} > 90000) or on() vector(0)',
+            6, 11, 6, 4,
+            [{"color": "green", "value": None}, {"color": "yellow", "value": 1}, {"color": "red", "value": 3}],
+        ),
+        _stat_sparkline(
+            "Copies bande (DUPLICATION)",
+            "Jobs de duplication vers bande réussis dans la fenêtre de scraping.",
+            'sum(nbu_client_jobs_count{action="DUPLICATION", status="0", client=~"$client_filter", site=~"$site"}) or on() vector(0)',
+            12, 11, 6, 4,
+        ),
+        _stat_sparkline(
+            "Réplications IMPORT (AIR)",
+            "Jobs IMPORT réussis (réplication inter-site via Auto Image Replication).",
+            'sum(nbu_client_jobs_count{action="IMPORT", status="0", client=~"$client_filter", site=~"$site"}) or on() vector(0)',
+            18, 11, 6, 4,
+        ),
+
+        # ── Row 2: Taux de réussite par phase ─────────────────────────────────
+        {"id": nid(), "type": "row", "title": "Taux de réussite par phase / Success Rate per Phase", "gridPos": {"x": 0, "y": 15, "w": 24, "h": 1}, "collapsed": False},
+        _gauge(
+            "Sauvegarde primaire / Primary Backup",
+            "Taux de succès des jobs BACKUP dans la fenêtre de scraping. Objectif : >90%.",
+            'sum(nbu_client_jobs_count{action="BACKUP", status="0", client=~"$client_filter", site=~"$site"}) / clamp_min(sum(nbu_client_jobs_count{action="BACKUP", client=~"$client_filter", site=~"$site"}), 1) * 100',
+            0, 16, 8, 6,
+            legend="BACKUP",
+        ),
+        _gauge(
+            "Copie bande / Tape Duplication",
+            "Taux de succès des jobs DUPLICATION (copie vers bande via SLP). Objectif : >90%.",
+            'sum(nbu_client_jobs_count{action="DUPLICATION", status="0", client=~"$client_filter", site=~"$site"}) / clamp_min(sum(nbu_client_jobs_count{action="DUPLICATION", client=~"$client_filter", site=~"$site"}), 1) * 100',
+            8, 16, 8, 6,
+            legend="DUPLICATION",
+        ),
+        _gauge(
+            "Réplication inter-site (IMPORT)",
+            "Taux de succès des jobs IMPORT (Auto Image Replication). Objectif : >90%.",
+            'sum(nbu_client_jobs_count{action="IMPORT", status="0", client=~"$client_filter", site=~"$site"}) / clamp_min(sum(nbu_client_jobs_count{action="IMPORT", client=~"$client_filter", site=~"$site"}), 1) * 100',
+            16, 16, 8, 6,
+            legend="IMPORT",
+        ),
+
+        # ── Row 3: Conformité clients dans le temps ───────────────────────────
+        {"id": nid(), "type": "row", "title": "Conformité BACKUP dans le temps / BACKUP Compliance Timeline", "gridPos": {"x": 0, "y": 22, "w": 24, "h": 1}, "collapsed": False},
+        state_timeline(
+            "Clients conformes (BACKUP < 25h) / Compliant clients (BACKUP < 25h)",
+            'clamp_max(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} < 90000, 1)',
+            0, 23, 16, 12,
+            legend="{{client}}",
+            thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 0.5}],
+        ),
+        piechart(
+            "Distribution de conformité / Compliance distribution",
+            'clamp_max(sum(nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} > (time() - 90000)) or on() vector(0), 9999)',
+            16, 23, 8, 6,
+            legend="Conformes",
+        ),
+        bar_gauge(
+            "Clients par ancienneté du backup / Clients by backup age",
+            'sort_desc(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"})',
+            16, 29, 8, 6,
+            unit="s",
+            thresholds=[
+                {"color": "green", "value": None},
+                {"color": "yellow", "value": 82800},
+                {"color": "orange", "value": 86400},
+                {"color": "red", "value": 90000},
+            ],
+            legend="{{client}}",
+        ),
+
+        # ── Row 4: Cycle de vie complet par client ────────────────────────────
+        {"id": nid(), "type": "row", "title": "Cycle de vie complet par client / Full Lifecycle per Client", "gridPos": {"x": 0, "y": 35, "w": 24, "h": 1}, "collapsed": False},
+        _table_lifecycle(),
+
+        # ── Row 5: Activité dans le temps ─────────────────────────────────────
+        {"id": nid(), "type": "row", "title": "Activité dans le temps / Activity Over Time", "gridPos": {"x": 0, "y": 58, "w": 24, "h": 1}, "collapsed": False},
+        _timeseries_phase_bars(59),
+        # Piechart of current window jobs by phase (next to the timeseries)
+        piechart(
+            "Répartition des jobs par phase / Jobs by phase",
+            'sum by (action) (nbu_client_jobs_count{status="0", client=~"$client_filter", site=~"$site"})',
+            16, 59, 8, 9,
+            legend="{{action}}",
+        ),
+        _timeseries_volume(68),
+
+        # ── Row 6: Clients en alerte ──────────────────────────────────────────
+        {"id": nid(), "type": "row", "title": "Clients en alerte / Clients in Alert", "gridPos": {"x": 0, "y": 76, "w": 24, "h": 1}, "collapsed": False},
+        _table_overdue(
+            "Clients dont le backup dépasse 25h / Clients with backup older than 25h",
+            "Clients en violation du SLA — dernier BACKUP > 25h. Les plus critiques en tête.",
+            "BACKUP", 0, 77, 12, 10, "Retard backup / Overdue", 90000,
+        ),
+        _table_overdue(
+            "Clients sans copie bande récente (>26h) / Clients missing tape copy (>26h)",
+            "Clients dont la dernière duplication vers bande date de plus de 26h.",
+            "DUPLICATION", 12, 77, 12, 10, "Retard copie bande / Tape copy overdue", 93600,
+        ),
+
+        # ── Row 7: Performance ────────────────────────────────────────────────
+        {"id": nid(), "type": "row", "title": "Performance / Job Duration", "gridPos": {"x": 0, "y": 87, "w": 24, "h": 1}, "collapsed": False},
+        _timeseries_duration(88),
+    ]
+
+    return dashboard(
+        "nbu-lifecycle",
+        "NetBackup — Cycle de vie des sauvegardes / Backup Lifecycle",
+        panels,
+        extra_vars=[client_filter_var()],
+    )

--- a/grafana/gen/multisite.py
+++ b/grafana/gen/multisite.py
@@ -1,0 +1,410 @@
+"""Multi-site comparison dashboard: cross-site backup volume, replication, and compliance."""
+
+from grafana.gen import panels as p
+from grafana.gen.variables import dashboard, client_filter_var
+
+# ── Architecture diagram (Markdown) ──────────────────────────────────────────
+_ARCH_MD = """\
+## Architecture multi-sites / Multi-site Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Site Principal / Primary Site               Site Distant / Remote Site      │
+│  ─────────────────────────────               ──────────────────────────────  │
+│                                                                              │
+│  [Clients]                                    [Clients locaux]               │
+│     │                                              │                         │
+│     ├─── BACKUP ───▶ NBU Master 1                  ├─── BACKUP ──▶ NBU Master 2 │
+│                           │                                      │           │
+│                           │── DUPLICATION ──▶ [Robot bande]      │           │
+│                           │                                      │           │
+│                           └── AIR (IMPORT) ──────────────────────┘           │
+│                                                   ▲                          │
+│                                              Réplication                     │
+│                                              inter-sites                     │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Métriques clés** : `nbu_jobs_bytes`, `nbu_status_count`, `nbu_client_last_job_success_seconds`
+**Alerte divergence** : si un site sauvegarde < 30% du volume moyen inter-sites → `NbuInterSiteDivergence`
+"""
+
+
+def _stat_bg(title, description, expr, x, y, w, h, unit="none", thresholds=None):
+    if thresholds is None:
+        thresholds = [{"color": "blue", "value": None}]
+    return {
+        "type": "stat",
+        "id": p.nid(),
+        "title": title,
+        "description": description,
+        "datasource": p.ds(),
+        "gridPos": p.gridpos(x, y, w, h),
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "textMode": "auto",
+        },
+        "targets": [p.target(expr, instant=True)],
+    }
+
+
+def _stat_value(title, description, expr, x, y, w, h, unit="none", thresholds=None):
+    if thresholds is None:
+        thresholds = [{"color": "blue", "value": None}]
+    return {
+        "type": "stat",
+        "id": p.nid(),
+        "title": title,
+        "description": description,
+        "datasource": p.ds(),
+        "gridPos": p.gridpos(x, y, w, h),
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "textMode": "auto",
+        },
+        "targets": [p.target(expr, instant=True)],
+    }
+
+
+def _gauge(title, description, expr, x, y, w, h, legend=""):
+    return {
+        "id": p.nid(),
+        "type": "gauge",
+        "title": title,
+        "description": description,
+        "gridPos": {"x": x, "y": y, "w": w, "h": h},
+        "datasource": p.ds(),
+        "targets": [{"datasource": p.ds(), "expr": expr, "instant": True, "refId": "A", "legendFormat": legend}],
+        "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "orientation": "auto",
+            "showThresholdLabels": False,
+            "showThresholdMarkers": True,
+        },
+        "fieldConfig": {
+            "defaults": {
+                "unit": "percent",
+                "min": 0,
+                "max": 100,
+                "color": {"mode": "thresholds"},
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                        {"color": "red", "value": None},
+                        {"color": "yellow", "value": 70},
+                        {"color": "green", "value": 90},
+                    ],
+                },
+            },
+            "overrides": [],
+        },
+    }
+
+
+def _table_missing(title, description, expr, x, y, w, h, value_col):
+    return {
+        "id": p.nid(),
+        "type": "table",
+        "title": title,
+        "description": description,
+        "gridPos": {"x": x, "y": y, "w": w, "h": h},
+        "datasource": p.ds(),
+        "targets": [{"datasource": p.ds(), "expr": expr, "instant": True, "format": "table", "refId": "A"}],
+        "transformations": [
+            {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {"Time": True, "__name__": True, "action": True},
+                    "indexByName": {"site": 0, "client": 1, "policy": 2, "Value": 3},
+                    "renameByName": {"site": "Site", "client": "Client", "policy": "Politique / Policy", "Value": value_col},
+                },
+            }
+        ],
+        "options": {
+            "showHeader": True,
+            "sortBy": [{"displayName": value_col, "desc": True}],
+            "footer": {"show": True, "reducer": ["count"], "countRows": True},
+        },
+        "fieldConfig": {
+            "defaults": {"custom": {"align": "left", "filterable": True}},
+            "overrides": [
+                {
+                    "matcher": {"id": "byName", "options": value_col},
+                    "properties": [
+                        {"id": "unit", "value": "s"},
+                        {"id": "custom.displayMode", "value": "color-background"},
+                        {
+                            "id": "thresholds",
+                            "value": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {"color": "yellow", "value": None},
+                                    {"color": "orange", "value": 172800},
+                                    {"color": "red", "value": 259200},
+                                ],
+                            },
+                        },
+                        {"id": "color", "value": {"mode": "thresholds"}},
+                    ],
+                },
+                {"matcher": {"id": "byName", "options": "Site"}, "properties": [{"id": "custom.width", "value": 100}]},
+            ],
+        },
+    }
+
+
+def build():
+    p.reset_ids()
+    out = []
+
+    # ── Architecture diagram ──────────────────────────────────────────────────
+    out.append(p.text_panel("Architecture multi-sites / Multi-site Architecture", _ARCH_MD, 0, 0, 24, 10))
+
+    # ── Row 1: Vue d'ensemble multi-sites / Multi-site Overview ───────────────
+    out.append(p.row("Vue d'ensemble multi-sites / Multi-site Overview", 10))
+
+    out.append(_stat_value(
+        "Total jobs (fenêtre de scraping)",
+        "Nombre total de jobs toutes phases (BACKUP + DUPLICATION + IMPORT + RESTORE) sur tous les sites sélectionnés.",
+        'sum(nbu_jobs_count{site=~"$site"})',
+        0, 11, 5, 4,
+        thresholds=[{"color": "blue", "value": None}],
+    ))
+    out.append(_stat_value(
+        "Volume BACKUP total",
+        "Total des octets transférés par les jobs BACKUP sur tous les sites.",
+        'sum(nbu_jobs_bytes{action="BACKUP", site=~"$site"})',
+        5, 11, 5, 4,
+        unit="decbytes",
+        thresholds=[{"color": "blue", "value": None}],
+    ))
+    out.append(_stat_bg(
+        "Clients actifs (24h)",
+        "Clients ayant eu au moins un BACKUP réussi dans les dernières 24h, tous sites.",
+        'count(nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} > (time() - 86400)) or on() vector(0)',
+        10, 11, 5, 4,
+        thresholds=[{"color": "red", "value": None}, {"color": "yellow", "value": 1}, {"color": "green", "value": 5}],
+    ))
+    out.append(_stat_bg(
+        "Clients sans backup (>25h)",
+        "Clients dont le dernier BACKUP dépasse 25h — violation du SLA journalier.",
+        'count(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} > 90000) or on() vector(0)',
+        15, 11, 4, 4,
+        thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 1}, {"color": "red", "value": 3}],
+    ))
+    out.append(_stat_bg(
+        "Clients sans réplication (>28h)",
+        "Clients dont le dernier IMPORT dépasse 28h — potentiellement non répliqués sur le site secondaire.",
+        'count(time() - nbu_client_last_job_success_seconds{action="IMPORT", client=~"$client_filter", site=~"$site"} > 100800) or on() vector(0)',
+        19, 11, 5, 4,
+        thresholds=[{"color": "green", "value": None}, {"color": "yellow", "value": 1}, {"color": "red", "value": 3}],
+    ))
+
+    # ── Row 2: Taux de réussite par site / Success Rate per Site ──────────────
+    out.append(p.row("Taux de réussite par site / Success Rate per Site", 15))
+
+    out.append(_gauge(
+        "Taux BACKUP (tous sites)",
+        "Ratio jobs BACKUP réussis / total dans la fenêtre de scraping, tous sites.",
+        'sum(nbu_status_count{action="BACKUP", status="0", site=~"$site"}) / clamp_min(sum(nbu_status_count{action="BACKUP", site=~"$site"}), 1) * 100',
+        0, 16, 8, 6,
+        legend="BACKUP",
+    ))
+    out.append(_gauge(
+        "Taux DUPLICATION (tous sites)",
+        "Ratio jobs de copie bande (DUPLICATION) réussis / total.",
+        'sum(nbu_status_count{action="DUPLICATION", status="0", site=~"$site"}) / clamp_min(sum(nbu_status_count{action="DUPLICATION", site=~"$site"}), 1) * 100',
+        8, 16, 8, 6,
+        legend="DUPLICATION",
+    ))
+    out.append(_gauge(
+        "Taux IMPORT / AIR (tous sites)",
+        "Ratio jobs IMPORT réussis / total. Mesure la fiabilité de la réplication inter-site.",
+        'sum(nbu_status_count{action="IMPORT", status="0", site=~"$site"}) / clamp_min(sum(nbu_status_count{action="IMPORT", site=~"$site"}), 1) * 100',
+        16, 16, 8, 6,
+        legend="IMPORT",
+    ))
+
+    # ── Row 3: Volume de sauvegarde par site / Backup Volume per Site ─────────
+    out.append(p.row("Volume de sauvegarde par site / Backup Volume per Site", 22))
+
+    out.append(p.barchart(
+        "Volume BACKUP par site / Backup volume per site",
+        'sum by (site) (nbu_jobs_bytes{action="BACKUP", site=~"$site"})',
+        0, 23, 12, 8,
+        legend="{{site}}",
+        unit="decbytes",
+    ))
+    out.append(p.timeseries(
+        "Évolution volume BACKUP par site / Backup volume over time per site",
+        [p.target('sum by (site) (nbu_jobs_bytes{action="BACKUP", site=~"$site"})', "{{site}}")],
+        12, 23, 12, 8,
+        unit="decbytes",
+    ))
+
+    # ── Row 4: Activité par site / Jobs per Site ──────────────────────────────
+    out.append(p.row("Activité par site / Activity per Site", 31))
+
+    out.append(p.barchart(
+        "Nombre de jobs par site et phase / Job count per site and phase",
+        'sum by (site, action) (nbu_jobs_count{site=~"$site"})',
+        0, 32, 12, 8,
+        legend="{{site}} — {{action}}",
+    ))
+    out.append(p.timeseries(
+        "Jobs BACKUP dans le temps par site / BACKUP jobs over time per site",
+        [p.target('sum by (site) (nbu_jobs_count{action="BACKUP", site=~"$site"})', "{{site}}")],
+        12, 32, 12, 8,
+    ))
+
+    # ── Row 5: Conformité BACKUP par site / BACKUP Compliance Timeline ─────────
+    out.append(p.row("Conformité BACKUP par site / BACKUP Compliance Timeline", 40))
+
+    out.append(p.state_timeline(
+        "Clients conformes BACKUP par site (< 25h) / Compliant clients per site",
+        'clamp_max(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"} < 90000, 1)',
+        0, 41, 16, 12,
+        legend="{{site}} — {{client}}",
+        thresholds=[{"color": "red", "value": None}, {"color": "green", "value": 0.5}],
+    ))
+    out.append(p.piechart(
+        "Répartition jobs par site / Jobs distribution per site",
+        'sum by (site) (nbu_jobs_count{action="BACKUP", site=~"$site"})',
+        16, 41, 8, 6,
+        legend="{{site}}",
+    ))
+    out.append(p.bar_gauge(
+        "Taux BACKUP par site / BACKUP success rate per site",
+        'sum by (site) (nbu_status_count{action="BACKUP", status="0", site=~"$site"}) / clamp_min(sum by (site) (nbu_status_count{action="BACKUP", site=~"$site"}), 1) * 100',
+        16, 47, 8, 6,
+        unit="percent",
+        thresholds=[{"color": "red", "value": None}, {"color": "yellow", "value": 70}, {"color": "green", "value": 90}],
+        legend="{{site}}",
+    ))
+
+    # ── Row 6: Réplication inter-sites / Inter-site Replication ──────────────
+    out.append(p.row("Réplication inter-sites / Inter-site Replication", 53))
+
+    out.append(_stat_value(
+        "Volume IMPORT total",
+        "Octets reçus via IMPORT (Auto Image Replication) sur tous les sites sélectionnés.",
+        'sum(nbu_jobs_bytes{action="IMPORT", site=~"$site"}) or on() vector(0)',
+        0, 54, 6, 4,
+        unit="decbytes",
+    ))
+    out.append(_stat_value(
+        "Jobs IMPORT réussis",
+        "Nombre total de jobs IMPORT réussis dans la fenêtre de scraping.",
+        'sum(nbu_status_count{action="IMPORT", status="0", site=~"$site"}) or on() vector(0)',
+        6, 54, 6, 4,
+    ))
+    out.append(p.barchart(
+        "Volume IMPORT par site / Replication volume per site",
+        'sum by (site) (nbu_jobs_bytes{action="IMPORT", site=~"$site"})',
+        12, 54, 12, 8,
+        legend="{{site}}",
+        unit="decbytes",
+    ))
+    out.append(p.timeseries(
+        "Volume IMPORT dans le temps par site / Replication volume over time",
+        [p.target('sum by (site) (nbu_jobs_bytes{action="IMPORT", site=~"$site"})', "{{site}}")],
+        0, 58, 12, 8,
+        unit="decbytes",
+    ))
+    out.append(p.timeseries(
+        "Jobs IMPORT dans le temps par site / IMPORT jobs over time per site",
+        [p.target('sum by (site) (nbu_status_count{action="IMPORT", site=~"$site"})', "{{site}}")],
+        12, 58, 12, 8,
+    ))
+
+    # ── Row 7: Divergence inter-sites / Inter-site Divergence ─────────────────
+    out.append(p.row("Divergence inter-sites / Inter-site Divergence", 66))
+
+    out.append(p.timeseries(
+        "Ratio BACKUP site / moyenne inter-sites (1.0 = normal, <0.3 = alerte)",
+        [p.target(
+            'sum by (site) (nbu_jobs_bytes{action="BACKUP", site=~"$site"}) / on() group_left() avg(sum by (site) (nbu_jobs_bytes{action="BACKUP", site=~"$site"}))',
+            "{{site}}",
+        )],
+        0, 67, 12, 8,
+        unit="percentunit",
+    ))
+    out.append(p.timeseries(
+        "BACKUP vs IMPORT par site / BACKUP vs IMPORT bytes per site",
+        [
+            p.target('sum by (site) (nbu_jobs_bytes{action="BACKUP", site=~"$site"})', "BACKUP {{site}}"),
+            p.target('sum by (site) (nbu_jobs_bytes{action="IMPORT", site=~"$site"})', "IMPORT {{site}}"),
+        ],
+        12, 67, 12, 8,
+        unit="decbytes",
+    ))
+
+    # ── Row 8: Clients en alerte multi-sites / Multi-site Client Alerts ────────
+    out.append(p.row("Clients en alerte / Clients in Alert", 75))
+
+    out.append(_table_missing(
+        "Clients sans backup récent (>25h) / Clients missing recent backup",
+        "Liste des clients en violation du SLA de sauvegarde (>25h), avec le site d'appartenance.",
+        'sort_desc(time() - nbu_client_last_job_success_seconds{action="BACKUP", client=~"$client_filter", site=~"$site"}) > 90000',
+        0, 76, 12, 10,
+        "Retard backup / Overdue",
+    ))
+    out.append(_table_missing(
+        "Clients sans réplication récente (>28h) / Clients missing recent replication",
+        "Clients dont la réplication IMPORT dépasse 28h — potentiellement non répliqués sur le site secondaire.",
+        'sort_desc(time() - nbu_client_last_job_success_seconds{action="IMPORT", client=~"$client_filter", site=~"$site"}) > 100800',
+        12, 76, 12, 10,
+        "Retard réplication / Replication lag",
+    ))
+
+    # ── Row 9: Bande par site / Tape per Site (NBU 10.5+) ─────────────────────
+    out.append(p.row("Bande par site / Tape per Site (NBU 10.5+)", 86))
+
+    out.append(p.barchart(
+        "Lecteurs UP par site / Tape drives UP per site",
+        'sum by (site) (nbu_tape_drives_count{status="DRIVE_STATUS_UP", site=~"$site"})',
+        0, 87, 8, 8,
+        legend="{{site}}",
+    ))
+    out.append(p.barchart(
+        "Cartouches par site / Tape media per site",
+        'sum by (site) (nbu_tape_media_count{site=~"$site"})',
+        8, 87, 8, 8,
+        legend="{{site}}",
+    ))
+    out.append(p.timeseries(
+        "Lecteurs DOWN dans le temps par site / DOWN drives over time per site",
+        [p.target('sum by (site) (nbu_tape_drives_count{status="DRIVE_STATUS_DOWN", site=~"$site"})', "{{site}}")],
+        16, 87, 8, 8,
+    ))
+
+    return dashboard(
+        "nbu-multisite",
+        "NetBackup — Comparaison multi-sites / Multi-site Comparison",
+        out,
+        extra_vars=[client_filter_var()],
+    )

--- a/grafana/gen/panels.py
+++ b/grafana/gen/panels.py
@@ -242,6 +242,75 @@ def barchart(title, expr, x, y, w, h, legend="{{policy_type}}", unit="none"):
     }
 
 
+def state_timeline(title, expr, x, y, w, h, legend="{{client}}", thresholds=None):
+    if thresholds is None:
+        thresholds = [{"color": "red", "value": None}, {"color": "green", "value": 0.5}]
+    return {
+        "type": "state-timeline",
+        "id": nid(),
+        "title": title,
+        "datasource": ds(),
+        "gridPos": gridpos(x, y, w, h),
+        "targets": [target(expr, legend, instant=False)],
+        "options": {
+            "mergeValues": True,
+            "showValue": "never",
+            "alignValue": "left",
+            "rowHeight": 0.9,
+            "legend": {"displayMode": "hidden", "placement": "bottom"},
+            "tooltip": {"mode": "single", "sort": "none"},
+        },
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+                "custom": {"fillOpacity": 90, "lineWidth": 0},
+            },
+            "overrides": [],
+        },
+    }
+
+
+def bar_gauge(title, expr, x, y, w, h, unit="none", thresholds=None, legend="{{client}}"):
+    if thresholds is None:
+        thresholds = [{"color": "green", "value": None}]
+    return {
+        "type": "bargauge",
+        "id": nid(),
+        "title": title,
+        "datasource": ds(),
+        "gridPos": gridpos(x, y, w, h),
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "color": {"mode": "thresholds"},
+                "thresholds": {"mode": "absolute", "steps": thresholds},
+            },
+            "overrides": [],
+        },
+        "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+            "valueMode": "color",
+            "showUnfilled": True,
+            "minVizWidth": 0,
+        },
+        "targets": [target(expr, legend, instant=True)],
+    }
+
+
+def text_panel(title, content, x, y, w, h):
+    """Static Markdown panel (no datasource/targets) — used for flow diagrams."""
+    return {
+        "type": "text",
+        "id": nid(),
+        "title": title,
+        "gridPos": gridpos(x, y, w, h),
+        "options": {"mode": "markdown", "content": content},
+    }
+
+
 def table_info(title, expr, x, y, w, h):
     return {
         "type": "table",

--- a/grafana/gen/tape.py
+++ b/grafana/gen/tape.py
@@ -1,0 +1,188 @@
+"""Tape & disk-pool infrastructure dashboard (API v12.0+, NBU 10.5+)."""
+
+from grafana.gen import panels as p
+from grafana.gen.variables import dashboard
+
+_TAPE_MD = """\
+## Infrastructure bande et disques / Tape & Disk Pool Infrastructure
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  NBU Master Server                    Robot bande / Tape Library             │
+│  ──────────────────                   ──────────────────────────             │
+│                                                                              │
+│  [Job DUPLICATION] ──▶ Lecteur bande ──▶ [Cartouche FULL]                   │
+│                        (Drive UP/DOWN)    [Cartouche PARTIAL]                │
+│                                           [Pool Scratch ↓ alerte]           │
+│                                                                              │
+│  [Disk Pool] ──▶ Volume UP/DOWN/UNKNOWN                                      │
+│                  (surveillance état et capacité)                             │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+> **Pré-requis**: NetBackup 10.5+ (API v12.0) et `collectors.tape.enabled: true` dans la config.
+"""
+
+
+def build():
+    p.reset_ids()
+    out = []
+
+    # ── Schéma infrastructure bande ───────────────────────────────────────────
+    out.append(p.text_panel("Infrastructure bande / Tape Infrastructure", _TAPE_MD, 0, 0, 24, 8))
+
+    # ── Row 1: Tape Drives ────────────────────────────────────────────────────
+    out.append(p.row("Lecteurs bande / Tape Drives", 8))
+
+    out.append(p.stat(
+        "Lecteurs UP / Drives UP",
+        'sum(nbu_tape_drives_count{status="DRIVE_STATUS_UP", site=~"$site"})',
+        0, 9, 6, 4,
+        thresholds=[{"color": "green", "value": None}],
+    ))
+    out.append(p.stat(
+        "Lecteurs DOWN / Drives DOWN",
+        'sum(nbu_tape_drives_count{status="DRIVE_STATUS_DOWN", site=~"$site"})',
+        6, 9, 6, 4,
+        thresholds=[
+            {"color": "green", "value": None},
+            {"color": "red", "value": 1},
+        ],
+    ))
+    out.append(p.stat(
+        "Total lecteurs / Total drives",
+        'sum(nbu_tape_drives_count{site=~"$site"})',
+        12, 9, 6, 4,
+        thresholds=[{"color": "blue", "value": None}],
+    ))
+    out.append(p.piechart(
+        "Lecteurs par statut / Drives by status",
+        'sum by (status) (nbu_tape_drives_count{site=~"$site"})',
+        18, 9, 6, 4,
+        legend="{{status}}",
+    ))
+
+    out.append(p.barchart(
+        "Lecteurs par type / Drives by type",
+        'sum by (drive_type, robot_type, status) (nbu_tape_drives_count{site=~"$site"})',
+        0, 13, 12, 8,
+        legend="{{drive_type}} / {{robot_type}} / {{status}}",
+    ))
+    out.append(p.timeseries(
+        "Évolution état lecteurs / Drive status over time",
+        [
+            p.target('sum by (status) (nbu_tape_drives_count{site=~"$site"})', "{{status}}"),
+        ],
+        12, 13, 12, 8,
+    ))
+
+    # ── Row 2: Tape Media ─────────────────────────────────────────────────────
+    out.append(p.row("Inventaire cartouches / Tape Media", 21))
+
+    out.append(p.stat(
+        "Total cartouches / Total media",
+        'sum(nbu_tape_media_count{site=~"$site"})',
+        0, 22, 6, 4,
+        thresholds=[{"color": "blue", "value": None}],
+    ))
+    out.append(p.piechart(
+        "Cartouches par pool / Media by pool",
+        'sum by (pool) (nbu_tape_media_count{site=~"$site"})',
+        6, 22, 9, 8,
+        legend="{{pool}}",
+    ))
+    out.append(p.piechart(
+        "Cartouches par type / Media by type",
+        'sum by (media_type) (nbu_tape_media_count{site=~"$site"})',
+        15, 22, 9, 8,
+        legend="{{media_type}}",
+    ))
+
+    out.append(p.barchart(
+        "Cartouches par pool et type / Media by pool & type",
+        'sum by (pool, media_type) (nbu_tape_media_count{site=~"$site"})',
+        0, 26, 24, 8,
+        legend="{{pool}} / {{media_type}}",
+    ))
+
+    # ── Row 3: Volume Pools ───────────────────────────────────────────────────
+    out.append(p.row("Pools de volumes bande / Tape Volume Pools", 34))
+
+    out.append(p.stat(
+        "Cartouches partiellement pleines / Partially full media",
+        'sum(nbu_tape_pool_partially_full{site=~"$site"})',
+        0, 35, 8, 4,
+        thresholds=[
+            {"color": "green", "value": None},
+            {"color": "yellow", "value": 5},
+            {"color": "red", "value": 20},
+        ],
+    ))
+    out.append(p.barchart(
+        "Partiellement pleines par pool / Partially full by pool",
+        'sum by (pool_name, pool_type) (nbu_tape_pool_partially_full{site=~"$site"})',
+        8, 35, 16, 4,
+        legend="{{pool_name}} ({{pool_type}})",
+    ))
+
+    out.append(p.timeseries(
+        "Évolution cartouches partielles / Partially full media over time",
+        [p.target('sum by (pool_name) (nbu_tape_pool_partially_full{site=~"$site"})', "{{pool_name}}")],
+        0, 39, 24, 7,
+    ))
+
+    # ── Row 4: Disk Pool Volumes ──────────────────────────────────────────────
+    out.append(p.row("Volumes disque / Disk Pool Volumes", 46))
+
+    out.append(p.stat(
+        "Volumes UP",
+        'sum(nbu_disk_pool_volume_count{state="UP", site=~"$site"})',
+        0, 47, 6, 4,
+        thresholds=[{"color": "green", "value": None}],
+    ))
+    out.append(p.stat(
+        "Volumes DOWN",
+        'sum(nbu_disk_pool_volume_count{state="DOWN", site=~"$site"})',
+        6, 47, 6, 4,
+        thresholds=[
+            {"color": "green", "value": None},
+            {"color": "red", "value": 1},
+        ],
+    ))
+    out.append(p.stat(
+        "Volumes UNKNOWN",
+        'sum(nbu_disk_pool_volume_count{state="UNKNOWN", site=~"$site"})',
+        12, 47, 6, 4,
+        thresholds=[
+            {"color": "green", "value": None},
+            {"color": "orange", "value": 1},
+        ],
+    ))
+    out.append(p.stat(
+        "Total volumes disque / Total disk volumes",
+        'sum(nbu_disk_pool_volume_count{site=~"$site"})',
+        18, 47, 6, 4,
+        thresholds=[{"color": "blue", "value": None}],
+    ))
+
+    out.append(p.barchart(
+        "Volumes par pool et état / Volumes by pool & state",
+        'sum by (pool_name, storage_category, state) (nbu_disk_pool_volume_count{site=~"$site"})',
+        0, 51, 16, 8,
+        legend="{{pool_name}} / {{storage_category}} / {{state}}",
+    ))
+    out.append(p.piechart(
+        "Répartition état volumes / Volume state distribution",
+        'sum by (state) (nbu_disk_pool_volume_count{site=~"$site"})',
+        16, 51, 8, 8,
+        legend="{{state}}",
+    ))
+
+    out.append(p.timeseries(
+        "État volumes disque dans le temps / Disk volume state over time",
+        [p.target('sum by (pool_name, state) (nbu_disk_pool_volume_count{site=~"$site"})',
+                  "{{pool_name}} / {{state}}")],
+        0, 59, 24, 7,
+    ))
+
+    return dashboard("nbu-tape", "NetBackup — Bande & Disques / Tape & Disk Pools", out)

--- a/grafana/gen/validate.py
+++ b/grafana/gen/validate.py
@@ -27,6 +27,14 @@ KNOWN_METRICS = {
     "nbu_malware_scan_count",
     "nbu_catalog_images_count",
     "nbu_slo_count",
+    # Tape / disk-pool collector (opt-in, NBU 10.5+)
+    "nbu_tape_drives_count",
+    "nbu_tape_media_count",
+    "nbu_tape_pool_partially_full",
+    "nbu_disk_pool_volume_count",
+    # Per-client lifecycle (opt-in, allowlisted)
+    "nbu_client_jobs_count",
+    "nbu_client_last_job_success_seconds",
 }
 
 _METRIC_RE = re.compile(r"nbu_[a-z0-9_]+")

--- a/grafana/gen/variables.py
+++ b/grafana/gen/variables.py
@@ -45,6 +45,12 @@ def policy_type_var():
     return _query_var("policy_type", "Policy type", "nbu_jobs_count", "policy_type")
 
 
+def client_filter_var():
+    # Sourced from the opt-in per-client metric; resolves to no clients (".*" allValue)
+    # when collectors.perClient is disabled, so lifecycle/multi-site panels degrade cleanly.
+    return _query_var("client_filter", "Client", "nbu_client_last_job_success_seconds", "client")
+
+
 def dashboard_links():
     """Tag-based links so every nbu dashboard cross-links to the others."""
     return [{

--- a/grafana/nbu-lifecycle.json
+++ b/grafana/nbu-lifecycle.json
@@ -1,0 +1,1629 @@
+{
+  "uid": "nbu-lifecycle",
+  "title": "NetBackup \u2014 Cycle de vie des sauvegardes / Backup Lifecycle",
+  "tags": [
+    "netbackup",
+    "nbu",
+    "backup"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "refresh": "1m",
+  "links": [
+    {
+      "type": "dashboards",
+      "title": "NetBackup",
+      "tags": [
+        "netbackup"
+      ],
+      "asDropdown": true,
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "client_filter",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Client",
+        "query": {
+          "query": "label_values(nbu_client_last_job_success_seconds, client)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations & Alerts",
+        "type": "dashboard",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "iconColor": "red"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "text",
+      "id": 1,
+      "title": "Sch\u00e9ma du cycle de vie / Lifecycle Flow",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "## Cycle de vie d'une sauvegarde / Backup Lifecycle Flow\n\n```\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502  Client                  Site Principal / Primary Site          Site distant  \u2502\n\u2502  \u2500\u2500\u2500\u2500\u2500\u2500                  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500        \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2502\n\u2502                                                                               \u2502\n\u2502  [Donn\u00e9es]               \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510                                 \u2502\n\u2502     \u2502                    \u2502  NBU Master 1   \u2502                                  \u2502\n\u2502     \u2502\u2500\u2500 BACKUP \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6  (sauvegarde)   \u2502                                  \u2502\n\u2502                          \u2502                 \u2502\u2500\u2500 DUPLICATION \u2500\u2500\u25b6 [Bande / Tape] \u2502\n\u2502                          \u2502                 \u2502                                  \u2502\n\u2502                          \u2502                 \u2502\u2500\u2500 AIR \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6 NBU Master 2   \u2502\n\u2502                          \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518                       \u2502          \u2502\n\u2502                                                                    \u2502          \u2502\n\u2502                                                               IMPORT re\u00e7u     \u2502\n\u2502                                                                               \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n```\n\n| Phase | M\u00e9trique | SLA |\n|-------|---------|-----|\n| BACKUP | `nbu_client_last_job_success_seconds{action=\"BACKUP\"}` | < 25h |\n| DUPLICATION | `nbu_client_last_job_success_seconds{action=\"DUPLICATION\"}` | < 26h |\n| IMPORT (AIR) | `nbu_client_last_job_success_seconds{action=\"IMPORT\"}` | < 28h |\n"
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Vue d'ensemble / Overview",
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Clients sauvegard\u00e9s (24h)",
+      "description": "Clients ayant eu au moins un backup primaire r\u00e9ussi dans les derni\u00e8res 24h.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} > (time() - 86400)) or on() vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Clients sans backup (>25h)",
+      "description": "Clients en violation du SLA journalier \u2014 dernier backup primaire > 25h.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 11,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} > 90000) or on() vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "Copies bande (DUPLICATION)",
+      "description": "Jobs de duplication vers bande r\u00e9ussis dans la fen\u00eatre de scraping.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 11,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_client_jobs_count{action=\"DUPLICATION\", status=\"0\", client=~\"$client_filter\", site=~\"$site\"}) or on() vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 6,
+      "title": "R\u00e9plications IMPORT (AIR)",
+      "description": "Jobs IMPORT r\u00e9ussis (r\u00e9plication inter-site via Auto Image Replication).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 11,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_client_jobs_count{action=\"IMPORT\", status=\"0\", client=~\"$client_filter\", site=~\"$site\"}) or on() vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Taux de r\u00e9ussite par phase / Success Rate per Phase",
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 8,
+      "type": "gauge",
+      "title": "Sauvegarde primaire / Primary Backup",
+      "description": "Taux de succ\u00e8s des jobs BACKUP dans la fen\u00eatre de scraping. Objectif : >90%.",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_client_jobs_count{action=\"BACKUP\", status=\"0\", client=~\"$client_filter\", site=~\"$site\"}) / clamp_min(sum(nbu_client_jobs_count{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "BACKUP"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "type": "gauge",
+      "title": "Copie bande / Tape Duplication",
+      "description": "Taux de succ\u00e8s des jobs DUPLICATION (copie vers bande via SLP). Objectif : >90%.",
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_client_jobs_count{action=\"DUPLICATION\", status=\"0\", client=~\"$client_filter\", site=~\"$site\"}) / clamp_min(sum(nbu_client_jobs_count{action=\"DUPLICATION\", client=~\"$client_filter\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "DUPLICATION"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "gauge",
+      "title": "R\u00e9plication inter-site (IMPORT)",
+      "description": "Taux de succ\u00e8s des jobs IMPORT (Auto Image Replication). Objectif : >90%.",
+      "gridPos": {
+        "x": 16,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_client_jobs_count{action=\"IMPORT\", status=\"0\", client=~\"$client_filter\", site=~\"$site\"}) / clamp_min(sum(nbu_client_jobs_count{action=\"IMPORT\", client=~\"$client_filter\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "IMPORT"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Conformit\u00e9 BACKUP dans le temps / BACKUP Compliance Timeline",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "type": "state-timeline",
+      "id": 12,
+      "title": "Clients conformes (BACKUP < 25h) / Compliant clients (BACKUP < 25h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 16,
+        "h": 12
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_max(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} < 90000, 1)",
+          "legendFormat": "{{site}} / {{client}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "mergeValues": true,
+        "showValue": "never",
+        "alignValue": "left",
+        "rowHeight": 0.9,
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 90,
+            "lineWidth": 0
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "piechart",
+      "id": 13,
+      "title": "Distribution de conformit\u00e9 / Compliance distribution",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 23,
+        "w": 8,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_max(sum(nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} > (time() - 90000)) or on() vector(0), 9999)",
+          "legendFormat": "Conformes",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "id": 14,
+      "title": "Clients par anciennet\u00e9 du backup / Clients by backup age",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 29,
+        "w": 8,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 82800
+              },
+              {
+                "color": "orange",
+                "value": 86400
+              },
+              {
+                "color": "red",
+                "value": 90000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{client}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "Cycle de vie complet par client / Full Lifecycle per Client",
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 16,
+      "type": "table",
+      "title": "Anciennet\u00e9 de la derni\u00e8re r\u00e9ussite par client et phase / Age of last success per client & phase",
+      "description": "Anciennet\u00e9 (en secondes) de la derni\u00e8re r\u00e9ussite pour chaque client/politique/phase. Jaune = proche du seuil (>23h), Orange = d\u00e9pass\u00e9 24h, Rouge = violation SLA (>25h). Trier la colonne Anciennet\u00e9 pour voir les clients les plus critiques en premier.",
+      "gridPos": {
+        "x": 0,
+        "y": 46,
+        "w": 24,
+        "h": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{client=~\"$client_filter\", site=~\"$site\"})",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "client": 0,
+              "policy": 1,
+              "action": 2,
+              "site": 3,
+              "Value": 4
+            },
+            "renameByName": {
+              "client": "Client",
+              "policy": "Politique / Policy",
+              "action": "Phase",
+              "site": "Site",
+              "Value": "Anciennet\u00e9 / Age"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Anciennet\u00e9 / Age",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "color-text",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Anciennet\u00e9 / Age"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 82800
+                    },
+                    {
+                      "color": "orange",
+                      "value": 86400
+                    },
+                    {
+                      "color": "red",
+                      "value": 90000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Phase"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "BACKUP": {
+                        "text": "Sauvegarde primaire",
+                        "color": "blue",
+                        "index": 0
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "DUPLICATION": {
+                        "text": "Copie bande",
+                        "color": "purple",
+                        "index": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "IMPORT": {
+                        "text": "R\u00e9plication AIR",
+                        "color": "orange",
+                        "index": 2
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Site"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "type": "row",
+      "title": "Activit\u00e9 dans le temps / Activity Over Time",
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Jobs r\u00e9ussis par phase / Successful jobs by phase",
+      "description": "Nombre de jobs status=0 par type dans la fen\u00eatre de scraping. Les barres repr\u00e9sentent le rythme d'activit\u00e9 de chaque phase du cycle de vie.",
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 16,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (action) (nbu_client_jobs_count{status=\"0\", action=~\"BACKUP|DUPLICATION|IMPORT|RESTORE\", client=~\"$client_filter\", site=~\"$site\"})",
+          "refId": "A",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "sum"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "barAlignment": 0,
+            "spanNulls": false,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BACKUP"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DUPLICATION"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "purple"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IMPORT"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RESTORE"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "piechart",
+      "id": 19,
+      "title": "R\u00e9partition des jobs par phase / Jobs by phase",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 59,
+        "w": 8,
+        "h": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, action) (nbu_client_jobs_count{status=\"0\", client=~\"$client_filter\", site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{action}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Volume transf\u00e9r\u00e9 par phase / Data transferred by phase",
+      "description": "Octets transf\u00e9r\u00e9s par type de job. Note : le filtre Client ne s'applique pas ici \u2014 nbu_jobs_bytes n'a pas de label client.",
+      "gridPos": {
+        "x": 0,
+        "y": 68,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (action) (nbu_jobs_bytes{action=~\"BACKUP|DUPLICATION|IMPORT\", site=~\"$site\"})",
+          "refId": "A",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BACKUP"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DUPLICATION"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "purple"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IMPORT"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "Clients en alerte / Clients in Alert",
+      "gridPos": {
+        "x": 0,
+        "y": 76,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 22,
+      "type": "table",
+      "title": "Clients dont le backup d\u00e9passe 25h / Clients with backup older than 25h",
+      "description": "Clients en violation du SLA \u2014 dernier BACKUP > 25h. Les plus critiques en t\u00eate.",
+      "gridPos": {
+        "x": 0,
+        "y": 77,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"}) > 90000",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "action": true
+            },
+            "indexByName": {
+              "site": 0,
+              "client": 1,
+              "policy": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "site": "Site",
+              "client": "Client",
+              "policy": "Politique / Policy",
+              "Value": "Retard backup / Overdue"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Retard backup / Overdue",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": [
+            "count"
+          ],
+          "countRows": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retard backup / Overdue"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 172800
+                    },
+                    {
+                      "color": "red",
+                      "value": 259200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Site"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "type": "table",
+      "title": "Clients sans copie bande r\u00e9cente (>26h) / Clients missing tape copy (>26h)",
+      "description": "Clients dont la derni\u00e8re duplication vers bande date de plus de 26h.",
+      "gridPos": {
+        "x": 12,
+        "y": 77,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{action=\"DUPLICATION\", client=~\"$client_filter\", site=~\"$site\"}) > 93600",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "action": true
+            },
+            "indexByName": {
+              "site": 0,
+              "client": 1,
+              "policy": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "site": "Site",
+              "client": "Client",
+              "policy": "Politique / Policy",
+              "Value": "Retard copie bande / Tape copy overdue"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Retard copie bande / Tape copy overdue",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": [
+            "count"
+          ],
+          "countRows": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retard copie bande / Tape copy overdue"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 172800
+                    },
+                    {
+                      "color": "red",
+                      "value": 259200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Site"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "type": "row",
+      "title": "Performance / Job Duration",
+      "gridPos": {
+        "x": 0,
+        "y": 87,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false
+    },
+    {
+      "id": 25,
+      "type": "timeseries",
+      "title": "Dur\u00e9e P95 et P50 des jobs BACKUP par politique / P95 & P50 BACKUP duration per policy",
+      "description": "Percentiles 50 (m\u00e9diane) et 95 de la dur\u00e9e des jobs BACKUP par type de politique. Une d\u00e9rive vers le haut indique un ralentissement (charge r\u00e9seau, volum\u00e9trie croissante).",
+      "gridPos": {
+        "x": 0,
+        "y": 88,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (policy_type, le) (rate(nbu_job_duration_seconds_bucket{action=\"BACKUP\", site=~\"$site\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P95 {{policy_type}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (policy_type, le) (rate(nbu_job_duration_seconds_bucket{action=\"BACKUP\", site=~\"$site\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P50 {{policy_type}}"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "spanNulls": true
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/grafana/nbu-multisite.json
+++ b/grafana/nbu-multisite.json
@@ -1,0 +1,2010 @@
+{
+  "uid": "nbu-multisite",
+  "title": "NetBackup \u2014 Comparaison multi-sites / Multi-site Comparison",
+  "tags": [
+    "netbackup",
+    "nbu",
+    "backup"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "refresh": "1m",
+  "links": [
+    {
+      "type": "dashboards",
+      "title": "NetBackup",
+      "tags": [
+        "netbackup"
+      ],
+      "asDropdown": true,
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "client_filter",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Client",
+        "query": {
+          "query": "label_values(nbu_client_last_job_success_seconds, client)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations & Alerts",
+        "type": "dashboard",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "iconColor": "red"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "text",
+      "id": 1,
+      "title": "Architecture multi-sites / Multi-site Architecture",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 10
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "## Architecture multi-sites / Multi-site Architecture\n\n```\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502  Site Principal / Primary Site               Site Distant / Remote Site      \u2502\n\u2502  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500               \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2502\n\u2502                                                                              \u2502\n\u2502  [Clients]                                    [Clients locaux]               \u2502\n\u2502     \u2502                                              \u2502                         \u2502\n\u2502     \u251c\u2500\u2500\u2500 BACKUP \u2500\u2500\u2500\u25b6 NBU Master 1                  \u251c\u2500\u2500\u2500 BACKUP \u2500\u2500\u25b6 NBU Master 2 \u2502\n\u2502                           \u2502                                      \u2502           \u2502\n\u2502                           \u2502\u2500\u2500 DUPLICATION \u2500\u2500\u25b6 [Robot bande]      \u2502           \u2502\n\u2502                           \u2502                                      \u2502           \u2502\n\u2502                           \u2514\u2500\u2500 AIR (IMPORT) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518           \u2502\n\u2502                                                   \u25b2                          \u2502\n\u2502                                              R\u00e9plication                     \u2502\n\u2502                                              inter-sites                     \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n```\n\n**M\u00e9triques cl\u00e9s** : `nbu_jobs_bytes`, `nbu_status_count`, `nbu_client_last_job_success_seconds`\n**Alerte divergence** : si un site sauvegarde < 30% du volume moyen inter-sites \u2192 `NbuInterSiteDivergence`\n"
+      }
+    },
+    {
+      "type": "row",
+      "id": 2,
+      "title": "Vue d'ensemble multi-sites / Multi-site Overview",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Total jobs (fen\u00eatre de scraping)",
+      "description": "Nombre total de jobs toutes phases (BACKUP + DUPLICATION + IMPORT + RESTORE) sur tous les sites s\u00e9lectionn\u00e9s.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 5,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_jobs_count{site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Volume BACKUP total",
+      "description": "Total des octets transf\u00e9r\u00e9s par les jobs BACKUP sur tous les sites.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 5,
+        "y": 11,
+        "w": 5,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "Clients actifs (24h)",
+      "description": "Clients ayant eu au moins un BACKUP r\u00e9ussi dans les derni\u00e8res 24h, tous sites.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 10,
+        "y": 11,
+        "w": 5,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} > (time() - 86400)) or on() vector(0)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 6,
+      "title": "Clients sans backup (>25h)",
+      "description": "Clients dont le dernier BACKUP d\u00e9passe 25h \u2014 violation du SLA journalier.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 15,
+        "y": 11,
+        "w": 4,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} > 90000) or on() vector(0)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 7,
+      "title": "Clients sans r\u00e9plication (>28h)",
+      "description": "Clients dont le dernier IMPORT d\u00e9passe 28h \u2014 potentiellement non r\u00e9pliqu\u00e9s sur le site secondaire.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 19,
+        "y": 11,
+        "w": 5,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(time() - nbu_client_last_job_success_seconds{action=\"IMPORT\", client=~\"$client_filter\", site=~\"$site\"} > 100800) or on() vector(0)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 8,
+      "title": "Taux de r\u00e9ussite par site / Success Rate per Site",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "gauge",
+      "title": "Taux BACKUP (tous sites)",
+      "description": "Ratio jobs BACKUP r\u00e9ussis / total dans la fen\u00eatre de scraping, tous sites.",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_status_count{action=\"BACKUP\", status=\"0\", site=~\"$site\"}) / clamp_min(sum(nbu_status_count{action=\"BACKUP\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "BACKUP"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "gauge",
+      "title": "Taux DUPLICATION (tous sites)",
+      "description": "Ratio jobs de copie bande (DUPLICATION) r\u00e9ussis / total.",
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_status_count{action=\"DUPLICATION\", status=\"0\", site=~\"$site\"}) / clamp_min(sum(nbu_status_count{action=\"DUPLICATION\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "DUPLICATION"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "gauge",
+      "title": "Taux IMPORT / AIR (tous sites)",
+      "description": "Ratio jobs IMPORT r\u00e9ussis / total. Mesure la fiabilit\u00e9 de la r\u00e9plication inter-site.",
+      "gridPos": {
+        "x": 16,
+        "y": 16,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_status_count{action=\"IMPORT\", status=\"0\", site=~\"$site\"}) / clamp_min(sum(nbu_status_count{action=\"IMPORT\", site=~\"$site\"}), 1) * 100",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "IMPORT"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "id": 12,
+      "title": "Volume de sauvegarde par site / Backup Volume per Site",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "barchart",
+      "id": 13,
+      "title": "Volume BACKUP par site / Backup volume per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 14,
+      "title": "\u00c9volution volume BACKUP par site / Backup volume over time per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 23,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 15,
+      "title": "Activit\u00e9 par site / Activity per Site",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 31,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "barchart",
+      "id": 16,
+      "title": "Nombre de jobs par site et phase / Job count per site and phase",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, action) (nbu_jobs_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} \u2014 {{action}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 17,
+      "title": "Jobs BACKUP dans le temps par site / BACKUP jobs over time per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_count{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 18,
+      "title": "Conformit\u00e9 BACKUP par site / BACKUP Compliance Timeline",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "state-timeline",
+      "id": 19,
+      "title": "Clients conformes BACKUP par site (< 25h) / Compliant clients per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 41,
+        "w": 16,
+        "h": 12
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "clamp_max(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"} < 90000, 1)",
+          "legendFormat": "{{site}} \u2014 {{client}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "mergeValues": true,
+        "showValue": "never",
+        "alignValue": "left",
+        "rowHeight": 0.9,
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 90,
+            "lineWidth": 0
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "piechart",
+      "id": 20,
+      "title": "R\u00e9partition jobs par site / Jobs distribution per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 41,
+        "w": 8,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_count{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "id": 21,
+      "title": "Taux BACKUP par site / BACKUP success rate per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 47,
+        "w": 8,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_status_count{action=\"BACKUP\", status=\"0\", site=~\"$site\"}) / clamp_min(sum by (site) (nbu_status_count{action=\"BACKUP\", site=~\"$site\"}), 1) * 100",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 22,
+      "title": "R\u00e9plication inter-sites / Inter-site Replication",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 23,
+      "title": "Volume IMPORT total",
+      "description": "Octets re\u00e7us via IMPORT (Auto Image Replication) sur tous les sites s\u00e9lectionn\u00e9s.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 54,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_jobs_bytes{action=\"IMPORT\", site=~\"$site\"}) or on() vector(0)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 24,
+      "title": "Jobs IMPORT r\u00e9ussis",
+      "description": "Nombre total de jobs IMPORT r\u00e9ussis dans la fen\u00eatre de scraping.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 54,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_status_count{action=\"IMPORT\", status=\"0\", site=~\"$site\"}) or on() vector(0)",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 25,
+      "title": "Volume IMPORT par site / Replication volume per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 54,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"IMPORT\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 26,
+      "title": "Volume IMPORT dans le temps par site / Replication volume over time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"IMPORT\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 27,
+      "title": "Jobs IMPORT dans le temps par site / IMPORT jobs over time per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 58,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_status_count{action=\"IMPORT\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 28,
+      "title": "Divergence inter-sites / Inter-site Divergence",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 66,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 29,
+      "title": "Ratio BACKUP site / moyenne inter-sites (1.0 = normal, <0.3 = alerte)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 67,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"}) / on() group_left() avg(sum by (site) (nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"}))",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 30,
+      "title": "BACKUP vs IMPORT par site / BACKUP vs IMPORT bytes per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 67,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"BACKUP\", site=~\"$site\"})",
+          "legendFormat": "BACKUP {{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_jobs_bytes{action=\"IMPORT\", site=~\"$site\"})",
+          "legendFormat": "IMPORT {{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 31,
+      "title": "Clients en alerte / Clients in Alert",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 75,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "type": "table",
+      "title": "Clients sans backup r\u00e9cent (>25h) / Clients missing recent backup",
+      "description": "Liste des clients en violation du SLA de sauvegarde (>25h), avec le site d'appartenance.",
+      "gridPos": {
+        "x": 0,
+        "y": 76,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{action=\"BACKUP\", client=~\"$client_filter\", site=~\"$site\"}) > 90000",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "action": true
+            },
+            "indexByName": {
+              "site": 0,
+              "client": 1,
+              "policy": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "site": "Site",
+              "client": "Client",
+              "policy": "Politique / Policy",
+              "Value": "Retard backup / Overdue"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Retard backup / Overdue",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": [
+            "count"
+          ],
+          "countRows": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retard backup / Overdue"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 172800
+                    },
+                    {
+                      "color": "red",
+                      "value": 259200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Site"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 33,
+      "type": "table",
+      "title": "Clients sans r\u00e9plication r\u00e9cente (>28h) / Clients missing recent replication",
+      "description": "Clients dont la r\u00e9plication IMPORT d\u00e9passe 28h \u2014 potentiellement non r\u00e9pliqu\u00e9s sur le site secondaire.",
+      "gridPos": {
+        "x": 12,
+        "y": 76,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(time() - nbu_client_last_job_success_seconds{action=\"IMPORT\", client=~\"$client_filter\", site=~\"$site\"}) > 100800",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "action": true
+            },
+            "indexByName": {
+              "site": 0,
+              "client": 1,
+              "policy": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "site": "Site",
+              "client": "Client",
+              "policy": "Politique / Policy",
+              "Value": "Retard r\u00e9plication / Replication lag"
+            }
+          }
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Retard r\u00e9plication / Replication lag",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": [
+            "count"
+          ],
+          "countRows": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retard r\u00e9plication / Replication lag"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 172800
+                    },
+                    {
+                      "color": "red",
+                      "value": 259200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Site"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "id": 34,
+      "title": "Bande par site / Tape per Site (NBU 10.5+)",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 86,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "barchart",
+      "id": 35,
+      "title": "Lecteurs UP par site / Tape drives UP per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 87,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_tape_drives_count{status=\"DRIVE_STATUS_UP\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 36,
+      "title": "Cartouches par site / Tape media per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 87,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_tape_media_count{site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 37,
+      "title": "Lecteurs DOWN dans le temps par site / DOWN drives over time per site",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 87,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site) (nbu_tape_drives_count{status=\"DRIVE_STATUS_DOWN\", site=~\"$site\"})",
+          "legendFormat": "{{site}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/nbu-tape.json
+++ b/grafana/nbu-tape.json
@@ -1,0 +1,1300 @@
+{
+  "uid": "nbu-tape",
+  "title": "NetBackup \u2014 Bande & Disques / Tape & Disk Pools",
+  "tags": [
+    "netbackup",
+    "nbu",
+    "backup"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "refresh": "1m",
+  "links": [
+    {
+      "type": "dashboards",
+      "title": "NetBackup",
+      "tags": [
+        "netbackup"
+      ],
+      "asDropdown": true,
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "site",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Site",
+        "query": {
+          "query": "label_values(nbu_up, site)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations & Alerts",
+        "type": "dashboard",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "iconColor": "red"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "text",
+      "id": 1,
+      "title": "Infrastructure bande / Tape Infrastructure",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 8
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "## Infrastructure bande et disques / Tape & Disk Pool Infrastructure\n\n```\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502  NBU Master Server                    Robot bande / Tape Library             \u2502\n\u2502  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500                   \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500             \u2502\n\u2502                                                                              \u2502\n\u2502  [Job DUPLICATION] \u2500\u2500\u25b6 Lecteur bande \u2500\u2500\u25b6 [Cartouche FULL]                   \u2502\n\u2502                        (Drive UP/DOWN)    [Cartouche PARTIAL]                \u2502\n\u2502                                           [Pool Scratch \u2193 alerte]           \u2502\n\u2502                                                                              \u2502\n\u2502  [Disk Pool] \u2500\u2500\u25b6 Volume UP/DOWN/UNKNOWN                                      \u2502\n\u2502                  (surveillance \u00e9tat et capacit\u00e9)                             \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n```\n\n> **Pr\u00e9-requis**: NetBackup 10.5+ (API v12.0) et `collectors.tape.enabled: true` dans la config.\n"
+      }
+    },
+    {
+      "type": "row",
+      "id": 2,
+      "title": "Lecteurs bande / Tape Drives",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Lecteurs UP / Drives UP",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_tape_drives_count{status=\"DRIVE_STATUS_UP\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Lecteurs DOWN / Drives DOWN",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 9,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_tape_drives_count{status=\"DRIVE_STATUS_DOWN\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "Total lecteurs / Total drives",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 9,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_tape_drives_count{site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "id": 6,
+      "title": "Lecteurs par statut / Drives by status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 9,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, status) (nbu_tape_drives_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{status}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 7,
+      "title": "Lecteurs par type / Drives by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, drive_type, robot_type, status) (nbu_tape_drives_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{drive_type}} / {{robot_type}} / {{status}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 8,
+      "title": "\u00c9volution \u00e9tat lecteurs / Drive status over time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 13,
+        "w": 12,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, status) (nbu_tape_drives_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{status}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 9,
+      "title": "Inventaire cartouches / Tape Media",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 10,
+      "title": "Total cartouches / Total media",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_tape_media_count{site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "id": 11,
+      "title": "Cartouches par pool / Media by pool",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 22,
+        "w": 9,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool) (nbu_tape_media_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "id": 12,
+      "title": "Cartouches par type / Media by type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 15,
+        "y": 22,
+        "w": 9,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, media_type) (nbu_tape_media_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{media_type}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 13,
+      "title": "Cartouches par pool et type / Media by pool & type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 26,
+        "w": 24,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool, media_type) (nbu_tape_media_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool}} / {{media_type}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 14,
+      "title": "Pools de volumes bande / Tape Volume Pools",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 34,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 15,
+      "title": "Cartouches partiellement pleines / Partially full media",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 8,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_tape_pool_partially_full{site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 16,
+      "title": "Partiellement pleines par pool / Partially full by pool",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 35,
+        "w": 16,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool_name, pool_type) (nbu_tape_pool_partially_full{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool_name}} ({{pool_type}})",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 17,
+      "title": "\u00c9volution cartouches partielles / Partially full media over time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 39,
+        "w": 24,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool_name) (nbu_tape_pool_partially_full{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool_name}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 18,
+      "title": "Volumes disque / Disk Pool Volumes",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 46,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 19,
+      "title": "Volumes UP",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 47,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_disk_pool_volume_count{state=\"UP\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 20,
+      "title": "Volumes DOWN",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 47,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_disk_pool_volume_count{state=\"DOWN\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 21,
+      "title": "Volumes UNKNOWN",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 47,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_disk_pool_volume_count{state=\"UNKNOWN\", site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 22,
+      "title": "Total volumes disque / Total disk volumes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 47,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(nbu_disk_pool_volume_count{site=~\"$site\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 23,
+      "title": "Volumes par pool et \u00e9tat / Volumes by pool & state",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 51,
+        "w": 16,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "legend": {
+          "showLegend": false
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool_name, storage_category, state) (nbu_disk_pool_volume_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool_name}} / {{storage_category}} / {{state}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "id": 24,
+      "title": "R\u00e9partition \u00e9tat volumes / Volume state distribution",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 51,
+        "w": 8,
+        "h": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, state) (nbu_disk_pool_volume_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{state}}",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 25,
+      "title": "\u00c9tat volumes disque dans le temps / Disk volume state over time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 24,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            },
+            "lineWidth": 1
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (site, pool_name, state) (nbu_disk_pool_volume_count{site=~\"$site\"})",
+          "legendFormat": "{{site}} / {{pool_name}} / {{state}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -11,17 +11,21 @@ import (
 )
 
 const (
-	drivesPath    = "/storage/drives"
-	tapeMediaPath = "/storage/tape-media"
-	robotHostPath = "/storage/robots-device-hosts"
-	maxMediaPages = 1000 // safety cap so a backend ignoring page[offset] cannot loop forever
-	pageLimitInt  = 100  // int form of pageLimit ("100"), for full-page truncation checks
+	drivesPath         = "/storage/drives"
+	tapeMediaPath      = "/storage/tape-media"
+	robotHostPath      = "/storage/robots-device-hosts"
+	tapeVolumePoolPath = "/storage/tape-volume-pools" // API v12.0+ (absent on v10.0)
+	diskPoolsPath      = "/storage/disk-pools"        // API v12.0+ (absent on v10.0)
+	maxMediaPages      = 1000                         // safety cap so a backend ignoring page[offset] cannot loop forever
+	pageLimitInt       = 100                          // int form of pageLimit ("100"), for full-page truncation checks
 )
 
 // tapeCollector is an opt-in sub-collector for tape/drive health. It reads
-// /storage/drives, /storage/tape-media and /storage/robots-device-hosts, with
+// /storage/drives, /storage/tape-media, /storage/robots-device-hosts and the
+// v12.0+ /storage/tape-volume-pools and /storage/disk-pools endpoints, with
 // per-endpoint graceful degradation (a missing endpoint on older NetBackup, or a
-// permission error, is logged and skipped).
+// permission error, is logged and skipped — so the pool endpoints simply contribute
+// nothing on appliances that lack them).
 type tapeCollector struct {
 	client NetBackupClient
 	cfg    models.Config
@@ -31,6 +35,8 @@ type tapeCollector struct {
 	driveInfo       *prometheus.Desc
 	mediaCount      *prometheus.Desc
 	robotHostsCount *prometheus.Desc
+	poolPartial     *prometheus.Desc
+	diskPoolVolumes *prometheus.Desc
 }
 
 func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *tapeCollector {
@@ -58,6 +64,16 @@ func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *t
 			"Number of device hosts that have robots configured",
 			[]string{"site"}, nil,
 		),
+		poolPartial: prometheus.NewDesc(
+			"nbu_tape_pool_partially_full",
+			"Number of partially full tape media volumes in each volume pool",
+			[]string{"site", "pool_name", "pool_type"}, nil,
+		),
+		diskPoolVolumes: prometheus.NewDesc(
+			"nbu_disk_pool_volume_count",
+			"Number of disk volumes per disk pool, grouped by pool name, storage category and volume state",
+			[]string{"site", "pool_name", "storage_category", "state"}, nil,
+		),
 	}
 }
 
@@ -70,6 +86,8 @@ func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric
 	c.collectDrives(ctx, ch)
 	c.collectMedia(ctx, ch)
 	c.collectRobotHosts(ctx, ch)
+	c.collectPools(ctx, ch)
+	c.collectDiskPools(ctx, ch)
 	return nil
 }
 
@@ -142,5 +160,72 @@ func (c *tapeCollector) collectDrives(ctx context.Context, ch chan<- prometheus.
 	for k, v := range counts {
 		ch <- prometheus.MustNewConstMetric(c.drivesCount, prometheus.GaugeValue, v,
 			c.site, k.state, k.driveType, k.robotType)
+	}
+}
+
+// collectPools paginates GET /storage/tape-volume-pools (API v12.0+) and emits
+// nbu_tape_pool_partially_full per (pool_name, pool_type). Absent on older
+// appliances; the fetch error is logged and skipped (graceful degradation).
+func (c *tapeCollector) collectPools(ctx context.Context, ch chan<- prometheus.Metric) {
+	offset := 0
+	for page := 0; page < maxMediaPages; page++ {
+		url := c.cfg.BuildURL(tapeVolumePoolPath, map[string]string{
+			QueryParamLimit:  pageLimit,
+			QueryParamOffset: strconv.Itoa(offset),
+		})
+		var resp models.TapeVolumePools
+		if err := c.client.FetchData(ctx, url, &resp); err != nil {
+			log.WithError(err).WithField("site", c.site).Warn("tape: tape-volume-pools fetch failed; skipping")
+			return
+		}
+		for _, p := range resp.Data {
+			a := p.Attributes
+			ch <- prometheus.MustNewConstMetric(c.poolPartial, prometheus.GaugeValue,
+				float64(a.PartiallyFullMedia), c.site, a.VolumePoolName, a.PoolType)
+		}
+		if resp.Meta.Pagination.Next == 0 || len(resp.Data) == 0 {
+			break
+		}
+		offset = resp.Meta.Pagination.Next
+		if ctx.Err() != nil {
+			break
+		}
+	}
+}
+
+// collectDiskPools paginates GET /storage/disk-pools (API v12.0+) and emits
+// nbu_disk_pool_volume_count per (pool_name, storage_category, volume state).
+// Absent on older appliances; the fetch error is logged and skipped.
+func (c *tapeCollector) collectDiskPools(ctx context.Context, ch chan<- prometheus.Metric) {
+	type key struct{ poolName, storageCategory, state string }
+	counts := map[key]float64{}
+	offset := 0
+	for page := 0; page < maxMediaPages; page++ {
+		url := c.cfg.BuildURL(diskPoolsPath, map[string]string{
+			QueryParamLimit:  pageLimit,
+			QueryParamOffset: strconv.Itoa(offset),
+		})
+		var resp models.DiskPools
+		if err := c.client.FetchData(ctx, url, &resp); err != nil {
+			log.WithError(err).WithField("site", c.site).Warn("tape: disk-pools fetch failed; skipping")
+			return
+		}
+		for _, pool := range resp.Data {
+			a := pool.Attributes
+			for _, vol := range a.DiskVolumes {
+				counts[key{a.Name, a.StorageCategory, vol.State}]++
+			}
+		}
+		if resp.Meta.Pagination.Next == 0 || len(resp.Data) == 0 {
+			break
+		}
+		offset = resp.Meta.Pagination.Next
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	for k, v := range counts {
+		ch <- prometheus.MustNewConstMetric(c.diskPoolVolumes, prometheus.GaugeValue, v,
+			c.site, k.poolName, k.storageCategory, k.state)
 	}
 }

--- a/internal/exporter/collector_tape.go
+++ b/internal/exporter/collector_tape.go
@@ -3,7 +3,6 @@ package exporter
 import (
 	"context"
 	"strconv"
-	"strings"
 
 	"github.com/fjacquet/nbu_exporter/internal/models"
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,18 +45,18 @@ func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *t
 		site:   site,
 		drivesCount: prometheus.NewDesc(
 			"nbu_tape_drives_count",
-			"Number of tape drives by status, drive type and robot type",
-			[]string{"site", "state", "drive_type", "robot_type"}, nil,
+			"Number of tape drives grouped by drive type, robot type and raw drive status",
+			[]string{"site", "drive_type", "robot_type", "status"}, nil,
 		),
 		driveInfo: prometheus.NewDesc(
 			"nbu_tape_drive_info",
 			"Tape drive info (always 1; metadata in labels)",
-			[]string{"site", "drive_name", "media_server", "drive_type", "robot_number", "state"}, nil,
+			[]string{"site", "drive_name", "media_server", "drive_type", "robot_number", "status"}, nil,
 		),
 		mediaCount: prometheus.NewDesc(
 			"nbu_tape_media_count",
-			"Number of tape volumes by media type and status",
-			[]string{"site", "media_type", "status"}, nil,
+			"Number of tape volumes grouped by volume pool, media type and robot type",
+			[]string{"site", "pool", "media_type", "robot_type"}, nil,
 		),
 		robotHostsCount: prometheus.NewDesc(
 			"nbu_tape_robot_device_hosts",
@@ -78,9 +77,6 @@ func newTapeCollector(client NetBackupClient, cfg models.Config, site string) *t
 }
 
 func (c *tapeCollector) Name() string { return "tape" }
-
-// driveState strips the DRIVE_STATUS_ prefix so the label reads UP/DOWN/MIXED/DISABLED.
-func driveState(s string) string { return strings.TrimPrefix(s, "DRIVE_STATUS_") }
 
 func (c *tapeCollector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	c.collectDrives(ctx, ch)
@@ -107,7 +103,7 @@ func (c *tapeCollector) collectRobotHosts(ctx context.Context, ch chan<- prometh
 }
 
 func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.Metric) {
-	type key struct{ mediaType, status string }
+	type key struct{ pool, mediaType, robotType string }
 	counts := map[key]float64{}
 	offset := 0
 	for page := 0; page < maxMediaPages; page++ {
@@ -126,7 +122,7 @@ func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.M
 			break
 		}
 		for _, d := range resp.Data {
-			counts[key{d.Attributes.MediaType, d.Attributes.MediaStatus}]++
+			counts[key{d.Attributes.VolumePool, d.Attributes.MediaType, d.Attributes.RobotType}]++
 		}
 		offset += len(resp.Data) // advance by rows returned; loop ends on the next empty page
 		if ctx.Err() != nil {
@@ -137,7 +133,7 @@ func (c *tapeCollector) collectMedia(ctx context.Context, ch chan<- prometheus.M
 		}
 	}
 	for k, v := range counts {
-		ch <- prometheus.MustNewConstMetric(c.mediaCount, prometheus.GaugeValue, v, c.site, k.mediaType, k.status)
+		ch <- prometheus.MustNewConstMetric(c.mediaCount, prometheus.GaugeValue, v, c.site, k.pool, k.mediaType, k.robotType)
 	}
 }
 
@@ -148,18 +144,17 @@ func (c *tapeCollector) collectDrives(ctx context.Context, ch chan<- prometheus.
 		log.WithError(err).WithField("site", c.site).Warn("tape: drives fetch failed; skipping")
 		return
 	}
-	type key struct{ state, driveType, robotType string }
+	type key struct{ driveType, robotType, status string }
 	counts := map[key]float64{}
 	for _, d := range resp.Data {
 		a := d.Attributes
-		state := driveState(a.DriveStatus)
-		counts[key{state, a.DriveType, a.RobotType}]++
+		counts[key{a.DriveType, a.RobotType, a.DriveStatus}]++
 		ch <- prometheus.MustNewConstMetric(c.driveInfo, prometheus.GaugeValue, 1,
-			c.site, a.DriveName, a.DeviceHost, a.DriveType, strconv.Itoa(a.RobotNumber), state)
+			c.site, a.DriveName, a.DeviceHost, a.DriveType, strconv.Itoa(a.RobotNumber), a.DriveStatus)
 	}
 	for k, v := range counts {
 		ch <- prometheus.MustNewConstMetric(c.drivesCount, prometheus.GaugeValue, v,
-			c.site, k.state, k.driveType, k.robotType)
+			c.site, k.driveType, k.robotType, k.status)
 	}
 }
 

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -78,7 +78,7 @@ func TestTapeCollector_Drives(t *testing.T) {
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
 
-	driveCounts := map[string]float64{} // "state|drive_type|robot_type" -> value
+	driveCounts := map[string]float64{} // "drive_type|robot_type|status" -> value
 	infoCount := 0
 	for m := range ch {
 		var d dto.Metric
@@ -87,15 +87,15 @@ func TestTapeCollector_Drives(t *testing.T) {
 		desc := m.Desc().String()
 		switch {
 		case strings.Contains(desc, "nbu_tape_drives_count"):
-			key := labelValue(&d, "state") + "|" + labelValue(&d, "drive_type") + "|" + labelValue(&d, "robot_type")
+			key := labelValue(&d, "drive_type") + "|" + labelValue(&d, "robot_type") + "|" + labelValue(&d, "status")
 			driveCounts[key] = d.GetGauge().GetValue()
 		case strings.Contains(desc, "nbu_tape_drive_info"):
 			require.Equal(t, float64(1), d.GetGauge().GetValue())
 			infoCount++
 		}
 	}
-	require.Equal(t, float64(2), driveCounts["UP|DT_HCART|TLD"])
-	require.Equal(t, float64(1), driveCounts["DOWN|DT_HCART|TLD"])
+	require.Equal(t, float64(2), driveCounts["DT_HCART|TLD|DRIVE_STATUS_UP"])
+	require.Equal(t, float64(1), driveCounts["DT_HCART|TLD|DRIVE_STATUS_DOWN"])
 	require.Equal(t, 3, infoCount, "one nbu_tape_drive_info per drive")
 }
 
@@ -120,17 +120,16 @@ func TestTapeCollector_MediaPaginated(t *testing.T) {
 	require.NoError(t, c.Collect(context.Background(), ch))
 	close(ch)
 
-	media := map[string]float64{} // "media_type|status" -> value
+	media := map[string]float64{} // "pool|media_type|robot_type" -> value
 	for m := range ch {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
 		if strings.Contains(m.Desc().String(), "nbu_tape_media_count") {
 			require.Equal(t, "site1", labelValue(&d, "site"))
-			media[labelValue(&d, "media_type")+"|"+labelValue(&d, "status")] = d.GetGauge().GetValue()
+			media[labelValue(&d, "pool")+"|"+labelValue(&d, "media_type")+"|"+labelValue(&d, "robot_type")] = d.GetGauge().GetValue()
 		}
 	}
-	require.Equal(t, float64(2), media["HCART|ACTIVE"], "both pages aggregated")
-	require.Equal(t, float64(1), media["HCART|FROZEN"])
+	require.Equal(t, float64(3), media["NetBackup|HCART|TLD"], "both pages aggregated by pool/media_type/robot_type")
 }
 
 func TestTapeCollector_RobotHostsAndRegistration(t *testing.T) {
@@ -219,10 +218,10 @@ func TestTapeCollector_MediaPartialOnError(t *testing.T) {
 		var d dto.Metric
 		require.NoError(t, m.Write(&d))
 		if strings.Contains(m.Desc().String(), "nbu_tape_media_count") {
-			media[labelValue(&d, "media_type")+"|"+labelValue(&d, "status")] = d.GetGauge().GetValue()
+			media[labelValue(&d, "pool")+"|"+labelValue(&d, "media_type")+"|"+labelValue(&d, "robot_type")] = d.GetGauge().GetValue()
 		}
 	}
-	require.Equal(t, float64(2), media["HCART|ACTIVE"], "page-1 counts emitted despite the page-2 error")
+	require.Equal(t, float64(2), media["NetBackup|HCART|TLD"], "page-1 counts emitted despite the page-2 error")
 }
 
 // TestTapeCollector_PoolsAndDiskPools verifies the two API v12.0+ endpoints:

--- a/internal/exporter/collector_tape_test.go
+++ b/internal/exporter/collector_tape_test.go
@@ -70,6 +70,8 @@ func TestTapeCollector_Drives(t *testing.T) {
 		"/storage/drives":              "../../testdata/api-versions/drives-response.json",
 		"/storage/tape-media":          "",
 		"/storage/robots-device-hosts": "",
+		"/storage/tape-volume-pools":   "",
+		"/storage/disk-pools":          "",
 	}}
 	c := newTapeCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 64)
@@ -103,6 +105,8 @@ func TestTapeCollector_MediaPaginated(t *testing.T) {
 		byPath: map[string]string{
 			"/storage/drives":              "",
 			"/storage/robots-device-hosts": "",
+			"/storage/tape-volume-pools":   "",
+			"/storage/disk-pools":          "",
 		},
 		byOffset: map[string]map[string]string{
 			"/storage/tape-media": {
@@ -134,6 +138,8 @@ func TestTapeCollector_RobotHostsAndRegistration(t *testing.T) {
 		"/storage/drives":              "",
 		"/storage/tape-media":          "",
 		"/storage/robots-device-hosts": "../../testdata/api-versions/robots-device-hosts-response.json",
+		"/storage/tape-volume-pools":   "",
+		"/storage/disk-pools":          "",
 	}}
 	c := newTapeCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 16)
@@ -161,6 +167,8 @@ func TestTapeCollector_GracefulDegradation(t *testing.T) {
 		"/storage/drives":              "",
 		"/storage/tape-media":          "",
 		"/storage/robots-device-hosts": "",
+		"/storage/tape-volume-pools":   "",
+		"/storage/disk-pools":          "",
 	}}
 	c := newTapeCollector(client, testConfig(), "site1")
 	ch := make(chan prometheus.Metric, 4)
@@ -191,6 +199,8 @@ func TestTapeCollector_MediaPartialOnError(t *testing.T) {
 		byPath: map[string]string{
 			"/storage/drives":              "",
 			"/storage/robots-device-hosts": "",
+			"/storage/tape-volume-pools":   "",
+			"/storage/disk-pools":          "",
 		},
 		byOffset: map[string]map[string]string{
 			"/storage/tape-media": {
@@ -213,4 +223,40 @@ func TestTapeCollector_MediaPartialOnError(t *testing.T) {
 		}
 	}
 	require.Equal(t, float64(2), media["HCART|ACTIVE"], "page-1 counts emitted despite the page-2 error")
+}
+
+// TestTapeCollector_PoolsAndDiskPools verifies the two API v12.0+ endpoints:
+// /storage/tape-volume-pools -> nbu_tape_pool_partially_full, and
+// /storage/disk-pools -> nbu_disk_pool_volume_count (counted by volume state).
+func TestTapeCollector_PoolsAndDiskPools(t *testing.T) {
+	client := &tapeRoutedClient{t: t, byPath: map[string]string{
+		"/storage/drives":              "",
+		"/storage/tape-media":          "",
+		"/storage/robots-device-hosts": "",
+		"/storage/tape-volume-pools":   "../../testdata/api-versions/tape-volume-pools-response.json",
+		"/storage/disk-pools":          "../../testdata/api-versions/disk-pools-response.json",
+	}}
+	c := newTapeCollector(client, testConfig(), "site1")
+	ch := make(chan prometheus.Metric, 64)
+	require.NoError(t, c.Collect(context.Background(), ch))
+	close(ch)
+
+	pools := map[string]float64{}    // "pool_name|pool_type" -> value
+	diskVols := map[string]float64{} // "pool_name|storage_category|state" -> value
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		require.Equal(t, "site1", labelValue(&d, "site"))
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "nbu_tape_pool_partially_full"):
+			pools[labelValue(&d, "pool_name")+"|"+labelValue(&d, "pool_type")] = d.GetGauge().GetValue()
+		case strings.Contains(desc, "nbu_disk_pool_volume_count"):
+			diskVols[labelValue(&d, "pool_name")+"|"+labelValue(&d, "storage_category")+"|"+labelValue(&d, "state")] = d.GetGauge().GetValue()
+		}
+	}
+	require.Equal(t, float64(3), pools["NetBackup|SCRATCH"], "partiallyFullMedia surfaced per pool")
+	require.Equal(t, float64(0), pools["CatalogBackup|NONE"])
+	require.Equal(t, float64(2), diskVols["dp1|MSDP|UP"], "disk volumes counted by state")
+	require.Equal(t, float64(1), diskVols["dp1|MSDP|DOWN"])
 }

--- a/internal/exporter/concurrent_test.go
+++ b/internal/exporter/concurrent_test.go
@@ -97,8 +97,8 @@ func TestCollectorConcurrentDescribe(t *testing.T) {
 			}
 
 			// Should always get the full descriptor set (8 core + 4 storage
-			// attribute + 5 extended job metrics).
-			const expectedDescriptors = 17
+			// attribute + 5 extended job metrics + 2 per-client lifecycle).
+			const expectedDescriptors = 19
 			if count != expectedDescriptors {
 				t.Errorf("Describe() returned %d descriptors, expected %d", count, expectedDescriptors)
 			}

--- a/internal/exporter/metrics.go
+++ b/internal/exporter/metrics.go
@@ -140,6 +140,26 @@ func (d *DurationAccum) Buckets() map[float64]uint64 {
 	return m
 }
 
+// ClientJobKey identifies per-client job counts by client, action and status
+// (the nbu_client_jobs_count metric).
+type ClientJobKey struct {
+	Client string // NetBackup client hostname
+	Action string // job action (BACKUP, DUPLICATION, IMPORT, …)
+	Status string // job status code as string ("0" == success)
+}
+
+// Labels returns the metric labels in descriptor order: [client, action, status].
+func (k ClientJobKey) Labels() []string { return []string{k.Client, k.Action, k.Status} }
+
+// ClientSuccessKey identifies a per-client/policy/action last-success timestamp
+// (the nbu_client_last_job_success_seconds metric), covering the full lifecycle
+// (BACKUP, DUPLICATION, IMPORT).
+type ClientSuccessKey struct {
+	Client string
+	Policy string
+	Action string
+}
+
 // JobAggregator accumulates every job-derived metric across paginated pages in a
 // single pass. A pointer is threaded through FetchJobDetails so each page folds
 // into the same maps. Keys are comparable structs for direct map lookups.
@@ -153,22 +173,56 @@ type JobAggregator struct {
 	DedupCount  map[JobPolicyKey]float64        // job count contributing to dedup mean
 	QueuedCount map[JobQueueKey]float64         // queued job count per action/reason
 	Duration    map[JobPolicyKey]*DurationAccum // completed-job duration histogram per action/policy
+
+	// Per-client lifecycle (opt-in). Populated only for allowlisted clients; both
+	// maps stay empty unless EnablePerClient has set a non-nil allowlist.
+	ClientCount       map[ClientJobKey]float64     // job count per client/action/status
+	ClientLastSuccess map[ClientSuccessKey]float64 // Unix ts of last status=0 job per client/policy/action
+	clientAllow       map[string]struct{}          // nil => per-client tracking off
 }
 
 // NewJobAggregator returns a JobAggregator with all maps initialized and capacity
 // hints applied to reduce reallocation during aggregation.
 func NewJobAggregator() *JobAggregator {
 	return &JobAggregator{
-		Size:        make(map[JobMetricKey]float64, expectedJobMetricKeys),
-		Count:       make(map[JobMetricKey]float64, expectedJobMetricKeys),
-		StatusCount: make(map[JobStatusKey]float64, expectedStatusMetricKeys),
-		StateCount:  make(map[JobStateKey]float64, expectedStatusMetricKeys),
-		FilesCount:  make(map[JobPolicyKey]float64, expectedJobMetricKeys),
-		DedupSum:    make(map[JobPolicyKey]float64, expectedJobMetricKeys),
-		DedupCount:  make(map[JobPolicyKey]float64, expectedJobMetricKeys),
-		QueuedCount: make(map[JobQueueKey]float64, expectedStatusMetricKeys),
-		Duration:    make(map[JobPolicyKey]*DurationAccum, expectedJobMetricKeys),
+		Size:              make(map[JobMetricKey]float64, expectedJobMetricKeys),
+		Count:             make(map[JobMetricKey]float64, expectedJobMetricKeys),
+		StatusCount:       make(map[JobStatusKey]float64, expectedStatusMetricKeys),
+		StateCount:        make(map[JobStateKey]float64, expectedStatusMetricKeys),
+		FilesCount:        make(map[JobPolicyKey]float64, expectedJobMetricKeys),
+		DedupSum:          make(map[JobPolicyKey]float64, expectedJobMetricKeys),
+		DedupCount:        make(map[JobPolicyKey]float64, expectedJobMetricKeys),
+		QueuedCount:       make(map[JobQueueKey]float64, expectedStatusMetricKeys),
+		Duration:          make(map[JobPolicyKey]*DurationAccum, expectedJobMetricKeys),
+		ClientCount:       make(map[ClientJobKey]float64),
+		ClientLastSuccess: make(map[ClientSuccessKey]float64),
 	}
+}
+
+// EnablePerClient turns on per-client lifecycle tracking for the allowlisted
+// clients. When enabled is false (the default) the aggregator records no per-client
+// series at all. An enabled-but-empty allowlist tracks nothing — matching the
+// opt-in collector's "empty allowlist emits nothing" contract.
+func (a *JobAggregator) EnablePerClient(enabled bool, allowlist []string) {
+	if !enabled {
+		a.clientAllow = nil
+		return
+	}
+	allow := make(map[string]struct{}, len(allowlist))
+	for _, c := range allowlist {
+		allow[c] = struct{}{}
+	}
+	a.clientAllow = allow
+}
+
+// trackClient reports whether the named client should be folded into the
+// per-client maps (per-client tracking on, and the client is allowlisted).
+func (a *JobAggregator) trackClient(name string) bool {
+	if a.clientAllow == nil {
+		return false
+	}
+	_, ok := a.clientAllow[name]
+	return ok
 }
 
 // observeDuration folds a completed job's duration into the histogram for its

--- a/internal/exporter/netbackup.go
+++ b/internal/exporter/netbackup.go
@@ -165,6 +165,19 @@ func aggregateJob(agg *JobAggregator, attr models.JobAttributes) {
 	if !attr.EndTime.IsZero() && attr.EndTime.After(attr.StartTime) {
 		agg.observeDuration(policyKey, attr.EndTime.Sub(attr.StartTime).Seconds())
 	}
+
+	// Per-client lifecycle (opt-in; only allowlisted clients are folded in, so the
+	// maps and the persistent last-success cache stay bounded by the allowlist).
+	if agg.trackClient(attr.ClientName) {
+		agg.ClientCount[ClientJobKey{Client: attr.ClientName, Action: attr.JobType, Status: status}]++
+		if attr.Status == 0 && !attr.EndTime.IsZero() {
+			csKey := ClientSuccessKey{Client: attr.ClientName, Policy: attr.PolicyName, Action: attr.JobType}
+			ts := float64(attr.EndTime.Unix())
+			if existing, ok := agg.ClientLastSuccess[csKey]; !ok || ts > existing {
+				agg.ClientLastSuccess[csKey] = ts
+			}
+		}
+	}
 }
 
 // FetchJobDetails retrieves a page of job records (up to 100) at the given cursor and
@@ -344,6 +357,9 @@ func FetchAllJobsFull(
 	// Single aggregator threaded through every page; comparable struct keys enable
 	// direct map lookups, and capacity hints reduce reallocation during processing.
 	agg := NewJobAggregator()
+	// Opt-in per-client lifecycle tracking, bounded by the allowlist (default off =>
+	// no per-client work). The per-client config is global across sites.
+	agg.EnablePerClient(client.cfg.Collectors.PerClient.Enabled, client.cfg.Collectors.PerClient.Allowlist)
 
 	// Track page count
 	pageCount := 0

--- a/internal/exporter/perclient_jobs_test.go
+++ b/internal/exporter/perclient_jobs_test.go
@@ -1,0 +1,86 @@
+package exporter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fjacquet/nbu_exporter/internal/models"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// collectPerClientLabels runs the job-aggregate emission for one site and returns
+// "<metric>|site|client|..." keys for the two per-client lifecycle metrics.
+func collectPerClientLabels(t *testing.T, c *NbuCollector, site string, agg *JobAggregator) []string {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	c.exposeJobAggregateMetrics(ch, site, agg)
+	close(ch)
+	var out []string
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		desc := m.Desc().String()
+		switch {
+		case strings.Contains(desc, "nbu_client_jobs_count"):
+			out = append(out, "nbu_client_jobs_count|"+labelValue(&d, "site")+"|"+labelValue(&d, "client")+"|"+labelValue(&d, "action")+"|"+labelValue(&d, "status"))
+		case strings.Contains(desc, "nbu_client_last_job_success_seconds"):
+			out = append(out, "nbu_client_last_job_success_seconds|"+labelValue(&d, "site")+"|"+labelValue(&d, "client")+"|"+labelValue(&d, "policy")+"|"+labelValue(&d, "action"))
+		}
+	}
+	return out
+}
+
+// TestExposePerClient_PerSiteCacheIsolation verifies the per-client metrics are
+// emitted with the correct site label, and that the persistent last-success cache
+// is keyed by site so one site's cached client never leaks under another site.
+func TestExposePerClient_PerSiteCacheIsolation(t *testing.T) {
+	cfg := testConfig()
+	cfg.Collectors.PerClient.Enabled = true
+	cfg.Collectors.PerClient.Allowlist = []string{"db01"}
+	c := newBaseCollector(cfg, nil)
+
+	aggA := NewJobAggregator()
+	aggA.EnablePerClient(true, []string{"db01"})
+	aggregateJob(aggA, models.JobAttributes{ClientName: "db01", JobType: "BACKUP", Status: 0, PolicyName: "P1", EndTime: time.Unix(1000, 0)})
+
+	gotA := collectPerClientLabels(t, c, "siteA", aggA)
+	require.Contains(t, gotA, "nbu_client_jobs_count|siteA|db01|BACKUP|0")
+	require.Contains(t, gotA, "nbu_client_last_job_success_seconds|siteA|db01|P1|BACKUP")
+
+	// Site B sees no jobs this cycle; site A's cached db01 must not emit under site B.
+	aggB := NewJobAggregator()
+	aggB.EnablePerClient(true, []string{"db01"})
+	gotB := collectPerClientLabels(t, c, "siteB", aggB)
+	for _, k := range gotB {
+		require.NotContains(t, k, "|siteB|db01|", "site A's cached client must not leak under site B")
+	}
+}
+
+// TestJobAggregator_PerClientGating verifies the per-client lifecycle maps are
+// populated only when the opt-in is enabled and only for allowlisted clients, so
+// cardinality (and the persistent last-success cache) stays bounded by the allowlist.
+func TestJobAggregator_PerClientGating(t *testing.T) {
+	// Disabled (default): no per-client tracking at all.
+	agg := NewJobAggregator()
+	require.False(t, agg.trackClient("db01"))
+	aggregateJob(agg, models.JobAttributes{ClientName: "db01", JobType: "BACKUP", Status: 0})
+	require.Empty(t, agg.ClientCount, "disabled per-client => no client series")
+	require.Empty(t, agg.ClientLastSuccess)
+
+	// Enabled with an allowlist: only allowlisted clients are folded in.
+	agg2 := NewJobAggregator()
+	agg2.EnablePerClient(true, []string{"db01"})
+	require.True(t, agg2.trackClient("db01"))
+	require.False(t, agg2.trackClient("app02"))
+
+	aggregateJob(agg2, models.JobAttributes{ClientName: "db01", JobType: "BACKUP", Status: 0, PolicyName: "P1", EndTime: time.Unix(1000, 0)})
+	aggregateJob(agg2, models.JobAttributes{ClientName: "app02", JobType: "BACKUP", Status: 0, PolicyName: "P1", EndTime: time.Unix(2000, 0)})
+
+	require.Equal(t, float64(1), agg2.ClientCount[ClientJobKey{Client: "db01", Action: "BACKUP", Status: "0"}])
+	_, hasApp := agg2.ClientCount[ClientJobKey{Client: "app02", Action: "BACKUP", Status: "0"}]
+	require.False(t, hasApp, "non-allowlisted client must not be folded in")
+	require.Equal(t, float64(1000), agg2.ClientLastSuccess[ClientSuccessKey{Client: "db01", Policy: "P1", Action: "BACKUP"}])
+}

--- a/internal/exporter/prometheus.go
+++ b/internal/exporter/prometheus.go
@@ -102,10 +102,28 @@ type NbuCollector struct {
 	nbuJobsQueuedCount *prometheus.Desc // Queued job count per action/reason
 	nbuJobDuration     *prometheus.Desc // Job duration histogram per action/policy
 
+	// Per-client lifecycle metrics (opt-in collectors.perClient + allowlist).
+	nbuClientJobsCount   *prometheus.Desc // Job count per site/client/action/status (current window)
+	nbuClientLastSuccess *prometheus.Desc // Unix ts of last successful job per site/client/policy/action
+	// Persistent last-success cache, keyed by site so a client's value survives scrape
+	// windows with no new jobs without leaking across sites. Bounded by the allowlist.
+	clientSuccessMu   sync.RWMutex
+	clientLastSuccess map[clientLastSuccessKey]float64
+
 	// Scrape time tracking
 	scrapeMu              sync.RWMutex // Protects lastStorageScrapeTime and lastJobsScrapeTime
 	lastStorageScrapeTime time.Time    // Last successful storage metric collection
 	lastJobsScrapeTime    time.Time    // Last successful jobs metric collection
+}
+
+// clientLastSuccessKey keys the persistent per-client last-success cache. It adds
+// the site dimension to ClientSuccessKey so cached values do not collide or leak
+// across NetBackup primaries in the multi-site model.
+type clientLastSuccessKey struct {
+	Site   string
+	Client string
+	Policy string
+	Action string
 }
 
 // withSite prepends the site label value to a slice of additional label values.
@@ -292,6 +310,17 @@ func newBaseCollector(cfg models.Config, tracing *TracerWrapper) *NbuCollector {
 			"Histogram of completed job durations in seconds",
 			[]string{"site", "action", "policy_type"}, nil,
 		),
+		nbuClientJobsCount: prometheus.NewDesc(
+			"nbu_client_jobs_count",
+			"Number of jobs per client, action and status in the scraping window (opt-in, allowlisted clients)",
+			[]string{"site", "client", "action", "status"}, nil,
+		),
+		nbuClientLastSuccess: prometheus.NewDesc(
+			"nbu_client_last_job_success_seconds",
+			"Unix timestamp of the last successful (status=0) job per client, policy and action (opt-in, allowlisted clients)",
+			[]string{"site", "client", "policy", "action"}, nil,
+		),
+		clientLastSuccess: make(map[clientLastSuccessKey]float64),
 	}
 }
 
@@ -321,6 +350,8 @@ func (c *NbuCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nbuJobsDedupRatio
 	ch <- c.nbuJobsQueuedCount
 	ch <- c.nbuJobDuration
+	ch <- c.nbuClientJobsCount
+	ch <- c.nbuClientLastSuccess
 }
 
 // createScrapeSpan creates a root span for the Prometheus scrape cycle.
@@ -703,6 +734,39 @@ func (c *NbuCollector) exposeJobAggregateMetrics(ch chan<- prometheus.Metric, si
 	for key, acc := range agg.Duration {
 		ch <- prometheus.MustNewConstHistogram(c.nbuJobDuration, acc.Count, acc.Sum, acc.Buckets(), withSite(site, key.Labels())...)
 	}
+
+	c.exposePerClientMetrics(ch, site, agg)
+}
+
+// exposePerClientMetrics emits the opt-in per-client lifecycle metrics for one site.
+// The aggregator only ever holds allowlisted clients (gated at the source), so the
+// emitted cardinality and the persistent last-success cache stay bounded by the
+// allowlist. The cache is keyed by site so a value survives scrape windows with no
+// new jobs without leaking across sites.
+func (c *NbuCollector) exposePerClientMetrics(ch chan<- prometheus.Metric, site string, agg *JobAggregator) {
+	for key, value := range agg.ClientCount {
+		ch <- prometheus.MustNewConstMetric(c.nbuClientJobsCount, prometheus.GaugeValue, value,
+			site, key.Client, key.Action, key.Status)
+	}
+
+	c.clientSuccessMu.Lock()
+	for key, ts := range agg.ClientLastSuccess {
+		ck := clientLastSuccessKey{Site: site, Client: key.Client, Policy: key.Policy, Action: key.Action}
+		if existing, ok := c.clientLastSuccess[ck]; !ok || ts > existing {
+			c.clientLastSuccess[ck] = ts
+		}
+	}
+	c.clientSuccessMu.Unlock()
+
+	c.clientSuccessMu.RLock()
+	for ck, ts := range c.clientLastSuccess {
+		if ck.Site != site {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(c.nbuClientLastSuccess, prometheus.GaugeValue, ts,
+			ck.Site, ck.Client, ck.Policy, ck.Action)
+	}
+	c.clientSuccessMu.RUnlock()
 }
 
 // exposeStorageMetrics sends storage metrics to the Prometheus channel.

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -360,6 +360,9 @@ func TestNbuCollectorDescribe(t *testing.T) {
 		"nbu_jobs_dedup_ratio",
 		"nbu_jobs_queued_count",
 		"nbu_job_duration_seconds",
+		// Per-client lifecycle metrics (opt-in)
+		"nbu_client_jobs_count",
+		"nbu_client_last_job_success_seconds",
 	}
 
 	descriptorNames := make(map[string]bool)

--- a/internal/models/Tape.go
+++ b/internal/models/Tape.go
@@ -20,6 +20,7 @@ type TapeMedia struct {
 		Attributes struct {
 			Barcode     string `json:"barcode"`
 			MediaType   string `json:"mediaType"`   // HCART, DLT, HC_CLN, ...
+			VolumePool  string `json:"volumePool"`  // e.g. "NetBackup", "Scratch"
 			MediaStatus string `json:"mediaStatus"` // free-form, e.g. "ACTIVE MULTIPLEXED"
 			RobotType   string `json:"robotType"`
 			RobotNumber int    `json:"robotNumber"`

--- a/internal/models/Tape.go
+++ b/internal/models/Tape.go
@@ -34,3 +34,45 @@ type RobotDeviceHosts struct {
 		ID string `json:"id"`
 	} `json:"data"`
 }
+
+// tapePagination is the cursor-style meta block on the v12.0+ tape/disk-pool
+// endpoints; a Next of 0 marks the last page.
+type tapePagination struct {
+	Pagination struct {
+		Next int `json:"next"`
+	} `json:"pagination"`
+}
+
+// TapeVolumePools is the response from GET /storage/tape-volume-pools (API v12.0+).
+type TapeVolumePools struct {
+	Data []struct {
+		Attributes struct {
+			VolumePoolName     string `json:"volumePoolName"`
+			Description        string `json:"description"`
+			PartiallyFullMedia int    `json:"partiallyFullMedia"`
+			PoolType           string `json:"poolType"`
+		} `json:"attributes"`
+	} `json:"data"`
+	Meta tapePagination `json:"meta"`
+}
+
+// DiskVolume is one volume entry nested inside a disk pool (API v12.0+).
+type DiskVolume struct {
+	Name  string `json:"name"`
+	ID    string `json:"id"`
+	State string `json:"state"` // UP / DOWN / UNKNOWN
+}
+
+// DiskPools is the response from GET /storage/disk-pools (API v12.0+).
+type DiskPools struct {
+	Data []struct {
+		Attributes struct {
+			Name            string       `json:"name"`
+			SType           string       `json:"sType"`
+			StorageCategory string       `json:"storageCategory"` // ADVANCED_DISK / CLOUD / MSDP / OPEN_STORAGE
+			DiskPoolState   string       `json:"diskPoolState"`   // UP / DOWN / TRANSIENT
+			DiskVolumes     []DiskVolume `json:"diskVolumes"`
+		} `json:"attributes"`
+	} `json:"data"`
+	Meta tapePagination `json:"meta"`
+}

--- a/testdata/api-versions/disk-pools-response.json
+++ b/testdata/api-versions/disk-pools-response.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "id": "dp1",
+      "type": "diskPool",
+      "attributes": {
+        "name": "dp1",
+        "sType": "PureDisk",
+        "storageCategory": "MSDP",
+        "diskPoolState": "UP",
+        "diskVolumes": [
+          { "name": "vol-a", "id": "a", "state": "UP" },
+          { "name": "vol-b", "id": "b", "state": "UP" },
+          { "name": "vol-c", "id": "c", "state": "DOWN" }
+        ]
+      }
+    }
+  ]
+}

--- a/testdata/api-versions/tape-media-page1.json
+++ b/testdata/api-versions/tape-media-page1.json
@@ -1,6 +1,6 @@
 {
   "data": [
-    {"attributes": {"barcode": "ABC001", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}},
-    {"attributes": {"barcode": "ABC002", "mediaType": "HCART", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}}
+    {"attributes": {"barcode": "ABC001", "mediaType": "HCART", "volumePool": "NetBackup", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}},
+    {"attributes": {"barcode": "ABC002", "mediaType": "HCART", "volumePool": "NetBackup", "mediaStatus": "ACTIVE", "robotType": "TLD", "robotNumber": 0}}
   ]
 }

--- a/testdata/api-versions/tape-media-page2.json
+++ b/testdata/api-versions/tape-media-page2.json
@@ -1,5 +1,5 @@
 {
   "data": [
-    {"attributes": {"barcode": "ABC003", "mediaType": "HCART", "mediaStatus": "FROZEN", "robotType": "TLD", "robotNumber": 0}}
+    {"attributes": {"barcode": "ABC003", "mediaType": "HCART", "volumePool": "NetBackup", "mediaStatus": "FROZEN", "robotType": "TLD", "robotNumber": 0}}
   ]
 }

--- a/testdata/api-versions/tape-volume-pools-response.json
+++ b/testdata/api-versions/tape-volume-pools-response.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "id": "0",
+      "type": "tapeVolumePool",
+      "attributes": {
+        "volumePoolName": "NetBackup",
+        "description": "default pool",
+        "partiallyFullMedia": 3,
+        "poolType": "SCRATCH"
+      }
+    },
+    {
+      "id": "1",
+      "type": "tapeVolumePool",
+      "attributes": {
+        "volumePoolName": "CatalogBackup",
+        "description": "catalog pool",
+        "partiallyFullMedia": 0,
+        "poolType": "NONE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands the **unique value of #39** (@cbijon) on top of the already-merged Features 2/3/4 and the multi-site dashboards (#43, now in `main`), as a clean superset — no duplicate collectors or metrics, no regression. Supersedes **#39**.

- **Tape collector superset**: adds `/storage/tape-volume-pools` → `nbu_tape_pool_partially_full` and `/storage/disk-pools` → `nbu_disk_pool_volume_count` (API v12.0+ / NBU 10.5+, graceful on older). Adopts #39's **richer tape label schema** (breaking vs the earlier *unreleased* tape collector): drives expose the raw `DRIVE_STATUS_*` `status`; media is keyed by `pool`/`media_type`/`robot_type`.
- **Per-client lifecycle** behind the existing `collectors.perClient` opt-in + allowlist: `nbu_client_jobs_count{client,action,status}` and `nbu_client_last_job_success_seconds{client,policy,action}` (BACKUP → DUPLICATION → IMPORT), derived from the main jobs scrape and allowlist-bounded. Fixes a latent multi-site cache-key bug in #39 (last-success cache now keyed by site).
- **Three dashboards** generated through #43's `site`-wired generator (no per-dashboard exemption): `nbu-lifecycle`, `nbu-tape`, `nbu-multisite`.
- **Alert rules**: `NbuTapePoolScratchLow`, `NbuDiskPoolVolumeDegraded`, `NbuClientNoRecentTapeCopy`, `NbuClientNoRecentReplication`, `NbuClientBackupFailureRate`, and `NbuInterSiteDivergence` (new `rules-multisite.yml`); dropped #39's `NbuClientNoRecentBackup` (dup of merged `NbuClientBackupStale`).
- **Docs/config**: metrics, dashboards, CHANGELOG, `config.yaml`, chart values, and demo-stack compose updated; corrected the stale tape-schema docs.

Credit to **@cbijon** for the original implementation in #39.

## Test Plan

- [x] `make ci` — fmt-check, vet, lint (0 issues), `test-race`, govulncheck (no vulns); total coverage 85.1% (≥70% gate)
- [x] `python3 -m grafana.build_dashboards` — all 7 dashboards pass `check_dashboard` + `check_site_wiring`; regen is deterministic
- [x] `make check-rules` — `promtool check` + unit tests green for all rule files (fire + silent cases per new alert)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional per-client backup lifecycle metrics and alerting (disabled by default with allowlist configuration).
  * Added optional tape collector with disk/volume pool metrics and related alerts (disabled by default).
  * Added inter-site backup divergence detection and alerting for multisite deployments.
  * Added three new Grafana dashboards: Backup Lifecycle, Tape & Disk Pools, and Multi-site Comparison.

* **Documentation**
  * Updated metrics documentation with tape and per-client collector details.
  * Updated Prometheus alerting rules documentation to reflect new multisite rules.
  * Expanded dashboard inventory documentation.

* **Configuration**
  * New `tape` and `perClient` collector toggles in configuration (disabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->