### PR TITLE
feat: expose nbu_exporter_build_info metric on /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`nbu_exporter_build_info` metric**: a constant `1` gauge carrying the running
+  exporter `version` and `goversion` labels, so a `/metrics` scrape reveals exactly which
+  build is deployed. The version comes from `-ldflags "-X main.version=..."` (GoReleaser
+  injects the release tag; the Makefile injects `git describe`; local `go build` reports
+  `dev`). Unlike the per-site collectors, this metric carries no `site` label — it describes
+  the exporter process itself.
 - **Full-stack deployment guide** (`docs/deploy-stack.md`, thanks **@cbijon**): end-to-end
   docker-compose walkthrough — API-key generation, single- and multi-site config, verification,
   alerting, optional collectors, and production hardening. Linked from the README and the docs

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CLI_BIN = nbu_exporter
 DIST    ?= dist
 COVER   ?= coverage.out
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS = -s -w
+LDFLAGS = -s -w -X main.version=$(VERSION)
 
 # Pinned tool versions (installed by `make tools`).
 GOLANGCI_VERSION    ?= v2.12.2

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -135,6 +135,7 @@ collectors:
 | `nbu_api_version` | `version` | Currently active NetBackup API version (14.0, 13.0, 12.0, or 10.0) |
 | `nbu_response_time_ms` | — | NetBackup API response time in milliseconds |
 | `nbu_last_scrape_timestamp_seconds` | `source` | Unix timestamp of the last successful collection (`source`: `storage` or `jobs`) |
+| `nbu_exporter_build_info` | `version`, `goversion` | Exporter build info; constant `1`, with the running exporter version and Go version. **No `site` label** — it describes the exporter process, not a NetBackup primary. |
 
 ## Label Encoding
 

--- a/internal/exporter/buildinfo.go
+++ b/internal/exporter/buildinfo.go
@@ -1,0 +1,16 @@
+package exporter
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewBuildInfoCollector returns a collector exposing `nbu_exporter_build_info{version,goversion} 1`,
+// so a scrape reveals exactly which exporter build is running. Standard Prometheus build-info pattern.
+func NewBuildInfoCollector(version, goversion string) prometheus.Collector {
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   "nbu_exporter",
+		Name:        "build_info",
+		Help:        "Exporter build information; constant 1, with the running version and Go version in the `version` and `goversion` labels.",
+		ConstLabels: prometheus.Labels{"version": version, "goversion": goversion},
+	})
+	g.Set(1)
+	return g
+}

--- a/internal/exporter/buildinfo_test.go
+++ b/internal/exporter/buildinfo_test.go
@@ -1,0 +1,27 @@
+package exporter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBuildInfoCollector(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(NewBuildInfoCollector("v1.2.3", "go1.99"))
+
+	const expected = `
+# HELP nbu_exporter_build_info Exporter build information; constant 1, with the running version and Go version in the ` + "`version`" + ` and ` + "`goversion`" + ` labels.
+# TYPE nbu_exporter_build_info gauge
+nbu_exporter_build_info{goversion="go1.99",version="v1.2.3"} 1
+`
+
+	require.NoError(t, testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expected),
+		"nbu_exporter_build_info",
+	))
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -51,6 +52,12 @@ var (
 	configFile string
 	debug      bool
 	apiTrace   bool
+
+	// version is the exporter build version. It defaults to "dev" for local
+	// builds and is overridden at release time via -ldflags "-X main.version=..."
+	// (GoReleaser injects the tag; the Makefile injects `git describe`). It is
+	// surfaced on /metrics as nbu_exporter_build_info{version,goversion}.
+	version = "dev"
 )
 
 // Server encapsulates the HTTP server and its dependencies for serving Prometheus metrics.
@@ -222,6 +229,16 @@ func (s *Server) Start() error {
 
 	// Store collector reference for shutdown cleanup
 	s.collector = collector
+
+	// Expose the exporter build (version + Go version) as a constant metric so a
+	// scrape reveals exactly which build is running, independent of collection.
+	if err := s.registry.Register(exporter.NewBuildInfoCollector(version, runtime.Version())); err != nil {
+		s.loopCancel()
+		<-s.loopDone
+		_ = s.loop.Close()
+		_ = collector.Close()
+		return fmt.Errorf("failed to register build info collector: %w", err)
+	}
 
 	// Register collector with Prometheus
 	if err := s.registry.Register(collector); err != nil {


### PR DESCRIPTION
## What

Adds a standard Prometheus build-info metric so a `/metrics` scrape reveals exactly which exporter build is deployed:

```
nbu_exporter_build_info{version="v4.0.4",goversion="go1.26.4"} 1
```

## How

- `internal/exporter/buildinfo.go` — `NewBuildInfoCollector(version, goversion)` returns a constant `1` gauge (standard Prometheus build-info pattern).
- `main.go` — new `main.version` variable (defaults to `"dev"`); the collector is registered directly into the server's existing `*prometheus.Registry` (the same registry `promhttp.HandlerFor` serves at `/metrics`). Because it's registered globally rather than per-site, it carries no `site` label.
- Version injection: GoReleaser's **default** ldflags already inject `-X main.version={{.Version}}`, so release binaries auto-populate the tag with no `.goreleaser.yml` change. The `Makefile` now also injects `git describe` for local `make cli` builds.
- Unit test via `testutil.GatherAndCompare`; `docs/metrics.md` and `CHANGELOG.md` updated.

## Verification

`make ci` passes locally: golangci-lint 0 issues, all tests green, build OK, govulncheck clean, total coverage 84.9% (threshold 70%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)