### PR TITLE
feat(config): env-driven TLS verification skip (NBU1_SKIP_CERTIFICATE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ NBU1_HOSTNAME=master.my.domain
 # unquoted value like the placeholder below is normally fine.
 NBU1_APIKEY=changeme
 
+# Skip TLS certificate verification for the NetBackup master server (INSECURE — use
+# only with a self-signed cert on a trusted network; keep false in production).
+# config.yaml can reference it as ${NBU1_SKIP_CERTIFICATE}.
+NBU1_SKIP_CERTIFICATE=false
+
 # Grafana admin login.
 GF_ADMIN_USER=admin
 GF_ADMIN_PASSWORD=changeme

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,12 @@ nbuserver:
     #   - 3.0  (NetBackup 10.0-10.4)
   apiKey: "${NBU1_APIKEY}"
   contentType: "application/vnd.netbackup+json; version=13.0" # Should match apiVersion
-  insecureSkipVerify: false # Set to true to skip TLS certificate verification (not recommended for production)
+  # Skip TLS certificate verification (INSECURE — use only with a self-signed cert on a
+  # trusted network; not recommended for production). Accepts a native boolean or a
+  # ${VAR} reference resolved at startup, same pattern as host/apiKey above:
+  #   insecureSkipVerify: true
+  #   insecureSkipVerify: "${NBU1_SKIP_CERTIFICATE}"
+  insecureSkipVerify: false
 
 # Optional: OpenTelemetry distributed tracing configuration
 # Enables distributed tracing for NetBackup API calls and Prometheus scrape cycles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       # or your own env references) rather than extending this block.
       - NBU1_HOSTNAME=${NBU1_HOSTNAME:-master.my.domain}
       - NBU1_APIKEY=${NBU1_APIKEY:-}
+      - NBU1_SKIP_CERTIFICATE=${NBU1_SKIP_CERTIFICATE:-false}
     networks:
       - monitoring
 

--- a/docs/config-examples/README.md
+++ b/docs/config-examples/README.md
@@ -168,7 +168,7 @@ nbuserver:
 | `apiVersion` | string | No | Auto-detect | API version ("13.0", "12.0", "10.0", or omit for auto-detection) |
 | `apiKey` | string | Yes | - | NetBackup API key (generate from NetBackup UI) |
 | `contentType` | string | Yes | - | API content type header |
-| `insecureSkipVerify` | bool | No | false | Skip TLS verification (not recommended for production) |
+| `insecureSkipVerify` | bool or `${VAR}` | No | false | Skip TLS verification (not recommended for production). Native bool or a `${VAR}` reference (e.g. `${NBU1_SKIP_CERTIFICATE}`) resolved at startup. |
 
 ### NBU Servers Section (multi-site)
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -20,7 +20,7 @@ nbuserver:
     apiVersion: "13.0"  # Optional: auto-detects if omitted
     apiKey: "your-api-key-here"
     contentType: "application/vnd.netbackup+json; version=13.0"
-    insecureSkipVerify: false
+    insecureSkipVerify: false  # or "${NBU1_SKIP_CERTIFICATE}" — see Environment Variables below
 
 # Optional: OpenTelemetry distributed tracing
 # opentelemetry:
@@ -76,6 +76,11 @@ the host), so existing single-site configurations keep working unchanged. See
 
 The `host` and `apiKey` fields in the `nbuserver` section support `${VAR}` interpolation.
 At startup the exporter expands every `${VAR}` reference and fails loudly if a variable is not set.
+
+`insecureSkipVerify` accepts either a native boolean (`insecureSkipVerify: true`) or the same
+`${VAR}` interpolation (`insecureSkipVerify: "${NBU1_SKIP_CERTIFICATE}"`), resolved at startup
+alongside `host`/`apiKey`. This lets you toggle TLS verification per environment (e.g. a lab
+override) without editing `config.yaml`.
 
 `nbu_exporter` loads a `.env` file natively at startup — you do not need a shell wrapper or
 `export` statements. It looks for `.env` in the working directory first, then in the same
