### PR TITLE
build: fully qualify base image names for Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o nbu_exporter .
 
 # Stage 2: Runtime
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 # Create the runtime user and log dir. These are busybox builtins (no network).
 RUN adduser -D -u 10001 nbu && \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 # Dockerfile for GoReleaser
 # Expects the binary to be pre-built by GoReleaser.
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 # ca-certificates for HTTPS, plus a non-root user and writable log dir
 RUN apk --no-cache add ca-certificates && \


### PR DESCRIPTION
Preparation for the Docker→Podman move.

Podman resolves unqualified image names via `unqualified-search-registries` in `registries.conf`. On RHEL/Fedora that list does not start with `docker.io`, and under `short-name-mode="enforcing"` an unqualified name fails outright in a non-interactive build. Docker always implies `docker.io/library`.

Every base image is now fully qualified. Already-qualified refs (`ghcr.io/*`, `gcr.io/*`, `registry.access.redhat.com/*`), `FROM scratch`, and inter-stage `FROM <stage>` references are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build images to use fully qualified Docker Hub references.
  * Improved consistency and reliability when pulling builder and runtime images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->