### PR TITLE
feat(deploy): full-stack deployment guide + wire all alert rules into the bundled stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Full-stack deployment guide** (`docs/deploy-stack.md`, thanks **@cbijon**): end-to-end
+  docker-compose walkthrough — API-key generation, single- and multi-site config, verification,
+  alerting, optional collectors, and production hardening. Linked from the README and the docs
+  "Deployment" nav. The README was also rewritten around the docker-compose stack as the
+  recommended path (feature list, inline config example, dashboards table).
+
+### Fixed
+
+- **Per-client, tape, and multi-site alerting rules are now actually loaded by the bundled
+  stack.** `rules-perclient.yml`, `rules-tape.yml`, and `rules-multisite.yml` shipped with unit
+  tests but were never wired into `prometheus.yml` (`rule_files:`) or mounted by `docker-compose`
+  — only `nbu.rules.yml` was. All four files are now mounted into `/etc/prometheus/rules/` and
+  listed under `rule_files:`, so their alerts evaluate out of the box.
+
 ## [4.0.0] - 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NBU Exporter - Prometheus Exporter for Veritas NetBackup
+# NBU Exporter — Prometheus Exporter for Veritas NetBackup
 
-A Prometheus exporter that collects backup job statistics and storage metrics from Veritas NetBackup REST API.
+A Prometheus exporter that collects backup job statistics, storage metrics, tape health, and per-client lifecycle data from the Veritas NetBackup REST API.
 
 [![CI](https://github.com/fjacquet/nbu_exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/nbu_exporter/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/fjacquet/nbu_exporter/actions/workflows/codeql.yml/badge.svg)](https://github.com/fjacquet/nbu_exporter/actions/workflows/codeql.yml)
@@ -12,86 +12,138 @@ A Prometheus exporter that collects backup job statistics and storage metrics fr
 
 ## Features
 
-- Job metrics collection by type, policy, and status
-- Storage unit capacity monitoring (free/used bytes)
-- Multi-site: scrape several NetBackup primaries from one exporter, labelled by `site`
-  (background snapshot collection loop; see [`config-multisite.yaml`](docs/config-examples/config-multisite.yaml))
-- Automatic NetBackup API version detection (14.0, 13.0, 12.0, 10.0)
-- Optional OpenTelemetry distributed tracing
-- Hot config reload via SIGHUP / file watcher
-- Health check endpoint
-- Docker support
+- **Job metrics** — count, volume, duration, dedup ratio, queued jobs; by action, policy type, and status
+- **Storage metrics** — free/used bytes per storage unit, capacity, concurrent job limits
+- **Tape & disk-pool metrics** — drive status per robot, media inventory per pool, disk pool volume states (NBU 10.5+, opt-in)
+- **Per-client lifecycle** — last successful job timestamp and job counts per client, for BACKUP / DUPLICATION / IMPORT phases (opt-in, allowlist or all clients)
+- **Multi-site** — scrape several NetBackup primaries from one exporter, every metric labelled by `site`
+- **Automatic API version detection** — probes 14.0 → 13.0 → 12.0 → 10.0 at startup; or pin explicitly
+- **7 Grafana dashboards** — Overview, Jobs, Storage, Data Protection, Tape & Disks, Lifecycle, Multi-site
+- **Prometheus alerting rules** — per-client compliance, tape health, inter-site divergence
+- **Hot config reload** via SIGHUP / fsnotify file watcher
+- **Optional OpenTelemetry** distributed tracing (OTLP gRPC)
+- **Health check** endpoint at `/health`
 
-## Quick Start
+## Full observability stack (recommended)
 
-On macOS, install via Homebrew:
+Deploy the exporter, Prometheus, and Grafana with one command:
 
 ```bash
-brew install fjacquet/tap/nbu_exporter
+git clone https://github.com/fjacquet/nbu_exporter.git
+cd nbu_exporter
+
+# Fill in your NBU master hostname and API key
+cp .env.example .env
+# Edit config.yaml with your nbuserver details (see Configuration below)
+
+docker compose up -d
 ```
 
-Or build from source (macOS/Linux):
+Then open:
+- **Grafana** — `http://localhost:3000` (admin / admin) → Dashboards → NetBackup
+- **Prometheus** — `http://localhost:9090`
+- **Metrics** — `http://localhost:9440/metrics`
 
-```bash
-make cli
+See [docs/deploy-stack.md](docs/deploy-stack.md) for the full step-by-step guide (API key generation, multi-site setup, alerting, production hardening).
+
+## Configuration
+
+```yaml
+# config.yaml — minimal single-site example
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    logName: "log/nbu-exporter.log"
+
+nbuserver:
+    scheme: "https"
+    uri: "/netbackup"
+    host: "nbu-master.my.domain"   # NBU primary server FQDN
+    port: "1556"
+    apiKey: "your-api-key-here"    # generated from NBU Admin Console → API Keys
+    insecureSkipVerify: false
+
+collectors:
+    tape:
+        enabled: true    # NBU 10.5+ required; set false if older
+    perClient:
+        enabled: false   # opt-in; set true to track per-client compliance
 ```
 
-Then configure and run:
+For multi-site, replace `nbuserver:` with an `nbuservers:` list — see [`docs/config-examples/config-multisite.yaml`](docs/config-examples/config-multisite.yaml).
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `NBU1_HOSTNAME` | NetBackup master hostname (single-site quickstart) |
+| `NBU1_APIKEY` | NetBackup API key |
+
+`config.yaml` supports `${VAR}` interpolation for secrets — never commit API keys.
+
+## Dashboards
+
+| Dashboard | What it shows |
+|---|---|
+| **Overview** | Site health tiles, backup success rate, storage usage, alert summary |
+| **Jobs** | Success rate, volume, duration p50/p95, dedup ratio, queued jobs |
+| **Storage** | Capacity gauges per storage unit |
+| **Data Protection** | Alerts, malware scans, catalog SLOs |
+| **Tape & Disks** | Drive status by robot, media inventory by pool, disk pool volumes |
+| **Lifecycle** | Per-client compliance timeline, BACKUP/DUPLICATION/IMPORT success rates, overdue clients |
+| **Multi-site** | Cross-site volume, replication rate, divergence ratio, per-site comparison |
+
+All dashboards have a `$site` variable to filter by site or view all at once.
+
+## Binary / CLI usage
 
 ```bash
-# Configure — supply credentials via environment variables (never commit secrets)
-cp .env.example .env        # fill in NBU1_HOSTNAME and NBU1_APIKEY
-cp config.yaml config.local.yaml  # optional: edit server settings
+# Build
+make cli                    # outputs bin/nbu_exporter
 
 # Run
-NBU1_HOSTNAME=nbu.example.com NBU1_APIKEY=mykey nbu_exporter --config config.yaml
-# or with a .env file sourced into your shell, simply:
-nbu_exporter --config config.yaml
+./bin/nbu_exporter --config config.yaml
+./bin/nbu_exporter --config config.yaml --debug   # verbose logging
+./bin/nbu_exporter --config config.yaml --trace   # log every API response body
+
+# macOS (Homebrew)
+brew install fjacquet/tap/nbu_exporter
 ```
-
-`host` and `apiKey` in `config.yaml` support `${VAR}` interpolation — see
-[Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) for details.
-
-Metrics are exposed at `http://localhost:9440/metrics`.
-
-### Environment Variables / .env
-
-| Variable | Description | Default in compose |
-|----------|-------------|-------------------|
-| `NBU1_HOSTNAME` | NetBackup master server hostname | `master.my.domain` |
-| `NBU1_APIKEY` | NetBackup API key | _(empty)_ |
-
-`NBU1_*` is a single-server quickstart convenience — `config.yaml` is always the source of truth.
-For multiple servers add more entries directly in `config.yaml` (literal values or additional env refs).
-
-## Documentation
-
-Full documentation is available at **[fjacquet.github.io/nbu_exporter](https://fjacquet.github.io/nbu_exporter/)**.
-
-| Topic | Link |
-|-------|------|
-| Installation | [Getting Started](https://fjacquet.github.io/nbu_exporter/getting-started/installation/) |
-| Configuration | [Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) |
-| Metrics Reference | [Metrics](https://fjacquet.github.io/nbu_exporter/metrics/) |
-| Docker Deployment | [Docker](https://fjacquet.github.io/nbu_exporter/docker/) |
-| OpenTelemetry | [Tracing Setup](https://fjacquet.github.io/nbu_exporter/opentelemetry-example/) |
-| Migration Guides | [NetBackup 11.0](https://fjacquet.github.io/nbu_exporter/netbackup-11-migration/) |
-| Changelog | [Changelog](https://fjacquet.github.io/nbu_exporter/changelog/) |
 
 ## Development
 
 ```bash
-make sure          # fmt, test, build, lint
-make test          # run tests
+make tools         # install golangci-lint, govulncheck, cyclonedx-gomod (one-time)
+make sure          # fmt + vet + test + build + lint
+make ci            # full CI gate (fmt-check, vet, lint, test-race, govulncheck, coverage)
 make test-coverage # tests with HTML coverage report
 make docker        # build Docker image
+
+# Regenerate Grafana dashboard JSONs after editing grafana/gen/*.py
+PYTHONPATH=. python3 grafana/build_dashboards.py
 ```
+
+## Documentation
+
+Full docs at **[fjacquet.github.io/nbu_exporter](https://fjacquet.github.io/nbu_exporter/)**.
+
+| Topic | Link |
+|---|---|
+| **Full stack deployment** | [docs/deploy-stack.md](docs/deploy-stack.md) |
+| Installation | [Getting Started](https://fjacquet.github.io/nbu_exporter/getting-started/installation/) |
+| Configuration | [Configuration Guide](https://fjacquet.github.io/nbu_exporter/getting-started/configuration/) |
+| Metrics reference | [Metrics](https://fjacquet.github.io/nbu_exporter/metrics/) |
+| Docker | [Docker](https://fjacquet.github.io/nbu_exporter/docker/) |
+| OpenTelemetry | [Tracing Setup](https://fjacquet.github.io/nbu_exporter/opentelemetry-example/) |
+| Changelog | [Changelog](https://fjacquet.github.io/nbu_exporter/changelog/) |
 
 ## Contributing
 
 1. Fork the repository
 2. Create a feature branch
-3. Run `make sure` before submitting
+3. Run `make ci` before submitting
 4. Submit a pull request
 
 ## License

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Deploy the exporter, Prometheus, and Grafana with one command:
 git clone https://github.com/fjacquet/nbu_exporter.git
 cd nbu_exporter
 
-# Fill in your NBU master hostname and API key
+# Set your NBU master hostname + API key in .env — the bundled config.yaml
+# reads them via ${NBU1_HOSTNAME} / ${NBU1_APIKEY} (no need to edit config.yaml
+# for a basic single-site setup; see Configuration below to customise).
 cp .env.example .env
-# Edit config.yaml with your nbuserver details (see Configuration below)
+$EDITOR .env
 
 docker compose up -d
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./deploy/prometheus/nbu.rules.yml:/etc/prometheus/rules/nbu.rules.yml:ro
+      - ./deploy/prometheus/rules-perclient.yml:/etc/prometheus/rules/rules-perclient.yml:ro
+      - ./deploy/prometheus/rules-tape.yml:/etc/prometheus/rules/rules-tape.yml:ro
+      - ./deploy/prometheus/rules-multisite.yml:/etc/prometheus/rules/rules-multisite.yml:ro
       - prometheus-data:/prometheus
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"

--- a/docs/deploy-stack.md
+++ b/docs/deploy-stack.md
@@ -1,0 +1,277 @@
+# Deploying the full monitoring stack
+
+This guide deploys nbu_exporter, Prometheus, and Grafana as a single docker-compose stack with all dashboards and alerting rules pre-wired.
+
+**Result:** 7 Grafana dashboards (Overview, Jobs, Storage, Data Protection, Tape, Lifecycle, Multi-site) + Prometheus alerting rules, all running in 3 containers.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| NetBackup version | 10.0 or later (10.5+ for tape/disk metrics) |
+| NetBackup API key | Generated from NBU Admin Console → API Keys |
+| Network access | Exporter host → NBU master on port 1556 |
+| Docker + Compose | v2.x (`docker compose version`) |
+
+---
+
+## 1. Get the repo
+
+```bash
+git clone https://github.com/fjacquet/nbu_exporter.git
+cd nbu_exporter
+```
+
+---
+
+## 2. Generate a NetBackup API key
+
+In the NetBackup Admin Console or web UI: **Security → API Keys → Add**.
+
+The key needs read access to: jobs, storage, catalog, alerts.
+
+---
+
+## 3. Configure
+
+### Single site
+
+```bash
+cp docs/config-examples/config-auto-detect.yaml config.yaml
+```
+
+Edit `config.yaml` and set your values:
+
+```yaml
+server:
+    host: "0.0.0.0"
+    port: "9440"
+    uri: "/metrics"
+    scrapingInterval: "1h"
+    logName: "log/nbu-exporter.log"
+
+nbuserver:
+    scheme: "https"
+    uri: "/netbackup"
+    host: "nbu-master.my.domain"   # ← NBU master FQDN
+    port: "1556"
+    apiKey: "your-api-key-here"    # ← generated above
+    insecureSkipVerify: false
+
+collectors:
+    tape:
+        enabled: true    # requires NBU 10.5+; set false if older
+    perClient:
+        enabled: false   # opt-in: see "Optional collectors" below
+```
+
+### Two sites (multi-site)
+
+```bash
+cp docs/config-examples/config-multisite.yaml config.yaml
+```
+
+Edit to replace the two `host` / `apiKey` / `site` placeholders. Each `site` value becomes a label on every metric — keep it short (e.g. `paris`, `lyon`).
+
+---
+
+## 4. Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts:
+- **nbu_exporter** on port 9440
+- **Prometheus** on port 9090
+- **Grafana** on port 3000 (login: `admin` / `admin`)
+
+---
+
+## 5. Verify
+
+```bash
+# Exporter health
+curl http://localhost:9440/health
+
+# Metrics endpoint (should list ~20+ nbu_* metrics)
+curl -s http://localhost:9440/metrics | grep "^nbu_" | cut -d'{' -f1 | sort -u
+
+# Prometheus scraping (should return "1")
+curl -s 'http://localhost:9090/api/v1/query?query=up{job="netbackup"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['result'][0]['value'][1])"
+```
+
+Open Grafana at `http://localhost:3000` → Dashboards → Browse → **NetBackup** folder.
+
+---
+
+## 6. Alerting rules
+
+Prometheus loads four rule files automatically (mounted into `/etc/prometheus/rules/`
+by docker-compose and listed under `rule_files:` in `prometheus.yml`):
+
+| File | Alerts |
+|---|---|
+| `deploy/prometheus/nbu.rules.yml` | Core: exporter down, scrape failures, metrics stale, storage full |
+| `deploy/prometheus/rules-perclient.yml` | Per-client compliance: backup staleness, tape-copy / replication freshness, failure rate |
+| `deploy/prometheus/rules-tape.yml` | Tape & disk health: drive down/disabled, scratch-pool low, disk-pool volume degraded |
+| `deploy/prometheus/rules-multisite.yml` | Inter-site backup-volume divergence |
+
+The per-client, tape, and multi-site rules reference the opt-in `nbu_client_*` and
+`nbu_tape_*` / `nbu_disk_pool_*` metrics — enable the matching collectors (see §7) for
+them to fire.
+
+To send alerts, add an Alertmanager config to `prometheus.yml`:
+
+```yaml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+```
+
+Key alerts:
+
+| Alert | Default threshold | Severity |
+|---|---|---|
+| `NbuClientBackupStale` | 25 h without successful backup | warning |
+| `NbuClientBackupCritical` | 48 h without successful backup | critical |
+| `NbuClientNoRecentTapeCopy` | 26 h without DUPLICATION | warning |
+| `NbuClientNoRecentReplication` | 28 h without IMPORT | warning |
+| `NbuTapeDriveDown` | ≥1 drive DOWN for 15 min | warning |
+| `NbuTapeDriveDisabled` | ≥1 drive DISABLED for 30 min | warning |
+| `NbuTapePoolScratchLow` | Scratch pool < 5 volumes | warning |
+| `NbuDiskPoolVolumeDegraded` | disk-pool volume not UP for 10 min | warning |
+| `NbuInterSiteDivergence` | Site < 30 % of cross-site average | warning |
+
+---
+
+## 7. Optional collectors
+
+### Tape metrics (NBU 10.5+)
+
+Enabled by default in the example config above. Adds:
+- `nbu_tape_drives_count` — drive status per robot
+- `nbu_tape_media_count` — media inventory per pool
+- `nbu_disk_pool_volume_count` — disk pool volume states
+
+### Per-client lifecycle metrics
+
+Enable to track per-client compliance (required for the Lifecycle and Multi-site dashboards to show per-client rows):
+
+```yaml
+collectors:
+  perClient:
+    enabled: true
+    allowlist:         # leave empty to collect all clients
+      - srv-db-01
+      - srv-app-01
+```
+
+Adds:
+- `nbu_client_jobs_count{site, client, action, status}` — job counts per client
+- `nbu_client_last_job_success_seconds{site, client, policy, action}` — timestamp of last success
+
+---
+
+## 8. Dashboards
+
+| Dashboard | What it shows |
+|---|---|
+| **Overview** | Health tiles per site, backup success rate, storage usage, alert summary |
+| **Jobs** | Success rate, volume, duration p50/p95, dedup ratio, queued jobs |
+| **Storage** | Capacity gauges per storage unit, used vs total |
+| **Data Protection** | Alerts by severity, malware scans, catalog SLOs |
+| **Tape & Disks** | Drive status, media inventory, pool levels, disk pool volumes |
+| **Lifecycle** | Per-client compliance history (state timeline), BACKUP / DUPLICATION / IMPORT success rates, overdue clients |
+| **Multi-site** | Cross-site backup volume, replication rate, divergence ratio, per-site comparison |
+
+All dashboards have a `$site` variable (top left) to filter by site or show all at once.
+
+---
+
+## 9. Multi-site Prometheus setup
+
+For two separate exporter instances (one per site), use a single Prometheus with two scrape targets:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'netbackup'
+    scrape_interval: 60s
+    scrape_timeout: 30s
+    static_configs:
+      - targets:
+          - 'nbu-exporter-paris:9440'
+          - 'nbu-exporter-lyon:9440'
+```
+
+Each exporter tags its metrics with `site` from its config. Prometheus aggregates them; Grafana filters with `$site`.
+
+---
+
+## 10. Production hardening
+
+```yaml
+# config.yaml — recommended for production
+nbuserver:
+    insecureSkipVerify: false   # always validate NBU TLS certificate
+```
+
+```bash
+# Change Grafana default password immediately
+GF_ADMIN_PASSWORD=<strong-password> docker compose up -d
+```
+
+Consider:
+- Running the stack behind a reverse proxy (nginx/Traefik) with TLS termination
+- Storing the NBU API key in a secrets manager and injecting via env var
+- Persisting Prometheus data with a named volume (already configured in docker-compose.yml)
+- Setting `collectionInterval: "5m"` (default) and `scrapingInterval: "1h"` — don't scrape more often than NBU's job window
+
+---
+
+## Troubleshooting
+
+### Exporter starts but no `nbu_*` metrics
+
+```bash
+docker compose logs nbu_exporter | grep -E "ERROR|version"
+```
+
+Common causes:
+- Wrong API key → regenerate in NBU UI
+- NBU API not reachable → check firewall on port 1556
+- `insecureSkipVerify: false` with self-signed cert → add CA or set to `true` temporarily to diagnose
+
+### Tape metrics missing
+
+```bash
+curl -s http://localhost:9440/metrics | grep nbu_tape
+```
+
+Empty → NBU version < 10.5, or `collectors.tape.enabled: false` in config.
+
+### Grafana dashboards empty
+
+1. Check Prometheus is scraping: `http://localhost:9090/targets`
+2. Check the datasource in Grafana: Settings → Data Sources → Prometheus → Test
+3. Query `nbu_up` in Explore — if no data, scraping isn't working
+
+### Check-rules (optional)
+
+```bash
+# Validate alerting rules syntax (requires promtool in PATH)
+make check-rules
+```
+
+---
+
+## Related docs
+
+- [Configuration reference](getting-started/configuration.md)
+- [All metrics](metrics.md)
+- [Docker usage](docker.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - NetBackup 11.0: netbackup-11-migration.md
       - API 10.5: api-10.5-migration.md
   - Deployment:
+      - Full Stack (docker-compose): deploy-stack.md
       - Verification: deployment-verification.md
       - Quick Reference: deployment-quick-reference.md
       - Docker: docker.md

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -7,6 +7,9 @@ global:
 
 rule_files:
   - /etc/prometheus/rules/nbu.rules.yml
+  - /etc/prometheus/rules/rules-perclient.yml
+  - /etc/prometheus/rules/rules-tape.yml
+  - /etc/prometheus/rules/rules-multisite.yml
 
 scrape_configs:
   # NBU Exporter metrics


### PR DESCRIPTION
Salvages the unique, post-#44 work from **PR #39** (by @cbijon) and drops the parts that duplicated what already landed on `main` via #44. Closes out #39.

## What's here

### Docs (from @cbijon, fork URLs corrected → upstream)
- **`docs/deploy-stack.md`** — end-to-end docker-compose deployment guide: API-key generation, single/multi-site config, verification, alerting, optional collectors, production hardening. Added to the docs **Deployment** nav.
- **`README.md`** — rewritten around the docker-compose stack as the recommended path (feature list, inline config example, dashboards table). Homebrew/CLI usage retained.

### Fix — alerting rules now actually load
`rules-perclient.yml` / `rules-tape.yml` / `rules-multisite.yml` shipped with unit tests (#42/#44) but were **never wired into the bundled stack** — `prometheus.yml` `rule_files:` and the `docker-compose` Prometheus mount referenced only `nbu.rules.yml`. All four files are now mounted into `/etc/prometheus/rules/` and listed under `rule_files:`, so their alerts evaluate out of the box (**17 rules total**).

## Dropped from #39
`deploy/prometheus/nbu-lifecycle.rules.yml` — it re-defined alerts already split across `rules-{perclient,tape,multisite}.yml` on `main` and re-introduced `NbuClientNoRecentBackup`, the duplicate #44 deliberately dropped in favour of `NbuClientBackupStale`. The deploy-stack §6 alert table was corrected to `main`'s actual alert names/thresholds.

## Verification
- `make check-rules` — rules valid + unit tests pass
- `promtool check config` on the staged container rule layout — 4 files / 17 rules load
- `docker compose config` — valid, 3 new split-file mounts present
- `mkdocs build --strict` — passes (deploy-stack.md in nav, no broken links)
- No Go changes → Go CI gate unaffected

Credit to **@cbijon** (co-author on the commit). Once this merges, **#39 can be closed as superseded**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus alerting rules now properly mounted and evaluated out of the box.

* **Documentation**
  * Added comprehensive full-stack deployment guide with Docker Compose walkthrough, including API-key generation, configuration, verification, and hardening steps.
  * Expanded README with detailed configuration examples, Grafana dashboards table, and operational usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->