### PR TITLE
chore: fleet health refresh

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,3 +64,6 @@ nav:
       - Overview: adr/README.md
       - ADR-0001 Tooling Baseline Sync: adr/0001-tooling-baseline-sync-with-pflex.md
   - Changelog: changelog.md
+
+extra:
+  version: v4.0.1


### PR DESCRIPTION
Fleet health audit + refresh (docs-only).

- mkdocs — refreshed: canonical repo_url/repo_name + mkdocs-material `extra.version` = v4.0.1
- Release warranted (mechanism + unreleased commits) → proposed patch **v4.0.1**.

No application-code changes.