### PR TITLE
build: bump Go 1.26.5 -> 1.26.6 (govulncheck stdlib fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fjacquet/nbu_exporter
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1


### PR DESCRIPTION
Go 1.26.5 carries 7 stdlib advisories reachable from this module — GO-2026-5026, -5972, -6088, -6089, -6090, -6091, -6218 — all fixed in **1.26.6**.

Verified locally: build, tests and `govulncheck` all clean on 1.26.6.

`go.mod` pins the patch level deliberately (so a floating tag cannot change the toolchain under a build), which means `setup-go`s `check-latest` cannot float onto the fix — the bump has to be explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)