### PR TITLE
fix(release): correct homebrew cask token env var

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,7 +128,8 @@ homebrew_casks:
     repository:
       owner: fjacquet
       name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    skip_upload: '{{ if .Env.HOMEBREW_TAP_GITHUB_TOKEN }}false{{ else }}true{{ end }}'
     directory: Casks
     binaries:
       - nbu_exporter


### PR DESCRIPTION
The v4.0.1 release failed at the homebrew cask step: `map has no entry for key "TAP_GITHUB_TOKEN"`. The cask used the wrong env var (`TAP_GITHUB_TOKEN` vs the pipeline's `HOMEBREW_TAP_GITHUB_TOKEN`) and had no `skip_upload` guard. Fixed both; goreleaser check passes.