### PR TITLE
docs: add systemd deployment (unit + env + guide)

### DIFF
--- a/deploy/nbu_exporter.env.example
+++ b/deploy/nbu_exporter.env.example
@@ -1,0 +1,7 @@
+# EnvironmentFile for the nbu_exporter systemd unit.
+# Supplies master-server API keys referenced as ${VAR} in config.yaml.
+#
+# Install:  /etc/nbu_exporter/nbu_exporter.env   (chmod 0600, chown root:nbu)
+
+NBU1_APIKEY=change-me
+# NBU2_APIKEY=change-me

--- a/deploy/nbu_exporter.service
+++ b/deploy/nbu_exporter.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=Veritas NetBackup Exporter (Prometheus + OTLP)
+Documentation=https://github.com/fjacquet/nbu_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=nbu
+Group=nbu
+
+# Master-server API keys referenced as ${NBU1_APIKEY} etc. in config.yaml.
+# Keep this file mode 0600, owned root:nbu.
+EnvironmentFile=/etc/nbu_exporter/nbu_exporter.env
+
+ExecStart=/usr/local/bin/nbu_exporter --config /etc/nbu_exporter/config.yaml
+# `systemctl reload nbu_exporter` performs a live config reload (SIGHUP).
+ExecReload=/bin/kill -HUP $MAINPID
+
+Restart=on-failure
+RestartSec=5
+
+# Log to the journal (set `logName: ""` in config.yaml). View with:
+#   journalctl -u nbu_exporter -f
+StandardOutput=journal
+StandardError=journal
+
+# --- Hardening (works with the journald logging above; no writable paths needed) ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,0 +1,53 @@
+# systemd (EL9 host)
+
+Docker is **not** required — the exporter is a single static (`CGO_ENABLED=0`) binary. For a
+non-container deployment on Enterprise Linux 9, use the unit shipped in `deploy/`.
+
+## Install
+
+```bash
+# user + binary
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin nbu
+sudo install -m 0755 bin/nbu_exporter /usr/local/bin/nbu_exporter
+
+# config + secrets
+sudo install -d -o root -g nbu -m 0750 /etc/nbu_exporter
+sudo install -m 0640 -o root -g nbu config.yaml /etc/nbu_exporter/config.yaml
+sudo install -m 0600 -o root -g nbu deploy/nbu_exporter.env.example /etc/nbu_exporter/nbu_exporter.env
+# edit /etc/nbu_exporter/nbu_exporter.env to set NBU1_APIKEY=...
+
+# service
+sudo install -m 0644 deploy/nbu_exporter.service /etc/systemd/system/nbu_exporter.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now nbu_exporter
+```
+
+Set `logName: ""` in `config.yaml` so logs go to the journal.
+
+## Operate
+
+```bash
+journalctl -u nbu_exporter -f         # follow logs
+sudo systemctl reload nbu_exporter    # live config reload (sends SIGHUP)
+sudo systemctl status nbu_exporter
+```
+
+## Hardening
+
+The unit runs as the unprivileged `nbu` user inside a sandbox:
+
+- `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true`
+- `PrivateTmp`, `PrivateDevices`, `ProtectKernel*`, `ProtectControlGroups`
+- `RestrictAddressFamilies=AF_INET AF_INET6`, `RestrictNamespaces`, `LockPersonality`
+- `Restart=on-failure`
+
+Secrets are supplied through the `EnvironmentFile` and referenced as `${NBU1_APIKEY}`
+in `config.yaml`. Keep that file mode `0600`.
+
+## macOS (launchd / Homebrew)
+
+On macOS run it under **launchd** (the systemd equivalent). `brew services` is not wired up:
+the Homebrew cask only installs the binary on your PATH — it defines no service block — so
+register a `launchd` job yourself, e.g. `~/Library/LaunchAgents/com.fjacquet.nbu_exporter.plist`
+with `ProgramArguments` `[/opt/homebrew/bin/nbu_exporter, --config, <path>/config.yaml]` and
+`RunAtLoad`/`KeepAlive` set, then `launchctl load` it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Verification: deployment-verification.md
       - Quick Reference: deployment-quick-reference.md
       - Docker: docker.md
+      - systemd: systemd.md
       - Dashboards: dashboards.md
   - Configuration Examples: config-examples/README.md
   - Architecture Decisions:


### PR DESCRIPTION
## What

First-class non-container deployment path alongside Docker:

- `deploy/nbu_exporter.service` — sandboxed systemd unit: dedicated `nbu` user, `EnvironmentFile` secrets, **SIGHUP live reload** via `ExecReload`, full hardening block (`ProtectSystem=strict`, `PrivateTmp/Devices`, `RestrictAddressFamilies`, …), journal logging.
- `deploy/nbu_exporter.env.example` — `0600` secret template.
- `docs/systemd.md` — install / operate / harden guide, incl. a **macOS launchd** note (`brew services` isn't wired up — the cask only drops the binary).
- mkdocs nav entry.

## Why

The binary is static (`CGO_ENABLED=0`), so Docker was never required. This documents the systemd path already shipped by `pflex`/`pscale`/`pstore`, bringing nbu to family parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117RjshAGPse5mfktTjDJLK