### PR TITLE
docs: document special characters in the API key value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,13 @@ NBU_TAG=latest
 # config.yaml references it as ${NBU1_HOSTNAME}.
 NBU1_HOSTNAME=master.my.domain
 
-# NetBackup API key for authentication.
-# config.yaml references it as ${NBU1_APIKEY}.
+# NetBackup API key for authentication. config.yaml references it as ${NBU1_APIKEY}.
+# Special characters: wrap the value in single quotes so it is taken literally, e.g.
+# NBU1_APIKEY='ak_v@lue!#{}'. Double quotes expand $VAR and process backslashes;
+# unquoted values treat " #" (space-hash) as a comment. For a literal ' use double
+# quotes ("ak'ey"); for a " use single quotes ('ak"ey'). NetBackup API keys are token
+# strings (dot-separated base64url segments) that contain none of these, so an
+# unquoted value like the placeholder below is normally fine.
 NBU1_APIKEY=changeme
 
 # Grafana admin login.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -116,6 +116,27 @@ nbuservers:
 
 The `.env` / `NBU1_*` naming is a single-server convenience; there is no limit on variable names.
 
+### API keys with special characters
+
+The API key is sent verbatim as the value of the HTTP `Authorization` header — it is
+never URL-encoded and never placed in a request body, so any character is safe end to
+end. The only place quoting matters is **parsing at load time**, and it differs by where
+you put the key:
+
+| Source | Rule |
+|---|---|
+| `.env`, single-quoted `'…'` | Fully literal — no `$` expansion, no `\` escapes, no `#` comment. Best default. Cannot contain a literal `'`. |
+| `.env`, double-quoted `"…"` | Expands `$VAR`/`${VAR}` and processes `\` escapes. `$`, `\`, `"` are special — write `\$`, `\\`, `\"`. |
+| `.env`, unquoted | `$VAR` expands; a ` #` (space-hash) starts a comment; a value **starting** with `'`/`"` is treated as quoted. |
+| `config.yaml` inline | Only the exact `${NAME}` token is interpolated (`os.LookupEnv`), so a literal key containing `${NAME}` is treated as an env ref. Prefer referencing an env var. |
+
+For quotes inside the key specifically: use double quotes to include a `'`, single
+quotes to include a `"`. NetBackup API keys are token strings (dot-separated,
+base64url-style segments), so in practice they contain none of these characters and an
+unquoted value works fine. When referencing an env var from `config.yaml`
+(`apiKey: "${NBU1_APIKEY}"`) the value is inserted verbatim and never re-scanned, so the
+env var itself may contain `$`, `${…}`, or any character.
+
 ## Server Section
 
 | Field | Type | Required | Description |


### PR DESCRIPTION
## Summary

Credential special-character documentation for nbu_exporter. Explains exactly how special characters behave in the API key across every input method, so a value with `$`, `#`, `{}`, quotes, etc. is not silently corrupted at load time.

- `.env.example` — comment block above `NBU1_APIKEY` recommending single quotes for literal values, with quote-inside-value guidance.
- `docs/getting-started/configuration.md` — new "API keys with special characters" subsection with a source-by-source parsing table (`.env` quoting rules, inline `${ENV}` interpolation).

Behaviour is unchanged — **documentation only**. `mkdocs build --strict` passes.

## Commits on this branch

- docs: document special characters in the API key value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NZrdJQcpUxy6DnvifWFLY
