### PR TITLE
ci: make `security` advisory (match central default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ sbom:
 	@mkdir -p $(DIST)
 	go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest mod -json -output $(DIST)/sbom.cdx.json
 
-security:
-	uvx semgrep scan --config auto --error --skip-unknown-extensions
+security:  # advisory: reports findings but never blocks the build (CodeQL/osv are the blocking gates)
+	uvx semgrep scan --config auto --skip-unknown-extensions || true
 
 docs:
 	uvx --with mkdocs-material --with pymdown-extensions mkdocs build --strict --site-dir site


### PR DESCRIPTION
Make the `make security` target advisory instead of blocking.

The `security:` target previously ran semgrep with `--error`, blocking the build on findings. CodeQL and osv are the actual blocking security gates; semgrep here is now advisory (reports findings but never blocks).

```
security:  # advisory: reports findings but never blocks the build (CodeQL/osv are the blocking gates)
	uvx semgrep scan --config auto --skip-unknown-extensions || true
```

Verified `make security` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H28tbCKQauHg4pX5ebCXi