@@ -164,7 +169,7 @@ the same fields plus a required, unique `site` (see [Multiple Sites](#multiple-s
 | `apiVersion` | string | No | API version (14.0, 13.0, 12.0, or 10.0). Auto-detects if omitted. |
 | `apiKey` | string | Yes | NetBackup API key |
 | `contentType` | string | Yes | API content type header |
-| `insecureSkipVerify` | bool | No | Skip TLS certificate verification |
+| `insecureSkipVerify` | bool or `${VAR}` | No | Skip TLS certificate verification. Native bool or a `${VAR}` reference (e.g. `${NBU1_SKIP_CERTIFICATE}`) resolved at startup; defaults to `false`. |
 
 ## OpenTelemetry Section (Optional)
 

--- a/internal/exporter/client.go
+++ b/internal/exporter/client.go
@@ -152,7 +152,7 @@ func NewNbuClient(cfg models.Config, opts ...ClientOption) *NbuClient {
 	}
 
 	// Log security warning if TLS verification is disabled
-	if cfg.NbuServer.InsecureSkipVerify {
+	if cfg.NbuServer.InsecureSkipVerify.Bool() {
 		log.Error("SECURITY WARNING: TLS certificate verification disabled - this is insecure for production use")
 	}
 
@@ -201,7 +201,7 @@ func NewNbuClient(cfg models.Config, opts ...ClientOption) *NbuClient {
 		IdleConnTimeout:     idleConnTimeout,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: cfg.NbuServer.InsecureSkipVerify,
+			InsecureSkipVerify: cfg.NbuServer.InsecureSkipVerify.Bool(),
 			MinVersion:         tls.VersionTLS12, // Enforce TLS 1.2 minimum
 		},
 	}

--- a/internal/exporter/client_test.go
+++ b/internal/exporter/client_test.go
@@ -172,16 +172,16 @@ func createTestServer(t *testing.T, apiVersion, apiKey string) *httptest.Server 
 func createBasicTestConfig(apiVersion, apiKey string) models.Config {
 	return models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: apiVersion,
 			APIKey:     apiKey,
@@ -231,16 +231,16 @@ func TestNbuClientFetchDataNotAcceptableError(t *testing.T) {
 
 			cfg := models.Config{
 				NbuServer: struct {
-					Port               string `yaml:"port"`
-					Scheme             string `yaml:"scheme"`
-					URI                string `yaml:"uri"`
-					Domain             string `yaml:"domain"`
-					DomainType         string `yaml:"domainType"`
-					Host               string `yaml:"host"`
-					APIKey             string `yaml:"apiKey"`
-					APIVersion         string `yaml:"apiVersion"`
-					ContentType        string `yaml:"contentType"`
-					InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+					Port               string         `yaml:"port"`
+					Scheme             string         `yaml:"scheme"`
+					URI                string         `yaml:"uri"`
+					Domain             string         `yaml:"domain"`
+					DomainType         string         `yaml:"domainType"`
+					Host               string         `yaml:"host"`
+					APIKey             string         `yaml:"apiKey"`
+					APIVersion         string         `yaml:"apiVersion"`
+					ContentType        string         `yaml:"contentType"`
+					InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 				}{
 					APIVersion: tt.apiVersion,
 					APIKey:     testAPIKey,
@@ -350,16 +350,16 @@ func TestNbuClientAuthorizationHeaderUnchanged(t *testing.T) {
 
 			cfg := models.Config{
 				NbuServer: struct {
-					Port               string `yaml:"port"`
-					Scheme             string `yaml:"scheme"`
-					URI                string `yaml:"uri"`
-					Domain             string `yaml:"domain"`
-					DomainType         string `yaml:"domainType"`
-					Host               string `yaml:"host"`
-					APIKey             string `yaml:"apiKey"`
-					APIVersion         string `yaml:"apiVersion"`
-					ContentType        string `yaml:"contentType"`
-					InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+					Port               string         `yaml:"port"`
+					Scheme             string         `yaml:"scheme"`
+					URI                string         `yaml:"uri"`
+					Domain             string         `yaml:"domain"`
+					DomainType         string         `yaml:"domainType"`
+					Host               string         `yaml:"host"`
+					APIKey             string         `yaml:"apiKey"`
+					APIVersion         string         `yaml:"apiVersion"`
+					ContentType        string         `yaml:"contentType"`
+					InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 				}{
 					APIVersion: "12.0",
 					APIKey:     apiKey,
@@ -505,7 +505,7 @@ func createMinimalConfig(apiVersion, apiKey string) models.Config {
 	cfg := models.Config{}
 	cfg.NbuServer.APIVersion = apiVersion
 	cfg.NbuServer.APIKey = apiKey
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	return cfg
 }
 
@@ -583,7 +583,7 @@ func TestNewNbuClientWithVersionDetectionExplicitVersion(t *testing.T) {
 			cfg.NbuServer.URI = "/netbackup"
 			cfg.NbuServer.APIKey = testAPIKey
 			cfg.NbuServer.APIVersion = tt.configuredVersion
-			cfg.NbuServer.InsecureSkipVerify = true
+			cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 
 			// For explicit versions, we should not attempt detection
 			if !tt.shouldDetect {
@@ -1249,7 +1249,7 @@ func TestNewNbuClient_TLSConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := createBasicTestConfig("13.0", "test-key")
-			cfg.NbuServer.InsecureSkipVerify = tt.insecureSkipVerify
+			cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(tt.insecureSkipVerify)
 
 			client := NewNbuClient(cfg)
 
@@ -1257,9 +1257,9 @@ func TestNewNbuClient_TLSConfig(t *testing.T) {
 			require.NotNil(t, client.client, "NewNbuClient() did not initialize HTTP client")
 
 			// Verify config is stored
-			if client.cfg.NbuServer.InsecureSkipVerify != tt.insecureSkipVerify {
+			if client.cfg.NbuServer.InsecureSkipVerify.Bool() != tt.insecureSkipVerify {
 				t.Errorf("NewNbuClient() InsecureSkipVerify = %v, want %v",
-					client.cfg.NbuServer.InsecureSkipVerify, tt.insecureSkipVerify)
+					client.cfg.NbuServer.InsecureSkipVerify.Bool(), tt.insecureSkipVerify)
 			}
 		})
 	}
@@ -1380,7 +1380,7 @@ func TestNbuClient_TLSInTransport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := createBasicTestConfig("13.0", "test-key")
-			cfg.NbuServer.InsecureSkipVerify = tt.insecureSkipVerify
+			cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(tt.insecureSkipVerify)
 
 			client := NewNbuClient(cfg)
 			if client == nil {

--- a/internal/exporter/collector_loop_test.go
+++ b/internal/exporter/collector_loop_test.go
@@ -65,7 +65,7 @@ func newNbuServerConfig(site, serverURL, apiVersion string) models.NbuServerConf
 		APIKey:             testAPIKey,
 		APIVersion:         apiVersion,
 		ContentType:        contentTypeJSON,
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: models.NewEnvBool(true),
 	}
 }
 

--- a/internal/exporter/concurrent_test.go
+++ b/internal/exporter/concurrent_test.go
@@ -365,7 +365,7 @@ func createConcurrentTestConfig(server *httptest.Server) models.Config {
 	cfg.NbuServer.URI = "/netbackup"
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = models.APIVersion130
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	cfg.Server.ScrapingInterval = "5m"
 	return cfg
 }

--- a/internal/exporter/end_to_end_test.go
+++ b/internal/exporter/end_to_end_test.go
@@ -511,7 +511,7 @@ func createTestConfigTLS(serverURL, apiVersion string) models.Config {
 	cfg.NbuServer.APIVersion = apiVersion
 	cfg.NbuServer.APIKey = "test-api-key"
 	cfg.NbuServer.ContentType = fmt.Sprintf("application/vnd.netbackup+json;version=%s", apiVersion)
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 
 	return cfg
 }

--- a/internal/exporter/health_test.go
+++ b/internal/exporter/health_test.go
@@ -253,7 +253,7 @@ func createHealthTestConfig(server *httptest.Server) models.Config {
 	cfg.NbuServer.URI = "/netbackup"
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = models.APIVersion130
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	cfg.Server.ScrapingInterval = "5m"
 	cfg.Server.CacheTTL = "5m"
 	return cfg

--- a/internal/exporter/integration_test.go
+++ b/internal/exporter/integration_test.go
@@ -429,7 +429,7 @@ func createTestConfig(serverURL, apiVersion string) models.Config {
 	cfg.NbuServer.APIKey = testutil.TestAPIKey
 	cfg.NbuServer.APIVersion = apiVersion
 	cfg.NbuServer.ContentType = testutil.ContentTypeJSON
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 
 	return cfg
 }

--- a/internal/exporter/otel_benchmark_test.go
+++ b/internal/exporter/otel_benchmark_test.go
@@ -53,16 +53,16 @@ func BenchmarkFetchDataWithoutTracing(b *testing.B) {
 
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: benchAPIVersion,
 			APIKey:     benchTestKey,
@@ -121,16 +121,16 @@ func BenchmarkFetchDataWithTracingFullSampling(b *testing.B) {
 
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: benchAPIVersion,
 			APIKey:     benchTestKey,
@@ -189,16 +189,16 @@ func BenchmarkFetchDataWithTracingPartialSampling(b *testing.B) {
 
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: benchAPIVersion,
 			APIKey:     benchTestKey,
@@ -238,16 +238,16 @@ func BenchmarkSpanCreation(b *testing.B) {
 
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: benchAPIVersion,
 			APIKey:     benchTestKey,
@@ -288,16 +288,16 @@ func BenchmarkAttributeRecording(b *testing.B) {
 
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: benchAPIVersion,
 			APIKey:     benchTestKey,

--- a/internal/exporter/otel_integration_test.go
+++ b/internal/exporter/otel_integration_test.go
@@ -61,16 +61,16 @@ func TestIntegrationEndToEndTracing(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: "13.0",
 			APIKey:     testKeyName,
@@ -125,16 +125,16 @@ func TestIntegrationBackwardCompatibility(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:       "nbu-master",
 			Port:       "1556",
@@ -218,16 +218,16 @@ func TestIntegrationGracefulDegradation(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: "13.0",
 			APIKey:     testKeyName,
@@ -289,16 +289,16 @@ func TestIntegrationTracePropagation(t *testing.T) {
 	// Create client
 	cfg := models.Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			APIVersion: "13.0",
 			APIKey:     testKeyName,

--- a/internal/exporter/prometheus_test.go
+++ b/internal/exporter/prometheus_test.go
@@ -57,7 +57,7 @@ func TestNewNbuCollectorExplicitVersion(t *testing.T) {
 			cfg.NbuServer.URI = ""
 			cfg.NbuServer.APIKey = testAPIKey
 			cfg.NbuServer.APIVersion = tt.apiVersion
-			cfg.NbuServer.InsecureSkipVerify = true
+			cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 			cfg.Server.ScrapingInterval = "5m"
 
 			// Create collector with explicit version
@@ -122,7 +122,7 @@ func createTestConfigWithServer(server *httptest.Server) models.Config {
 	cfg.NbuServer.URI = ""
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = "" // Empty to trigger detection
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	cfg.Server.ScrapingInterval = "5m"
 	return cfg
 }
@@ -238,7 +238,7 @@ func TestNewNbuCollectorDetectionFailure(t *testing.T) {
 			cfg.NbuServer.URI = ""
 			cfg.NbuServer.APIKey = testAPIKey
 			cfg.NbuServer.APIVersion = "" // Empty to trigger detection
-			cfg.NbuServer.InsecureSkipVerify = true
+			cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 			cfg.Server.ScrapingInterval = "5m"
 
 			// Create collector - should fail
@@ -270,7 +270,7 @@ func TestNbuCollectorAPIVersionMetric(t *testing.T) {
 	cfg.NbuServer.URI = ""
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = models.APIVersion130
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	cfg.Server.ScrapingInterval = "5m"
 
 	// Create collector
@@ -323,7 +323,7 @@ func TestNbuCollectorDescribe(t *testing.T) {
 	cfg.NbuServer.URI = ""
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = models.APIVersion130
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	cfg.Server.ScrapingInterval = "5m"
 
 	// Create collector
@@ -398,16 +398,16 @@ func TestNbuCollectorCreateScrapeSpanNilSafe(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:       testServerNBUMaster,
 			Port:       "1556",
@@ -461,16 +461,16 @@ func TestNbuCollectorCreateScrapeSpanWithTracer(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:       testServerNBUMaster,
 			Port:       "1556",
@@ -530,16 +530,16 @@ func TestNbuCollectorCollectWithoutTracing(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:       testServerNBUMaster,
 			Port:       "1556",
@@ -648,16 +648,16 @@ func TestNbuCollectorTracingDisabled(t *testing.T) {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:       testServerNBUMaster,
 			Port:       "1556",
@@ -725,16 +725,16 @@ func TestNbuCollectorStorageCacheIntegration(t *testing.T) {
 			CacheTTL:         "1m", // 1 minute cache for testing
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:               serverHost,
 			Port:               serverPort,
@@ -742,7 +742,7 @@ func TestNbuCollectorStorageCacheIntegration(t *testing.T) {
 			URI:                "",
 			APIKey:             testKeyName,
 			APIVersion:         "13.0",
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: models.NewEnvBool(true),
 		},
 	}
 
@@ -797,16 +797,16 @@ func TestNbuCollectorHelpStringIncludesTTL(t *testing.T) {
 			CacheTTL:         "2m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Host:               serverHost,
 			Port:               serverPort,
@@ -814,7 +814,7 @@ func TestNbuCollectorHelpStringIncludesTTL(t *testing.T) {
 			URI:                "",
 			APIKey:             testKeyName,
 			APIVersion:         "13.0",
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: models.NewEnvBool(true),
 		},
 	}
 
@@ -873,7 +873,7 @@ func TestNbuCollectorNbuUpHasSiteLabel(t *testing.T) {
 	cfg.NbuServer.Port = serverPort
 	cfg.NbuServer.APIKey = testAPIKey
 	cfg.NbuServer.APIVersion = models.APIVersion130
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 	// SetDefaults (called inside NewNbuCollector via performVersionDetectionIfNeeded)
 	// promotes NbuServer -> NbuServers[0].Site = serverHost
 

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -33,17 +34,73 @@ var SupportedAPIVersions = []string{APIVersion140, APIVersion130, APIVersion120,
 // by the multi-site feature. The Site field defaults to the Host value when the
 // legacy single nbuserver: block is auto-mapped.
 type NbuServerConfig struct {
-	Site               string `yaml:"site"`
-	Port               string `yaml:"port"`
-	Scheme             string `yaml:"scheme"`
-	URI                string `yaml:"uri"`
-	Domain             string `yaml:"domain"`
-	DomainType         string `yaml:"domainType"`
-	Host               string `yaml:"host"`
-	APIKey             string `yaml:"apiKey"`
-	APIVersion         string `yaml:"apiVersion"`
-	ContentType        string `yaml:"contentType"`
-	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+	Site               string  `yaml:"site"`
+	Port               string  `yaml:"port"`
+	Scheme             string  `yaml:"scheme"`
+	URI                string  `yaml:"uri"`
+	Domain             string  `yaml:"domain"`
+	DomainType         string  `yaml:"domainType"`
+	Host               string  `yaml:"host"`
+	APIKey             string  `yaml:"apiKey"`
+	APIVersion         string  `yaml:"apiVersion"`
+	ContentType        string  `yaml:"contentType"`
+	InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
+}
+
+// EnvBool is a boolean config value that may be written in YAML either as a native
+// boolean (insecureSkipVerify: true) or as a ${VAR} environment reference resolved at
+// secret-resolution time (insecureSkipVerify: ${NBU1_SKIP_CERTIFICATE}). This keeps
+// backward compatibility with existing native-bool configs while allowing env-driven
+// control that matches the ${NBU1_*} pattern already used for host/apiKey.
+type EnvBool struct {
+	raw string // ${...} reference or literal string form, when written as a string
+	val bool   // resolved value
+}
+
+// NewEnvBool returns an already-resolved EnvBool (for tests / programmatic config).
+func NewEnvBool(v bool) EnvBool { return EnvBool{val: v} }
+
+// Bool returns the resolved boolean value.
+func (b EnvBool) Bool() bool { return b.val }
+
+// UnmarshalYAML accepts either a native YAML boolean or a string (which may be a ${VAR}
+// reference resolved later by Resolve). yaml.v2 signature.
+func (b *EnvBool) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var bv bool
+	if err := unmarshal(&bv); err == nil {
+		b.val = bv
+		return nil
+	}
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return fmt.Errorf("insecureSkipVerify must be a boolean or ${ENV} reference: %w", err)
+	}
+	b.raw = s
+	return nil
+}
+
+// Resolve expands any ${VAR} reference (via expand) and parses the result to a bool.
+// It is a no-op when the value was a native boolean or the field was omitted. An empty
+// expansion resolves to false; a non-boolean expansion is an error.
+func (b *EnvBool) Resolve(expand func(string) (string, error)) error {
+	if b.raw == "" {
+		return nil
+	}
+	s, err := expand(b.raw)
+	if err != nil {
+		return err
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		b.val = false
+		return nil
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return fmt.Errorf("insecureSkipVerify: cannot parse %q as boolean", s)
+	}
+	b.val = v
+	return nil
 }
 
 // ApplyTo copies this server's connection settings into cfg's legacy NbuServer
@@ -97,16 +154,16 @@ type Config struct {
 	// backward compatibility and is automatically promoted into NbuServers[0]
 	// during Validate()/SetDefaults() if NbuServers is empty.
 	NbuServer struct {
-		Port               string `yaml:"port"`
-		Scheme             string `yaml:"scheme"`
-		URI                string `yaml:"uri"`
-		Domain             string `yaml:"domain"`
-		DomainType         string `yaml:"domainType"`
-		Host               string `yaml:"host"`
-		APIKey             string `yaml:"apiKey"`
-		APIVersion         string `yaml:"apiVersion"`
-		ContentType        string `yaml:"contentType"`
-		InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+		Port               string  `yaml:"port"`
+		Scheme             string  `yaml:"scheme"`
+		URI                string  `yaml:"uri"`
+		Domain             string  `yaml:"domain"`
+		DomainType         string  `yaml:"domainType"`
+		Host               string  `yaml:"host"`
+		APIKey             string  `yaml:"apiKey"`
+		APIVersion         string  `yaml:"apiVersion"`
+		ContentType        string  `yaml:"contentType"`
+		InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 	} `yaml:"nbuserver"`
 
 	// NbuServers is the multi-site server list. When empty and NbuServer.Host is

--- a/internal/models/Config_test.go
+++ b/internal/models/Config_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -18,16 +19,16 @@ func TestConfigSetDefaults(t *testing.T) {
 			name: "preserves empty API version for auto-detection",
 			config: Config{
 				NbuServer: struct {
-					Port               string `yaml:"port"`
-					Scheme             string `yaml:"scheme"`
-					URI                string `yaml:"uri"`
-					Domain             string `yaml:"domain"`
-					DomainType         string `yaml:"domainType"`
-					Host               string `yaml:"host"`
-					APIKey             string `yaml:"apiKey"`
-					APIVersion         string `yaml:"apiVersion"`
-					ContentType        string `yaml:"contentType"`
-					InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+					Port               string  `yaml:"port"`
+					Scheme             string  `yaml:"scheme"`
+					URI                string  `yaml:"uri"`
+					Domain             string  `yaml:"domain"`
+					DomainType         string  `yaml:"domainType"`
+					Host               string  `yaml:"host"`
+					APIKey             string  `yaml:"apiKey"`
+					APIVersion         string  `yaml:"apiVersion"`
+					ContentType        string  `yaml:"contentType"`
+					InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 				}{
 					APIVersion: "",
 				},
@@ -38,16 +39,16 @@ func TestConfigSetDefaults(t *testing.T) {
 			name: "preserves existing API version",
 			config: Config{
 				NbuServer: struct {
-					Port               string `yaml:"port"`
-					Scheme             string `yaml:"scheme"`
-					URI                string `yaml:"uri"`
-					Domain             string `yaml:"domain"`
-					DomainType         string `yaml:"domainType"`
-					Host               string `yaml:"host"`
-					APIKey             string `yaml:"apiKey"`
-					APIVersion         string `yaml:"apiVersion"`
-					ContentType        string `yaml:"contentType"`
-					InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+					Port               string  `yaml:"port"`
+					Scheme             string  `yaml:"scheme"`
+					URI                string  `yaml:"uri"`
+					Domain             string  `yaml:"domain"`
+					DomainType         string  `yaml:"domainType"`
+					Host               string  `yaml:"host"`
+					APIKey             string  `yaml:"apiKey"`
+					APIVersion         string  `yaml:"apiVersion"`
+					ContentType        string  `yaml:"contentType"`
+					InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 				}{
 					APIVersion: "11.1",
 				},
@@ -106,16 +107,16 @@ func createConfigWithAPIVersion(apiVersion string) *Config {
 			LogName:          testLogName,
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string  `yaml:"port"`
+			Scheme             string  `yaml:"scheme"`
+			URI                string  `yaml:"uri"`
+			Domain             string  `yaml:"domain"`
+			DomainType         string  `yaml:"domainType"`
+			Host               string  `yaml:"host"`
+			APIKey             string  `yaml:"apiKey"`
+			APIVersion         string  `yaml:"apiVersion"`
+			ContentType        string  `yaml:"contentType"`
+			InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Port:       "1556",
 			Scheme:     "https",
@@ -444,16 +445,16 @@ func TestAPIVersionConstants(t *testing.T) {
 func createConfigWithNBUServer(scheme, host, port, uri string) Config {
 	return Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string  `yaml:"port"`
+			Scheme             string  `yaml:"scheme"`
+			URI                string  `yaml:"uri"`
+			Domain             string  `yaml:"domain"`
+			DomainType         string  `yaml:"domainType"`
+			Host               string  `yaml:"host"`
+			APIKey             string  `yaml:"apiKey"`
+			APIVersion         string  `yaml:"apiVersion"`
+			ContentType        string  `yaml:"contentType"`
+			InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Scheme: scheme,
 			Host:   host,
@@ -678,16 +679,16 @@ func TestConfigMaskAPIKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := Config{
 				NbuServer: struct {
-					Port               string `yaml:"port"`
-					Scheme             string `yaml:"scheme"`
-					URI                string `yaml:"uri"`
-					Domain             string `yaml:"domain"`
-					DomainType         string `yaml:"domainType"`
-					Host               string `yaml:"host"`
-					APIKey             string `yaml:"apiKey"`
-					APIVersion         string `yaml:"apiVersion"`
-					ContentType        string `yaml:"contentType"`
-					InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+					Port               string  `yaml:"port"`
+					Scheme             string  `yaml:"scheme"`
+					URI                string  `yaml:"uri"`
+					Domain             string  `yaml:"domain"`
+					DomainType         string  `yaml:"domainType"`
+					Host               string  `yaml:"host"`
+					APIKey             string  `yaml:"apiKey"`
+					APIVersion         string  `yaml:"apiVersion"`
+					ContentType        string  `yaml:"contentType"`
+					InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 				}{
 					APIKey: tt.apiKey,
 				},
@@ -704,16 +705,16 @@ func TestConfigMaskAPIKey(t *testing.T) {
 func TestConfigBuildURL(t *testing.T) {
 	config := Config{
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string  `yaml:"port"`
+			Scheme             string  `yaml:"scheme"`
+			URI                string  `yaml:"uri"`
+			Domain             string  `yaml:"domain"`
+			DomainType         string  `yaml:"domainType"`
+			Host               string  `yaml:"host"`
+			APIKey             string  `yaml:"apiKey"`
+			APIVersion         string  `yaml:"apiVersion"`
+			ContentType        string  `yaml:"contentType"`
+			InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Scheme: "https",
 			Host:   testServerNBUMaster,
@@ -806,16 +807,16 @@ func TestConfigValidateServerFields(t *testing.T) {
 				ScrapingInterval: "5m",
 			},
 			NbuServer: struct {
-				Port               string `yaml:"port"`
-				Scheme             string `yaml:"scheme"`
-				URI                string `yaml:"uri"`
-				Domain             string `yaml:"domain"`
-				DomainType         string `yaml:"domainType"`
-				Host               string `yaml:"host"`
-				APIKey             string `yaml:"apiKey"`
-				APIVersion         string `yaml:"apiVersion"`
-				ContentType        string `yaml:"contentType"`
-				InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+				Port               string  `yaml:"port"`
+				Scheme             string  `yaml:"scheme"`
+				URI                string  `yaml:"uri"`
+				Domain             string  `yaml:"domain"`
+				DomainType         string  `yaml:"domainType"`
+				Host               string  `yaml:"host"`
+				APIKey             string  `yaml:"apiKey"`
+				APIVersion         string  `yaml:"apiVersion"`
+				ContentType        string  `yaml:"contentType"`
+				InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 			}{
 				Port:   "1556",
 				Scheme: "https",
@@ -1045,16 +1046,16 @@ func createBaseTestConfig() Config {
 			ScrapingInterval: "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string  `yaml:"port"`
+			Scheme             string  `yaml:"scheme"`
+			URI                string  `yaml:"uri"`
+			Domain             string  `yaml:"domain"`
+			DomainType         string  `yaml:"domainType"`
+			Host               string  `yaml:"host"`
+			APIKey             string  `yaml:"apiKey"`
+			APIVersion         string  `yaml:"apiVersion"`
+			ContentType        string  `yaml:"contentType"`
+			InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Port:   "1556",
 			Scheme: "https",
@@ -1287,16 +1288,16 @@ func TestConfigValidateOTelEndpoint(t *testing.T) {
 				ScrapingInterval: "5m",
 			},
 			NbuServer: struct {
-				Port               string `yaml:"port"`
-				Scheme             string `yaml:"scheme"`
-				URI                string `yaml:"uri"`
-				Domain             string `yaml:"domain"`
-				DomainType         string `yaml:"domainType"`
-				Host               string `yaml:"host"`
-				APIKey             string `yaml:"apiKey"`
-				APIVersion         string `yaml:"apiVersion"`
-				ContentType        string `yaml:"contentType"`
-				InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+				Port               string  `yaml:"port"`
+				Scheme             string  `yaml:"scheme"`
+				URI                string  `yaml:"uri"`
+				Domain             string  `yaml:"domain"`
+				DomainType         string  `yaml:"domainType"`
+				Host               string  `yaml:"host"`
+				APIKey             string  `yaml:"apiKey"`
+				APIVersion         string  `yaml:"apiVersion"`
+				ContentType        string  `yaml:"contentType"`
+				InsecureSkipVerify EnvBool `yaml:"insecureSkipVerify"`
 			}{
 				Port:   "1556",
 				Scheme: "https",
@@ -1703,7 +1704,7 @@ func TestConfigBuildURLAfterValidation(t *testing.T) {
 func TestValidate_InsecureSkipVerify_AllowedViaConfig(t *testing.T) {
 	// InsecureSkipVerify is controlled via config file - no env var required
 	cfg := createBaseTestConfig()
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = NewEnvBool(true)
 
 	err := cfg.Validate()
 
@@ -1714,7 +1715,7 @@ func TestValidate_InsecureSkipVerify_AllowedViaConfig(t *testing.T) {
 
 func TestValidate_SecureByDefault(t *testing.T) {
 	cfg := createBaseTestConfig()
-	cfg.NbuServer.InsecureSkipVerify = false // Default secure mode
+	cfg.NbuServer.InsecureSkipVerify = NewEnvBool(false) // Default secure mode
 
 	err := cfg.Validate()
 
@@ -1992,5 +1993,81 @@ func TestGetCollectionInterval(t *testing.T) {
 	cfg.Server.CollectionInterval = "not-a-duration"
 	if got := cfg.GetCollectionInterval(); got != 5*time.Minute {
 		t.Errorf("invalid GetCollectionInterval() = %v, want 5m fallback", got)
+	}
+}
+
+func TestEnvBoolNativeAndEnvRef(t *testing.T) {
+	// native YAML bool
+	var native struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("skip: true\n"), &native); err != nil {
+		t.Fatalf("unmarshal native bool: %v", err)
+	}
+	if !native.Skip.Bool() {
+		t.Fatal("native bool true not resolved to true")
+	}
+
+	// ${VAR} reference: unresolved until Resolve is called (defaults false)
+	var ref struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("skip: ${NBU1_SKIP_CERTIFICATE}\n"), &ref); err != nil {
+		t.Fatalf("unmarshal env ref: %v", err)
+	}
+	if ref.Skip.Bool() {
+		t.Fatal("env ref should be false before Resolve")
+	}
+	// resolve via a fake expander returning "true"
+	if err := ref.Skip.Resolve(func(s string) (string, error) { return "true", nil }); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !ref.Skip.Bool() {
+		t.Fatal("env ref true not resolved")
+	}
+
+	// absent field defaults to false and Resolve is a no-op
+	var absent struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("other: 1\n"), &absent); err != nil {
+		t.Fatalf("unmarshal absent: %v", err)
+	}
+	if err := absent.Skip.Resolve(func(s string) (string, error) { return "", nil }); err != nil {
+		t.Fatalf("resolve absent: %v", err)
+	}
+	if absent.Skip.Bool() {
+		t.Fatal("absent field should be false")
+	}
+
+	// unset ${VAR}: Resolve propagates the expander's error (matches host/apiKey policy)
+	var unset struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("skip: ${UNSET_SKIP_VAR}\n"), &unset); err != nil {
+		t.Fatalf("unmarshal unset ref: %v", err)
+	}
+	wantErr := errors.New("environment variable(s) referenced in config but not set: UNSET_SKIP_VAR")
+	if err := unset.Skip.Resolve(func(s string) (string, error) { return "", wantErr }); err == nil {
+		t.Fatal("expected error resolving unset ${VAR}, got nil")
+	}
+
+	// non-boolean expansion is an error
+	var bad struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("skip: ${SKIP_TLS}\n"), &bad); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := bad.Skip.Resolve(func(s string) (string, error) { return "not-a-bool", nil }); err == nil {
+		t.Fatal("expected error for non-boolean expansion, got nil")
+	}
+
+	// non-bool, non-string YAML value is a type error
+	var invalid struct {
+		Skip EnvBool `yaml:"skip"`
+	}
+	if err := yaml.Unmarshal([]byte("skip: [1, 2, 3]\n"), &invalid); err == nil {
+		t.Fatal("expected error unmarshalling a list into EnvBool, got nil")
 	}
 }

--- a/internal/models/immutable.go
+++ b/internal/models/immutable.go
@@ -71,7 +71,7 @@ func NewImmutableConfig(cfg *Config) (ImmutableConfig, error) {
 		baseURL:            cfg.GetNBUBaseURL(),
 		apiKey:             cfg.NbuServer.APIKey,
 		apiVersion:         cfg.NbuServer.APIVersion,
-		insecureSkipVerify: cfg.NbuServer.InsecureSkipVerify,
+		insecureSkipVerify: cfg.NbuServer.InsecureSkipVerify.Bool(),
 
 		// Server
 		serverAddress:    cfg.GetServerAddress(),

--- a/internal/models/immutable_test.go
+++ b/internal/models/immutable_test.go
@@ -19,7 +19,7 @@ func createValidConfig() *Config {
 	cfg.NbuServer.URI = "/netbackup"
 	cfg.NbuServer.APIKey = "test-api-key-12345678"
 	cfg.NbuServer.APIVersion = "13.0"
-	cfg.NbuServer.InsecureSkipVerify = false
+	cfg.NbuServer.InsecureSkipVerify = NewEnvBool(false)
 
 	cfg.OpenTelemetry.Enabled = true
 	cfg.OpenTelemetry.Endpoint = "localhost:4317"

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -9,9 +9,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ResolveSecrets expands ${ENV} references in the NBU server host and apiKey fields.
-// Mutates cfg in place. Call this immediately after YAML decode, before Validate().
-// Returns an error (with field context) if any referenced variable is not set.
+// ResolveSecrets expands ${ENV} references in the NBU server host, apiKey, and
+// insecureSkipVerify fields (legacy single-server block and, if present, each entry of
+// the multi-site nbuservers list). Mutates cfg in place. Call this immediately after
+// YAML decode, before Validate(). Returns an error (with field context) if any
+// referenced variable is not set.
 func ResolveSecrets(cfg *models.Config) error {
 	host, err := ExpandEnv(cfg.NbuServer.Host)
 	if err != nil {
@@ -24,6 +26,16 @@ func ResolveSecrets(cfg *models.Config) error {
 		return fmt.Errorf("nbuserver.apiKey: %w", err)
 	}
 	cfg.NbuServer.APIKey = apiKey
+
+	if err := cfg.NbuServer.InsecureSkipVerify.Resolve(ExpandEnv); err != nil {
+		return fmt.Errorf("nbuserver.insecureSkipVerify: %w", err)
+	}
+
+	for i := range cfg.NbuServers {
+		if err := cfg.NbuServers[i].InsecureSkipVerify.Resolve(ExpandEnv); err != nil {
+			return fmt.Errorf("nbuservers[%d] (%s) insecureSkipVerify: %w", i, cfg.NbuServers[i].Site, err)
+		}
+	}
 
 	return nil
 }

--- a/internal/utils/file_test.go
+++ b/internal/utils/file_test.go
@@ -119,7 +119,7 @@ nbuserver:
 				if cfg.NbuServer.Domain != "example.com" {
 					t.Errorf("Expected domain 'example.com', got '%s'", cfg.NbuServer.Domain)
 				}
-				if !cfg.NbuServer.InsecureSkipVerify {
+				if !cfg.NbuServer.InsecureSkipVerify.Bool() {
 					t.Error("Expected insecureSkipVerify to be true")
 				}
 			},
@@ -300,6 +300,175 @@ nbuserver:
 		}
 		if cfg.NbuServer.APIKey != "env-api-key" {
 			t.Errorf("APIKey = %q, want %q", cfg.NbuServer.APIKey, "env-api-key")
+		}
+	})
+
+	t.Run("insecureSkipVerify native bool passes through unchanged", func(t *testing.T) {
+		cfg := &models.Config{}
+		cfg.NbuServer.Host = "literal-host"
+		cfg.NbuServer.APIKey = "literal-key"
+		cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
+
+		if err := ResolveSecrets(cfg); err != nil {
+			t.Fatalf("ResolveSecrets() unexpected error: %v", err)
+		}
+		if !cfg.NbuServer.InsecureSkipVerify.Bool() {
+			t.Error("native bool true should remain true after ResolveSecrets")
+		}
+	})
+
+	t.Run("insecureSkipVerify resolves ${VAR} reference to true", func(t *testing.T) {
+		t.Setenv("TEST_NBU_SKIP_CERT", "true")
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "skip-cert-config.yaml")
+		content := `
+server:
+  host: "localhost"
+  port: "9440"
+  uri: "/metrics"
+  scrapingInterval: "5m"
+  logName: "test.log"
+nbuserver:
+  host: "literal-host"
+  port: "1556"
+  scheme: "https"
+  uri: "/netbackup"
+  apiKey: "literal-key"
+  apiVersion: "13.0"
+  insecureSkipVerify: "${TEST_NBU_SKIP_CERT}"
+`
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		var cfg models.Config
+		if err := ReadFile(&cfg, filePath); err != nil {
+			t.Fatalf("ReadFile() unexpected error: %v", err)
+		}
+		if !cfg.NbuServer.InsecureSkipVerify.Bool() {
+			t.Error("TEST_NBU_SKIP_CERT=true did not resolve insecureSkipVerify to true")
+		}
+	})
+
+	t.Run("insecureSkipVerify unset ${VAR} returns error with field context", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "skip-cert-unset-config.yaml")
+		content := `
+server:
+  host: "localhost"
+  port: "9440"
+  uri: "/metrics"
+  scrapingInterval: "5m"
+  logName: "test.log"
+nbuserver:
+  host: "literal-host"
+  port: "1556"
+  scheme: "https"
+  uri: "/netbackup"
+  apiKey: "literal-key"
+  apiVersion: "13.0"
+  insecureSkipVerify: "${UNSET_SKIP_CERT_VAR_XYZ}"
+`
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		var cfg models.Config
+		err := ReadFile(&cfg, filePath)
+		if err == nil {
+			t.Fatal("ReadFile() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "nbuserver.insecureSkipVerify") {
+			t.Errorf("error %q should mention field nbuserver.insecureSkipVerify", err.Error())
+		}
+		if !strings.Contains(err.Error(), "UNSET_SKIP_CERT_VAR_XYZ") {
+			t.Errorf("error %q should name the missing var", err.Error())
+		}
+	})
+
+	t.Run("insecureSkipVerify non-boolean value errors", func(t *testing.T) {
+		t.Setenv("TEST_NBU_SKIP_CERT_BAD", "not-a-bool")
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "skip-cert-bad-config.yaml")
+		content := `
+server:
+  host: "localhost"
+  port: "9440"
+  uri: "/metrics"
+  scrapingInterval: "5m"
+  logName: "test.log"
+nbuserver:
+  host: "literal-host"
+  port: "1556"
+  scheme: "https"
+  uri: "/netbackup"
+  apiKey: "literal-key"
+  apiVersion: "13.0"
+  insecureSkipVerify: "${TEST_NBU_SKIP_CERT_BAD}"
+`
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		var cfg models.Config
+		err := ReadFile(&cfg, filePath)
+		if err == nil {
+			t.Fatal("ReadFile() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "insecureSkipVerify") {
+			t.Errorf("error %q should mention insecureSkipVerify", err.Error())
+		}
+	})
+
+	t.Run("nbuservers list resolves a distinct ${VAR} per site", func(t *testing.T) {
+		t.Setenv("TEST_NBU1_SKIP_CERT", "true")
+		t.Setenv("TEST_NBU2_SKIP_CERT", "false")
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "skip-cert-multisite-config.yaml")
+		content := `
+server:
+  host: "localhost"
+  port: "9440"
+  uri: "/metrics"
+  scrapingInterval: "5m"
+  logName: "test.log"
+nbuservers:
+  - site: "paris"
+    host: "nbu-paris.example.com"
+    port: "1556"
+    scheme: "https"
+    uri: "/netbackup"
+    apiKey: "paris-key"
+    apiVersion: "13.0"
+    insecureSkipVerify: "${TEST_NBU1_SKIP_CERT}"
+  - site: "lyon"
+    host: "nbu-lyon.example.com"
+    port: "1556"
+    scheme: "https"
+    uri: "/netbackup"
+    apiKey: "lyon-key"
+    apiVersion: "13.0"
+    insecureSkipVerify: "${TEST_NBU2_SKIP_CERT}"
+`
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		var cfg models.Config
+		if err := ReadFile(&cfg, filePath); err != nil {
+			t.Fatalf("ReadFile() unexpected error: %v", err)
+		}
+		if len(cfg.NbuServers) != 2 {
+			t.Fatalf("expected 2 nbuservers entries, got %d", len(cfg.NbuServers))
+		}
+		if !cfg.NbuServers[0].InsecureSkipVerify.Bool() {
+			t.Error("site paris: TEST_NBU1_SKIP_CERT=true did not resolve to true")
+		}
+		if cfg.NbuServers[1].InsecureSkipVerify.Bool() {
+			t.Error("site lyon: TEST_NBU2_SKIP_CERT=false did not resolve to false")
 		}
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -50,16 +50,16 @@ func createTestConfig() models.Config {
 			CacheTTL:         "5m",
 		},
 		NbuServer: struct {
-			Port               string `yaml:"port"`
-			Scheme             string `yaml:"scheme"`
-			URI                string `yaml:"uri"`
-			Domain             string `yaml:"domain"`
-			DomainType         string `yaml:"domainType"`
-			Host               string `yaml:"host"`
-			APIKey             string `yaml:"apiKey"`
-			APIVersion         string `yaml:"apiVersion"`
-			ContentType        string `yaml:"contentType"`
-			InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+			Port               string         `yaml:"port"`
+			Scheme             string         `yaml:"scheme"`
+			URI                string         `yaml:"uri"`
+			Domain             string         `yaml:"domain"`
+			DomainType         string         `yaml:"domainType"`
+			Host               string         `yaml:"host"`
+			APIKey             string         `yaml:"apiKey"`
+			APIVersion         string         `yaml:"apiVersion"`
+			ContentType        string         `yaml:"contentType"`
+			InsecureSkipVerify models.EnvBool `yaml:"insecureSkipVerify"`
 		}{
 			Scheme:             "https",
 			Host:               "localhost",
@@ -67,7 +67,7 @@ func createTestConfig() models.Config {
 			URI:                "/netbackup",
 			APIKey:             "test-api-key-12345678",
 			APIVersion:         "13.0",
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: models.NewEnvBool(true),
 		},
 	}
 }
@@ -367,7 +367,7 @@ func TestServerStartShutdown_Integration(t *testing.T) {
 	cfg.NbuServer.Host = host
 	cfg.NbuServer.Port = port
 	cfg.NbuServer.Scheme = "https"
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 
 	// Create server with SafeConfig
 	safeCfg := models.NewSafeConfig(&cfg)
@@ -518,7 +518,7 @@ func TestServerErrorPropagation(t *testing.T) {
 	cfg.NbuServer.Host = nbuHost
 	cfg.NbuServer.Port = nbuPort
 	cfg.NbuServer.Scheme = "https"
-	cfg.NbuServer.InsecureSkipVerify = true
+	cfg.NbuServer.InsecureSkipVerify = models.NewEnvBool(true)
 
 	safeCfg := models.NewSafeConfig(&cfg)
 	server := NewServer(safeCfg, "")


### PR DESCRIPTION
## Summary
- `nbuserver.insecureSkipVerify` (and each entry's `insecureSkipVerify` in the multi-site `nbuservers:` list) now accepts either a native YAML boolean or a `${VAR}` environment reference, resolved at startup — mirroring the `${NBU1_HOSTNAME}` / `${NBU1_APIKEY}` pattern already used for connection secrets. This replicates the pscale_exporter v0.13.0 pattern.
- Added a new `models.EnvBool` type (`UnmarshalYAML` + `Resolve(expand)` + `Bool()`) and retyped `insecureSkipVerify` on both the legacy `nbuserver:` block and the multi-site `NbuServerConfig` struct.
- `ResolveSecrets` now resolves `insecureSkipVerify` for the legacy block and for every entry in `nbuservers[]`, so a multi-site config can reference a distinct `NBU1_SKIP_CERTIFICATE`, `NBU2_SKIP_CERTIFICATE`, ... per site — failing loudly on an unset referenced variable, consistent with `host`/`apiKey`.
- Wired `.Bool()` into the resty/`http.Transport` TLS config and the existing security-warning log check.
- `config.yaml` currently defines a single target (the legacy `nbuserver:` block), so only `NBU1_SKIP_CERTIFICATE` was added to `.env.example` / `docker-compose.yml`.

## Test plan
- [x] `make ci` (golangci-lint, `go test -race`, `go build`, `govulncheck`) — all pass
- [x] New `models.EnvBool` unit tests: native bool, `${VAR}` resolution, absent field, unset var (errors, matching host/apiKey policy), non-boolean value (errors), invalid YAML type (errors)
- [x] New `ResolveSecrets`/`ReadFile` integration tests: single-server `${VAR}` resolution, unset-var error with field context, non-boolean error, and a multi-site `nbuservers:` case resolving a distinct `${VAR}` per site
- [x] All existing tests updated for the `bool` → `EnvBool` retype and pass unchanged in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)